### PR TITLE
fix: extend Metal watchdog eval guards to all Apple Silicon Macs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -851,20 +851,21 @@ End-to-end run on M2 Pro 32 GB, dev model + HDR LoRA fused, q8:
 
 ---
 
-## Metal Watchdog Mitigation (auto, memory-gated)
+## Metal Watchdog Mitigation
 
 The macOS GPU watchdog (`kIOGPUCommandBufferCallbackErrorImpactingInteractivity`, ~10 s per Metal command buffer) trips when:
 
 1. A single command buffer takes too long (one giant lazy-graph dispatch).
 2. Many small command buffers queue behind system processes (mds_stores, knowledgeconstructiond, Spotlight, Siri).
 
-LTX-2 mitigates both automatically on `<=48 GB` Macs by inserting `mx.eval` at strategic points so each command buffer is small enough to fit one watchdog window but few enough that queue contention doesn't dominate:
+LTX-2 mitigates both by inserting `mx.eval` at strategic points so each command buffer is small enough to fit one watchdog window but few enough that queue contention doesn't dominate. These guards apply on **all Apple Silicon Macs** — the previous 48 GB threshold was empirically wrong; M2 Max 64 GB machines exhibit `MTLCommandBufferErrorInternal` (code 14) crashes without them:
 
-- **Gemma forward**: per-layer eval (48 layers × ~100 ms each). Override via `LTX2_GEMMA_EVAL_EVERY=N` (default `1` on ≤48 GB, `0` on bigger Macs).
-- **TextEmbeddingProjection**: per-output-projection eval (splits the 188160→4096 video matmul from the 188160→2048 audio matmul). No-op on >48 GB.
-- **Embeddings1DConnector**: per-block eval (8 video + 8 audio blocks). No-op on >48 GB.
+- **Gemma forward**: per-layer eval (48 layers × ~100 ms each). Override via `LTX2_GEMMA_EVAL_EVERY=N` (default `1`).
+- **TextEmbeddingProjection**: per-output-projection eval (splits the 188160→4096 video matmul from the 188160→2048 audio matmul).
+- **Embeddings1DConnector**: per-block eval (8 video + 8 audio blocks).
+- **LTX DiT block loop**: eval every `LTX2_DIT_EVAL_EVERY` blocks (default `8`). Splits the 48-block forward into 6 command buffers of ~6 blocks each (~1–2 s/buffer), well within the watchdog window.
 
-`>48 GB` Macs (Mac Studio, M-series Ultra) keep full lazy-graph pipelining for max throughput.
+Mac Studio / M-series Ultra users who have never seen a watchdog crash may recover full lazy-graph pipelining by setting `LTX2_GEMMA_EVAL_EVERY=0` and `LTX2_DIT_EVAL_EVERY=0`. This disables all eval guards and restores maximum throughput at the cost of watchdog safety on machines where those guards were needed.
 
 ### `LTX2_GEMMA_MAX_LENGTH`
 

--- a/packages/ltx-core-mlx/src/ltx_core_mlx/model/transformer/model.py
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/model/transformer/model.py
@@ -22,6 +22,18 @@ from enum import Enum
 
 import mlx.core as mx
 import mlx.nn as nn
+import os as _os
+
+# LTX2_DIT_EVAL_EVERY: insert mx.eval every N blocks to keep each Metal
+# command buffer below the macOS GPU watchdog (~10 s deadline).
+# The 48-layer DiT lazy graph can exceed the deadline at production
+# resolutions (640x480+, 33+ frames) even on 64 GB Macs — validated
+# by MTLCommandBufferErrorInternal (code 14) crashes on M2 Max 64 GB.
+# Default 8: splits 48 blocks into 6 command buffers of ~6 blocks
+# each (~1–2 s/buffer), well within the watchdog window.
+# Set to 0 to disable (full lazy graph, original behaviour).
+_DIT_EVAL_EVERY = int(_os.environ.get("LTX2_DIT_EVAL_EVERY", "8"))
+_mx_eval = getattr(mx, "eval")  # noqa: B009
 
 from ltx_core_mlx.guidance.perturbations import BatchedPerturbationConfig
 from ltx_core_mlx.model.transformer.adaln import AdaLayerNormSingle
@@ -371,17 +383,6 @@ class LTXModel(nn.Module):
         if block_stack_override is not None:
             video_hidden, audio_hidden = block_stack_override(video_hidden, audio_hidden)
         else:
-            import os as _os
-            # LTX2_DIT_EVAL_EVERY: insert mx.eval every N blocks to keep each Metal
-            # command buffer below the macOS GPU watchdog (~10 s deadline).
-            # The 48-layer DiT lazy graph can exceed the deadline at production
-            # resolutions (640x480+, 33+ frames) even on 64 GB Macs — validated
-            # by MTLCommandBufferErrorInternal (code 14) crashes on M2 Max 64 GB.
-            # Default 8: splits 48 blocks into 6 command buffers of ~6 blocks
-            # each (~1–2 s/buffer), well within the watchdog window.
-            # Set to 0 to disable (full lazy graph, original behaviour).
-            _dit_eval_every = int(_os.environ.get("LTX2_DIT_EVAL_EVERY", "8"))
-            _mx_eval = getattr(mx, "eval")  # noqa: B009
             num_layers = self.config.num_layers if block_provider is not None else len(self.transformer_blocks)
             for block_idx in range(num_layers):
                 block = block_provider(block_idx) if block_provider is not None else self.transformer_blocks[block_idx]
@@ -412,7 +413,7 @@ class LTXModel(nn.Module):
                     # blocks so the previous block's weights become
                     # evictable.
                     _mx_eval(video_hidden, audio_hidden)
-                elif _dit_eval_every > 0 and (block_idx + 1) % _dit_eval_every == 0:
+                elif _DIT_EVAL_EVERY > 0 and (block_idx + 1) % _DIT_EVAL_EVERY == 0:
                     # Watchdog guard: flush accumulated lazy graph every N blocks
                     # so no single Metal command buffer exceeds the ~10 s deadline.
                     _mx_eval(video_hidden, audio_hidden)

--- a/packages/ltx-core-mlx/src/ltx_core_mlx/model/transformer/model.py
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/model/transformer/model.py
@@ -371,6 +371,17 @@ class LTXModel(nn.Module):
         if block_stack_override is not None:
             video_hidden, audio_hidden = block_stack_override(video_hidden, audio_hidden)
         else:
+            import os as _os
+            # LTX2_DIT_EVAL_EVERY: insert mx.eval every N blocks to keep each Metal
+            # command buffer below the macOS GPU watchdog (~10 s deadline).
+            # The 48-layer DiT lazy graph can exceed the deadline at production
+            # resolutions (640x480+, 33+ frames) even on 64 GB Macs — validated
+            # by MTLCommandBufferErrorInternal (code 14) crashes on M2 Max 64 GB.
+            # Default 8: splits 48 blocks into 6 command buffers of ~6 blocks
+            # each (~1–2 s/buffer), well within the watchdog window.
+            # Set to 0 to disable (full lazy graph, original behaviour).
+            _dit_eval_every = int(_os.environ.get("LTX2_DIT_EVAL_EVERY", "8"))
+            _mx_eval = getattr(mx, "eval")  # noqa: B009
             num_layers = self.config.num_layers if block_provider is not None else len(self.transformer_blocks)
             for block_idx in range(num_layers):
                 block = block_provider(block_idx) if block_provider is not None else self.transformer_blocks[block_idx]
@@ -400,8 +411,11 @@ class LTXModel(nn.Module):
                     # Streaming: force MLX graph materialization between
                     # blocks so the previous block's weights become
                     # evictable.
-                    _materialize = mx.eval
-                    _materialize(video_hidden, audio_hidden)
+                    _mx_eval(video_hidden, audio_hidden)
+                elif _dit_eval_every > 0 and (block_idx + 1) % _dit_eval_every == 0:
+                    # Watchdog guard: flush accumulated lazy graph every N blocks
+                    # so no single Metal command buffer exceeds the ~10 s deadline.
+                    _mx_eval(video_hidden, audio_hidden)
 
         if tap is not None:
             tap(video_hidden - block_input_v, audio_hidden - block_input_a)

--- a/packages/ltx-core-mlx/src/ltx_core_mlx/text_encoders/gemma/embeddings_connector.py
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/text_encoders/gemma/embeddings_connector.py
@@ -17,6 +17,7 @@ Weight keys (under ``video_embeddings_connector`` or ``audio_embeddings_connecto
 
 from __future__ import annotations
 
+import os
 import mlx.core as mx
 import mlx.nn as nn
 
@@ -328,14 +329,16 @@ class Embeddings1DConnector(nn.Module):
         # block to keep each block's Metal command buffer below the
         # macOS GPU watchdog: 8 blocks of MHA + GEGLU FF at seq_len 640
         # otherwise concatenate into a single dispatch that exceeds the
-        # 10 s threshold under sustained system contention (Spotlight,
-        # Siri, mds_stores, knowledgeconstructiond). No-op on >48 GB.
-        _split_per_block = mx.device_info()["memory_size"] <= 48 * 1024**3
+        # 10 s threshold under sustained system contention.
+        # Originally gated on <=48 GB, but M2 Max 64 GB also crashes at
+        # production resolutions — eval every block for all devices.
+        # LTX2_GEMMA_EVAL_EVERY=0 in env disables this (full lazy graph).
+        _connector_eval = int(os.environ.get("LTX2_GEMMA_EVAL_EVERY", "1")) > 0
         _mx_eval = getattr(mx, "eval")  # noqa: B009 -- security hook flags mx.eval pattern
 
         for block in self.transformer_1d_blocks:
             hidden_states = block(hidden_states, rope_freqs=rope_freqs, attention_mask=attn_mask)
-            if _split_per_block:
+            if _connector_eval:
                 _mx_eval(hidden_states)
 
         # Optional output normalization (affine-free)

--- a/packages/ltx-core-mlx/src/ltx_core_mlx/text_encoders/gemma/encoders/base_encoder.py
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/text_encoders/gemma/encoders/base_encoder.py
@@ -144,13 +144,14 @@ class GemmaLanguageModel(nn.Module):
         # command buffer below the macOS GPU watchdog deadline. The
         # downstream feature_extractor projection materializes its inputs
         # in one buffer; without per-layer eval, that buffer pulls all 48
-        # Gemma layers into a single dispatch that exceeds the limit
-        # under sustained system contention (Spotlight, Siri, mds_stores).
-        # No-op on >48 GB devices, which keep full lazy-graph pipelining.
-        # LTX2_GEMMA_EVAL_EVERY=N overrides the auto-default (1 on
-        # <=48 GB, 0 on >48 GB).
-        _split_per_layer = mx.device_info()["memory_size"] <= 48 * 1024**3
-        eval_every = int(os.environ.get("LTX2_GEMMA_EVAL_EVERY", "1" if _split_per_layer else "0"))
+        # Gemma layers into a single dispatch that exceeds the macOS GPU
+        # watchdog limit (~10 s) under sustained system contention.
+        # Originally gated on <=48 GB, but M2 Max 64 GB also crashes
+        # (MTLCommandBufferErrorInternal code 14) at production resolutions
+        # — the prior 48 GB threshold was validated only at 384x256x9 where
+        # the lazy graph fits the watchdog window. Default is now 1 (per-layer)
+        # for all devices. LTX2_GEMMA_EVAL_EVERY=0 disables (full lazy graph).
+        eval_every = int(os.environ.get("LTX2_GEMMA_EVAL_EVERY", "1"))
         for i, layer in enumerate(inner.layers):
             h = layer(h, mask=combined_mask, cache=None)
             if isinstance(h, tuple):


### PR DESCRIPTION
*Note: I'm not a developer — this fix was found by Claude Code while diagnosing a crash on my machine. I'm sharing it back in case it helps others. The fix may not be how you'd approach it, but it resolved the crash for me.*

## Problem

On M2 Max 64 GB (macOS 15.7.3 Sequoia), every generation attempt crashes within ~10 seconds:

```
libc++abi: terminating due to uncaught exception of type std::runtime_error:
[METAL] Command buffer execution failed: Internal Error (0000000e:Internal Error)
```

The same crash is reported on another M2 Max 64 GB machine running Sonoma (phosphene issue #3).

## Root cause

The existing Metal watchdog guards in `base_encoder.py` and `embeddings_connector.py` (added in commit 3431205) gate per-layer/per-block `mx.eval()` calls behind a `memory_size <= 48 GB` threshold. On a 64 GB machine this condition is false, so Gemma's 48-layer forward pass and the connector blocks accumulate as one giant lazy graph and submit to Metal as a single command buffer — exceeding the ~10 s watchdog deadline.

The threshold was validated at 384×256×9 frames, where the lazy graph completes within the window. At production resolutions (640×480+, 121 frames) it does not.

## Fix

- `base_encoder.py`: removed the memory-size gate; `LTX2_GEMMA_EVAL_EVERY` now defaults to `1` (per-layer) on all devices. Set `LTX2_GEMMA_EVAL_EVERY=0` to restore full lazy-graph behaviour.
- `embeddings_connector.py`: same — per-block eval is now the default for all devices, honouring `LTX2_GEMMA_EVAL_EVERY=0` to opt out.
- `model.py`: added `LTX2_DIT_EVAL_EVERY` (default 8) — flushes the DiT block loop every 8 layers on the non-streaming path, for the same reason.

## Tested on

M2 Max 64 GB, macOS 15.7.3, Q4 distilled model, Quick preset (640×480, 121 frames): generation completes successfully in ~199 seconds.