### PR TITLE
refactor: adopt mlx-arsenal diffusion primitives

### DIFF
--- a/packages/ltx-core-mlx/pyproject.toml
+++ b/packages/ltx-core-mlx/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
 ]
 dependencies = [
     "mlx>=0.31.0",
+    "mlx-arsenal>=0.2.2",
     "mlx-lm>=0.31.0",
     "safetensors>=0.4.0",
     "huggingface-hub>=0.26.0",

--- a/packages/ltx-core-mlx/src/ltx_core_mlx/model/transformer/timestep_embedding.py
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/model/transformer/timestep_embedding.py
@@ -1,76 +1,18 @@
-"""Timestep embeddings.
-
-Ported from ltx-core/src/ltx_core/model/transformer/timestep_embedding.py
-"""
+"""Timestep embedding re-exports + LTX-specific wrapper."""
 
 from __future__ import annotations
 
-import math
-
 import mlx.core as mx
 import mlx.nn as nn
+from mlx_arsenal.diffusion import TimestepEmbedding, get_timestep_embedding
 
-
-def get_timestep_embedding(
-    timesteps: mx.array,
-    embedding_dim: int,
-    flip_sin_to_cos: bool = True,
-    downscale_freq_shift: float = 0.0,
-    scale: float = 1.0,
-    max_period: float = 10000.0,
-) -> mx.array:
-    """Create sinusoidal timestep embeddings.
-
-    Reference: ltx-core timestep_embedding.py get_timestep_embedding.
-    Called via Timesteps(flip_sin_to_cos=True, downscale_freq_shift=0).
-
-    Args:
-        timesteps: 1D array of timestep values.
-        embedding_dim: Dimension of the output embeddings.
-        flip_sin_to_cos: If True, output [cos, sin]; if False, [sin, cos].
-        downscale_freq_shift: Controls delta between frequencies.
-        scale: Scaling factor applied to embeddings before sin/cos.
-        max_period: Controls the minimum frequency of the embeddings.
-
-    Returns:
-        Embeddings of shape (len(timesteps), embedding_dim).
-    """
-    half = embedding_dim // 2
-    exponent = -math.log(max_period) * mx.arange(0, half).astype(mx.float32)
-    exponent = exponent / (half - downscale_freq_shift)
-    freqs = mx.exp(exponent)
-    args = timesteps[:, None].astype(mx.float32) * freqs[None, :]
-    args = scale * args
-    # Reference: cat([sin, cos]) then if flip_sin_to_cos swap halves -> [cos, sin]
-    if flip_sin_to_cos:
-        embedding = mx.concatenate([mx.cos(args), mx.sin(args)], axis=-1)
-    else:
-        embedding = mx.concatenate([mx.sin(args), mx.cos(args)], axis=-1)
-    if embedding_dim % 2:
-        embedding = mx.pad(embedding, [(0, 0), (0, 1)])
-    return embedding
-
-
-class TimestepEmbedding(nn.Module):
-    """MLP that projects sinusoidal timestep embeddings.
-
-    Weight keys: ``linear1.{weight,bias}``, ``linear2.{weight,bias}``
-    """
-
-    def __init__(self, in_channels: int, time_embed_dim: int):
-        super().__init__()
-        self.linear1 = nn.Linear(in_channels, time_embed_dim)
-        self.linear2 = nn.Linear(time_embed_dim, time_embed_dim)
-
-    def __call__(self, sample: mx.array) -> mx.array:
-        sample = nn.silu(self.linear1(sample))
-        return self.linear2(sample)
+__all__ = ["TimestepEmbedder", "TimestepEmbedding", "get_timestep_embedding"]
 
 
 class TimestepEmbedder(nn.Module):
     """Container matching weight key ``emb.timestep_embedder.*``.
 
-    Weight keys: ``timestep_embedder.linear1.*``, ``timestep_embedder.linear2.*``
+    Weight keys: ``timestep_embedder.linear1.*``, ``timestep_embedder.linear2.*``.
     """
 
     def __init__(self, in_channels: int, time_embed_dim: int):

--- a/packages/ltx-pipelines-mlx/pyproject.toml
+++ b/packages/ltx-pipelines-mlx/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
 ]
 dependencies = [
     "ltx-core-mlx",
+    "mlx-arsenal>=0.2.2",
     "pillow>=10.4.0",
     "tqdm>=4.66.0",
 ]

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/scheduler.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/scheduler.py
@@ -1,11 +1,45 @@
-"""Sigma schedules for diffusion denoising.
+"""LTX-2 sigma schedules.
 
-Ported from ltx-core/src/ltx_core/components/schedulers.py
+`ltx2_schedule` is a thin wrapper over `mlx_arsenal.diffusion.dynamic_shift_schedule`
+that preserves LTX's original keyword name (``steps``) and default ``num_tokens``.
+The predefined LTX-specific tables (DISTILLED_SIGMAS, STAGE_2_SIGMAS) and the
+LTX-only helpers (get_sigma_schedule, sigma_to_timestep) stay local.
 """
 
 from __future__ import annotations
 
 import mlx.core as mx
+from mlx_arsenal.diffusion import dynamic_shift_schedule
+
+_MAX_SHIFT_ANCHOR = 4096
+
+
+def ltx2_schedule(
+    steps: int,
+    num_tokens: int = _MAX_SHIFT_ANCHOR,
+    max_shift: float = 2.05,
+    base_shift: float = 0.95,
+    stretch: bool = True,
+    terminal: float = 0.1,
+) -> list[float]:
+    """LTX-2 token-count-adaptive flow-matching sigma schedule."""
+    return dynamic_shift_schedule(
+        steps,
+        num_tokens=num_tokens,
+        base_shift=base_shift,
+        max_shift=max_shift,
+        stretch=stretch,
+        terminal=terminal,
+    )
+
+
+__all__ = [
+    "DISTILLED_SIGMAS",
+    "STAGE_2_SIGMAS",
+    "get_sigma_schedule",
+    "ltx2_schedule",
+    "sigma_to_timestep",
+]
 
 # Predefined sigma schedule for 8-step distilled model.
 # 9 values = 8 steps (iterate consecutive pairs: sigmas[i], sigmas[i+1]).
@@ -66,64 +100,3 @@ def sigma_to_timestep(sigma: float) -> mx.array:
         Timestep as (1,) array.
     """
     return mx.array([sigma], dtype=mx.bfloat16)
-
-
-# --- Dynamic schedulers ---
-
-_BASE_SHIFT_ANCHOR = 1024
-_MAX_SHIFT_ANCHOR = 4096
-
-
-def ltx2_schedule(
-    steps: int,
-    num_tokens: int = _MAX_SHIFT_ANCHOR,
-    max_shift: float = 2.05,
-    base_shift: float = 0.95,
-    stretch: bool = True,
-    terminal: float = 0.1,
-) -> list[float]:
-    """Generate a dynamic sigma schedule with token-count-dependent shifting.
-
-    Ported from ltx-core LTX2Scheduler. Used for non-distilled (full) models
-    with CFG guidance.
-
-    Args:
-        steps: Number of denoising steps.
-        num_tokens: Number of latent tokens (affects sigma shift).
-        max_shift: Maximum shift parameter.
-        base_shift: Base shift parameter.
-        stretch: Whether to stretch sigmas to match terminal value.
-        terminal: Terminal sigma value for stretching.
-
-    Returns:
-        List of steps+1 sigma values (includes terminal 0.0 if stretch).
-    """
-    import math
-
-    import numpy as np
-
-    sigmas = np.linspace(1.0, 0.0, steps + 1)
-
-    # Compute shift based on token count
-    mm = (max_shift - base_shift) / (_MAX_SHIFT_ANCHOR - _BASE_SHIFT_ANCHOR)
-    b = base_shift - mm * _BASE_SHIFT_ANCHOR
-    sigma_shift = num_tokens * mm + b
-
-    # Shift non-zero sigmas; avoid 1/0 for the terminal zero entry
-    nonzero = sigmas != 0
-    shifted = np.empty_like(sigmas)
-    shifted[~nonzero] = 0.0
-    shifted[nonzero] = math.exp(sigma_shift) / (math.exp(sigma_shift) + (1.0 / sigmas[nonzero] - 1.0))
-    sigmas = shifted
-
-    if stretch:
-        non_zero = sigmas != 0
-        non_zero_sigmas = sigmas[non_zero]
-        if len(non_zero_sigmas) > 0:
-            one_minus_z = 1.0 - non_zero_sigmas
-            scale_factor = one_minus_z[-1] / (1.0 - terminal)
-            if scale_factor != 0:
-                stretched = 1.0 - (one_minus_z / scale_factor)
-                sigmas[non_zero] = stretched
-
-    return sigmas.tolist()

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/utils/samplers.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/utils/samplers.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 import mlx.core as mx
+from mlx_arsenal.diffusion import euler_step
 from tqdm import tqdm
 
 from ltx_core_mlx.components.guiders import MultiModalGuiderFactory
@@ -44,29 +45,6 @@ class DenoiseOutput:
 
     video_latent: mx.array  # (B, N_video, C)
     audio_latent: mx.array  # (B, N_audio, C)
-
-
-def euler_step(
-    x: mx.array,
-    x0: mx.array,
-    sigma: float,
-    sigma_next: float,
-) -> mx.array:
-    """Single Euler step: x_{t-1} = x_t + (sigma_next - sigma) * (x_t - x0) / sigma.
-
-    Args:
-        x: Current noisy sample.
-        x0: Predicted clean sample.
-        sigma: Current noise level.
-        sigma_next: Next noise level.
-
-    Returns:
-        Updated sample at sigma_next.
-    """
-    if sigma == 0:
-        return x0
-    d = (x - x0) / sigma
-    return x + (sigma_next - sigma) * d
 
 
 def _is_uniform_mask(mask: mx.array) -> bool:


### PR DESCRIPTION
## Summary
Consolidate diffusion primitives that were duplicated across ported MLX projects into the shared [`mlx-arsenal`](https://pypi.org/project/mlx-arsenal/) library (0.2.2) and import them back here.

- **Timestep embedding** — `get_timestep_embedding` + `TimestepEmbedding` now come from `mlx_arsenal.diffusion`; the LTX-specific weight-key wrapper `TimestepEmbedder` stays local.
- **Sigma schedule** — `ltx2_schedule` becomes a thin wrapper over `mlx_arsenal.diffusion.dynamic_shift_schedule`, preserving the LTX signature (`steps=`, default `num_tokens=4096`). LTX-specific tables (`DISTILLED_SIGMAS`, `STAGE_2_SIGMAS`) and helpers stay local.
- **Euler step** — `euler_step` in `utils/samplers.py` imports from arsenal; the local 5-line duplicate is deleted.

Net: −105 LOC, zero signature change at the pipeline level.

## Parity evidence
Compared local vs arsenal implementations with identical seeded inputs:
- `get_timestep_embedding` at dims ∈ {64, 128, 256, 1024} — bit-exact.
- `ltx2_schedule` vs `dynamic_shift_schedule(base_tokens=1024, max_tokens=4096)` across steps ∈ {8,15,30,50} × tokens ∈ {512,1024,2048,4096,8192} — bit-exact.
- `euler_step` across 5 (sigma, sigma_next) combinations — bit-exact.

All 29 comparisons returned `max_abs_diff == 0.0`.

## Test plan
- [x] Fast test suite: 331 passed (`pytest tests/ --ignore=test_generate* --ignore=test_two_stage --ignore=test_pipeline_smoke --ignore=test_weight_loading --ignore=test_loader --ignore=test_trainer_datasets`).
- [x] `pytest tests/test_scheduler.py tests/test_guidance.py tests/test_utils.py` — 66 passed.
- [x] `ruff check packages/` — clean.
- [ ] Full end-to-end generation (skipped in this PR — the primitives are bit-exact, so no behavior change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)