### PR TITLE
docs: bring CLAUDE.md / README / PIPELINES.md into coherence (release process + tiers + LipDub)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -348,22 +348,23 @@ Full pipeline ↔ option matrix lives at [docs/PIPELINES.md](docs/PIPELINES.md).
 
 Entry point: `uv run ltx-2-mlx <command>`. Available commands:
 
-| Command | Pipeline | Description |
-|---------|----------|-------------|
-| `generate` | T2V / I2V (mode flag required) | `--one-stage` (dev+CFG @ target), `--two-stage` (dev+CFG+upscale, recommended), `--two-stages-hq` (res_2s+CFG+upscale), `--distilled` (distilled+upscale, fastest). `--image` for I2V on any mode. |
-| `a2v` | Audio-to-video | Two-stage audio-conditioned generation (Euler + CFG) |
-| `keyframe` | Keyframe interpolation | Two-stage interpolation between start/end frames |
-| `ic-lora` | IC-LoRA | Two-stage generation with control video conditioning (depth, canny, pose, motion tracks) |
-| `hdr-ic-lora` | HDR IC-LoRA | Two-stage HDR generation via IC-LoRA + LogC3 inverse (saves SDR mp4 + linear-HDR `.npz`) |
-| `retake` | Retake | Regenerate a time segment of an existing video (dev model + CFG) |
-| `extend` | Extend | Add frames before or after an existing video (dev model + CFG) |
-| `upscale` | Upscale | Standalone neural spatial upscale of an existing video (VAE encode → upsampler → VAE decode, no DiT). Defaults to 2x; use `--upsampler spatial_upscaler_x1_5_v1_0` for 1.5x. Audio remuxed if present. |
-| `enhance` | Prompt enhancement | Enhance a text prompt using Gemma (no video generation) |
-| `info` | Model info | Show model configuration and memory estimates |
-| `train` | Training | Train a LoRA or full model from YAML config (requires ltx-trainer-mlx) |
-| `preprocess` | Data preprocessing | Encode raw videos into latents + conditions for training |
+| Command | Pipeline | Tier | Description |
+|---------|----------|------|-------------|
+| `generate` | T2V / I2V (mode flag required) | Stable | `--one-stage` (dev+CFG @ target), `--two-stage` (dev+CFG+upscale, recommended), `--two-stages-hq` (res_2s+CFG+upscale), `--distilled` (distilled+upscale, fastest). `--image` for I2V on any mode. |
+| `keyframe` | Keyframe interpolation | Stable | Two-stage interpolation between start/end frames |
+| `ic-lora` | IC-LoRA | Stable | Two-stage generation with control video conditioning (depth, canny, pose, motion tracks) |
+| `hdr-ic-lora` | HDR IC-LoRA | Stable | Two-stage HDR generation via IC-LoRA + LogC3 inverse (saves SDR mp4 + linear-HDR `.npz`) |
+| `upscale` | Upscale | Stable | Standalone neural spatial upscale of an existing video (VAE encode → upsampler → VAE decode, no DiT). Defaults to 2x; use `--upsampler spatial_upscaler_x1_5_v1_0` for 1.5x. Audio remuxed if present. |
+| `a2v` | Audio-to-video | Beta | Two-stage audio-conditioned generation (Euler + CFG). Sync quality depends on prompt-audio alignment. |
+| `retake` | Retake | Beta | Regenerate a time segment of an existing video (dev model + CFG) |
+| `extend` | Extend | Beta | Add frames before or after an existing video (dev model + CFG) |
+| `lipdub` | LipDub | Experimental | Lip-dub a reference video → re-sync visuals to source audio. Output audio is a VAE+vocoder reconstruction (audible artifacts on rich music). Uses pre-1.0 LipDub IC-LoRA. |
+| `enhance` | Prompt enhancement | Stable | Enhance a text prompt using Gemma (no video generation) |
+| `info` | Model info | Stable | Show model configuration and memory estimates |
+| `train` | Training | Stable | Train a LoRA or full model from YAML config (requires ltx-trainer-mlx) |
+| `preprocess` | Data preprocessing | Stable | Encode raw videos into latents + conditions for training |
 
-All pipelines except one-stage T2V/I2V use the dev model with CFG guidance. Common flags: `--model`, `--prompt`, `--output`, `--seed`, `--quiet`.
+All pipelines except one-stage T2V/I2V use the dev model with CFG guidance. Common flags: `--model`, `--prompt`, `--output`, `--seed`, `--quiet`. Tier semantics + promotion criteria live in [docs/PIPELINE_MATURITY.md](docs/PIPELINE_MATURITY.md).
 
 ### Low-RAM Example
 
@@ -908,15 +909,94 @@ The fix that actually unblocked production-quality generation was `1a30f74`: eve
 
 ---
 
+## Release Process
+
+The project is pre-1.0 (`0.x.y`). Under that scheme the `0.y` segment serves
+as the major version: **breaking changes bump `y`, strictly additive changes
+bump `z`**. This is documented at the top of [CHANGELOG.md](CHANGELOG.md)
+and applies to every consumer of the package.
+
+### Branch & PR discipline
+
+- `main` is **protected**: PR required, CI green required (`lint` +
+  `syntax` strict, plus `test (3.11)` / `test (3.12)` / `commitlint`),
+  no force-push, no deletion. Direct push is blocked.
+- One PR = one logical concern. Split mixed work into multiple PRs so
+  each carries a coherent version bump (see PR #8/#9/#10 splitting the
+  upstream PR #212 sync into additive / default-changes / new-pipeline).
+- PR titles use conventional-commits prefixes (`feat:`, `fix:`,
+  `chore:`, `refactor:`, `docs:`). `commitlint` enforces this.
+
+### Versioning rules
+
+| Change type | Bump | Example |
+|---|---|---|
+| New pipeline (additive) | `z` | `0.12.0 → 0.12.1` (LipDub) |
+| New helper / primitive (additive) | `z` | `0.11.0 → 0.11.1` (diffusion_steps) |
+| Internal refactor, public API unchanged | `z` | `0.11.0 → 0.11.1` (ic_lora delegation) |
+| Default value change (potentially breaking for callers relying on defaults) | `y` | `0.11.1 → 0.12.0` (TilingConfig / rope defaults) |
+| Removal / signature change | `y` | `0.9.x → 0.10.0` (ImageToVideoPipeline removal) |
+
+### Release artifacts
+
+Every release on `main` produces, in this order:
+
+1. **Merged squash commit** with conventional-commits subject + body.
+2. **Annotated git tag** `vX.Y.Z` on the merge commit (created locally
+   with `git tag -a vX.Y.Z -m '...'`, pushed via `git push origin vX.Y.Z`).
+3. **GitHub Release** auto-created by `.github/workflows/release.yml` (it
+   listens on `v*` tags). After creation, edit the release notes to use
+   the corresponding `CHANGELOG.md` section verbatim via
+   `gh release edit vX.Y.Z --notes-file …`.
+4. **CHANGELOG entry** at the top of the file under
+   `## [X.Y.Z] - YYYY-MM-DD` with `### Added` / `### Changed` /
+   `### Fixed` / `### Removed` sections as needed. Plain prose first
+   paragraph explaining the why; details below.
+5. **`pyproject.toml` version bump** in the workspace root **and** in
+   every sub-package (`packages/ltx-core-mlx/`, `packages/ltx-pipelines-mlx/`,
+   `packages/ltx-trainer/`) — all four must stay in sync.
+6. **`.release-please-manifest.json` bump** so release-please can drive
+   future automated releases from the correct base.
+
+### Pre-releases (release candidates)
+
+When a release introduces visible behavioural changes that downstream
+apps must validate before adopting, cut a **pre-release** first:
+
+- Tag as `vX.Y.Z-rc.N` (e.g. `v0.12.0-rc.1`).
+- Mark as **pre-release** in GitHub Releases UI (or `--prerelease`
+  on `gh release create`).
+- Promote to the stable tag only after downstream validation.
+
+### Maturity tiers
+
+Pipelines are classified Stable / Beta / Experimental in
+[docs/PIPELINE_MATURITY.md](docs/PIPELINE_MATURITY.md). CLI `--help`
+output for non-Stable subcommands carries a `[beta]` or
+`[experimental]` tag. Tier promotion criteria + per-tier stability
+guarantees live in that doc.
+
+### Downstream communication
+
+**Out of scope.** External communication with consumer apps / integrators
+is owned by Damien. The release process produces the artifacts above —
+notifying consumers, drafting changelog announcements, scheduling
+upgrades, etc., is not done from this repo.
+
+---
+
 ## Conventions
 
 - Python 3.11+
 - Mandatory type hints on all functions
 - Google-style docstrings
-- ruff for formatting/linting
+- ruff for formatting/linting (pre-commit + CI lint job)
 - Tests in `tests/` using pytest
-- Conventional commits (feat:, fix:, docs:, refactor:)
-- Package imports: `ltx_core_mlx.*` for core, `ltx_pipelines_mlx.*` for pipelines
+- **Conventional commits** (`feat:`, `fix:`, `chore:`, `docs:`,
+  `refactor:`, `feat!:` / `fix!:` for breaking) — enforced by
+  `commitlint` in CI.
+- Package imports: `ltx_core_mlx.*` for core, `ltx_pipelines_mlx.*` for pipelines.
+- One PR = one concern + one version bump (see Release Process above).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Pure MLX port of [LTX-2](https://github.com/Lightricks/LTX-2) for Apple Silicon.
 - **Keyframe interpolation** — smooth transition between reference images
 - **IC-LoRA** — reference video conditioning (depth/pose/edges)
 - **HDR IC-LoRA** — LogC3-compressed HDR generation (V2V upgrade or pure T2V) producing linear HDR `.npz` + SDR mp4 preview
+- **LipDub** *(experimental)* — lip-dub a reference video by re-syncing visuals to the source audio
 - **Two-stage generation** — half-res → neural upscale → refine
 - **HQ generation** — res_2s second-order sampler + CFG/STG guidance
 - **Prompt enhancement** — Gemma 3 12B rewrites short prompts into detailed descriptions
@@ -249,6 +250,13 @@ ltx-2-mlx hdr-ic-lora HDR IC-LoRA (two-stage, LogC3 → linear HDR)
   --skip-stage-2             Skip upscale stage (half-res HDR output)
                   → saves <output>.mp4 + <output>.hdr.npz (fp32 (F,H,W,3) linear HDR)
 
+ltx-2-mlx lipdub     [experimental] Lip-dub a reference video → audio
+  --reference-video          Reference video providing visuals + target audio (required)
+  --lora PATH STRENGTH       LipDub IC-LoRA (e.g. Lightricks/LTX-2.3-22b-IC-LoRA-LipDub), exactly one
+  --reference-strength       Reference video conditioning strength (default: 1.0)
+  --stage1-steps / --stage2-steps
+                  Frame count auto-derived from the reference video (snapped to 8k+1)
+
 ltx-2-mlx enhance    Prompt enhancement (no generation)
   --mode              "t2v" or "i2v" (default: t2v)
 
@@ -257,7 +265,9 @@ ltx-2-mlx info       Model info and memory estimate
 
 ### Environment variables
 
-- `LTX2_GEMMA_EVAL_EVERY=N` — override the auto-default for per-layer eval in Gemma forward (default: `1` on ≤48 GB Macs, `0` on bigger Macs). The auto-default keeps each Metal command buffer below the macOS GPU watchdog threshold without sacrificing throughput on capable hardware. Set explicitly only for debugging.
+- `LTX2_GEMMA_EVAL_EVERY=N` — per-layer `mx.eval` cadence in the Gemma forward (default: `1`, i.e. eval every layer). Keeps each Metal command buffer below the macOS GPU watchdog (~10 s) deadline. Set to `0` on Mac Studio / M-series Ultra owners who never see the watchdog crash to recover full lazy-graph throughput.
+- `LTX2_DIT_EVAL_EVERY=N` — flush the DiT block loop every N blocks (default: `8`, splits 48 blocks into 6 command buffers). Same trade-off as above; set to `0` on machines that don't crash to maximise throughput.
+- `LTX2_GEMMA_MAX_LENGTH=N` — cap Gemma padded sequence length (default: `1024`). Last-resort knob; quality risk on lower values because left-padded RoPE positions drift outside the LTX training distribution.
 - `LTX2_GEMMA_MAX_LENGTH=N` — cap padded Gemma sequence length (default 1024). Reducing to 512/256 speeds Gemma forward proportionally but **shifts left-padded RoPE positions** away from the LTX training distribution (quality risk). Last-resort knob.
 
 ## Frame Count Reference

--- a/docs/PIPELINES.md
+++ b/docs/PIPELINES.md
@@ -2,11 +2,13 @@
 
 Reference for all CLI subcommands of `ltx-2-mlx`, the pipeline class
 backing each, and which memory / performance flags apply where.
-Current as of **v0.9.0**.
+Current as of **v0.12.1**.
 
 For the underlying architecture and conventions, see
 [CLAUDE.md](../CLAUDE.md). For the high-level user-facing overview,
-see [README.md](../README.md).
+see [README.md](../README.md). For production-readiness classification
+of each pipeline (Stable / Beta / Experimental) and stability guarantees
+by tier, see [PIPELINE_MATURITY.md](PIPELINE_MATURITY.md).
 
 ## Core pipelines
 
@@ -16,12 +18,13 @@ see [README.md](../README.md).
 | `generate --two-stage` | `TI2VidTwoStagesPipeline` | T2V / I2V | Euler + CFG (30 steps) | Euler distilled (3 steps) | q8 + dev LoRA | ✅ | 0.0 |
 | `generate --two-stages-hq` | `TI2VidTwoStagesHQPipeline` | T2V / I2V | res_2s + CFG (15 steps × 2 sub-steps) | Euler distilled (3) | q8 + dev LoRA | ✅ | 0.0 |
 | `generate --distilled` | `DistilledPipeline` | T2V / I2V | Euler distilled (8 steps) at half-res | Euler distilled (3) at full-res | q8 (distilled only) | ❌ | — |
-| `a2v` | `A2VidPipelineTwoStage` | A2V (+ optional I2V) | Euler + CFG (30) | Euler distilled (3) | q8 + dev LoRA | ✅ (audio cfg=7) | 0.0 |
+| `a2v` *(beta)* | `A2VidPipelineTwoStage` | A2V (+ optional I2V) | Euler + CFG (30) | Euler distilled (3) | q8 + dev LoRA | ✅ (audio cfg=7) | 0.0 |
 | `keyframe` | `KeyframeInterpolationPipeline` | start frame ↔ end frame | Euler + CFG (30) | Euler distilled (3) | q8 + dev LoRA | ✅ | 0.0 |
 | `ic-lora` | `ICLoraPipeline` | V2V (control video) + optional I2V | Euler distilled (8) | Euler distilled (3) | q8 + control LoRA | ❌ | — |
 | `hdr-ic-lora` | `HDRICLoraPipeline(ICLoraPipeline)` | V2V / pure T2V / +I2V → linear HDR | Euler distilled (8) | Euler distilled (3) | q8 + HDR LoRA | ❌ | — |
-| `retake` | `RetakePipeline.retake_from_video` | regenerate latent frame range | Euler dev + CFG (30) | — | dev | ✅ | 0.0 |
-| `extend` | `RetakePipeline.extend_from_video` (same class) | append frames before/after | Euler dev + CFG (30) | — | dev | ✅ | 0.0 |
+| `lipdub` *(exp.)* | `LipDubPipeline(ICLoraPipeline)` | V2V + ref audio → lip-dubbed | Euler distilled (8) | Euler distilled (3) | q8 + LipDub LoRA | ❌ | — |
+| `retake` *(beta)* | `RetakePipeline.retake_from_video` | regenerate latent frame range | Euler dev + CFG (30) | — | dev | ✅ | 0.0 |
+| `extend` *(beta)* | `RetakePipeline.extend_from_video` (same class) | append frames before/after | Euler dev + CFG (30) | — | dev | ✅ | 0.0 |
 | `enhance` | Gemma rewrite | prompt → enriched prompt | — | — | Gemma 3 12B | — | — |
 | `info` / `train` / `preprocess` | — | utilities | — | — | — | — | — |
 
@@ -35,7 +38,8 @@ see [README.md](../README.md).
 | `--tile-overlap K` | 2 | Token-grid overlap (smoother blend at cost of redundant compute). | when tiling active |
 | `--enable-teacache` | off | Timestep-aware residual caching. ~1.46× speedup (Euler) / ~1.78× (HQ). Conservative thresh 0.5. | `generate --two-stage`, `generate --two-stages-hq` |
 | `--teacache-thresh F` | 0.5 (Euler) / 1.0 (HQ) | Skip aggressiveness. Higher = more skip = faster but quality risk. | with `--enable-teacache` |
-| `LTX2_GEMMA_EVAL_EVERY=N` | auto (1 on ≤48 GB Macs, 0 otherwise) | Override per-layer eval cadence in Gemma forward. The auto-default keeps each Metal command buffer below the macOS GPU watchdog threshold without sacrificing throughput on capable hardware. Set explicitly only for debugging. | all pipelines (text encoding shared) |
+| `LTX2_GEMMA_EVAL_EVERY=N` | 1 (per-layer eval) | Per-layer `mx.eval` cadence in Gemma forward. Keeps each Metal command buffer below the macOS GPU watchdog (~10 s) deadline. Default `1` on all Apple Silicon since PR #3 (M2 Max 64 GB also crashes without it at production resolutions). Set to `0` on Mac Studio / M-series Ultra owners who never see the watchdog crash to recover lazy-graph throughput. | all pipelines (text encoding shared) |
+| `LTX2_DIT_EVAL_EVERY=N` | 8 | Flush the DiT block loop every N blocks (splits 48 blocks into 6 command buffers, ~1-2 s each). Same trade-off as `LTX2_GEMMA_EVAL_EVERY`. Set to `0` to disable. | all pipelines (DiT forward shared) |
 | `LTX2_GEMMA_MAX_LENGTH=N` | 1024 | Cap Gemma padded seq_len (last-resort escape hatch). Quality risk: shifts left-padded RoPE positions. | all pipelines |
 
 ## Pipeline-specific options
@@ -50,6 +54,7 @@ see [README.md](../README.md).
 | `keyframe` | `--start` / `--end` (image paths, required), `--fps`, all two-stage flags |
 | `ic-lora` | `--lora PATH STRENGTH` (required, repeatable), `--video-conditioning PATH STRENGTH` (required, repeatable), `--conditioning-strength` (1.0), `--image`, `--skip-stage-2`, `--stage1-steps`, `--stage2-steps` |
 | `hdr-ic-lora` | same as `ic-lora`, but `--video-conditioning` is **optional** (omit for pure T2V HDR). Auto-detects HDR transform from LoRA metadata. Outputs `.mp4` SDR + `.hdr.npz` linear HDR fp32 |
+| `lipdub` *(experimental)* | `--reference-video PATH` (required, provides visuals + audio), `--lora PATH STRENGTH` (exactly one LipDub IC-LoRA, required), `--reference-strength` (1.0), `--stage1-steps` / `--stage2-steps`. Frame count auto-derived from the reference video metadata (snapped to `8k+1`). Output audio is VAE+vocoder reconstruction — remux original audio for music-fidelity use cases. |
 | `retake` | `--video` (required), `--start` / `--end` (latent frame indices, required), `--steps` (30), `--no-regen-audio`, `--cfg-scale`, `--stg-scale` |
 | `extend` | `--video` (required), `--extend-frames N` (required), `--direction before|after`, `--steps`, `--cfg-scale`, `--stg-scale` |
 


### PR DESCRIPTION
## Summary

Pure doc unification post-PR #212 sync. No behaviour change. Three entry-point docs (CLAUDE.md, README.md, docs/PIPELINES.md) now tell one consistent story:

### CLAUDE.md
- **New `## Release Process` section** before Conventions. Documents:
  - Branch protection rules on \`main\`
  - Pre-1.0 versioning: \`0.y\` = major, \`0.z\` = additive
  - Versioning rules table with concrete examples
  - 6-step release artifacts checklist (commit → tag → GitHub Release → CHANGELOG → pyproject bumps → release-please manifest)
  - Pre-release (rc) discipline
  - Maturity tier cross-reference
  - Downstream communication explicitly out of scope
- CLI Commands table: added Tier column (Stable / Beta / Experimental) per row + LipDub row
- Conventions section: references the new release process + commitlint + one-PR-one-concern

### README.md
- LipDub in Features list (marked experimental)
- New \`lipdub\` block in CLI Reference
- Environment variables refreshed: \`LTX2_GEMMA_EVAL_EVERY\` default now \`1\` on all Apple Silicon (PR #3), added \`LTX2_DIT_EVAL_EVERY\`

### docs/PIPELINES.md
- Version footer \`0.9.0 → 0.12.1\`
- LipDub row in Core pipelines + Pipeline-specific options
- Tier badges \`*(beta)*\` / \`*(exp.)*\` in table rows
- Env-var rows match PR #3 defaults + LTX2_DIT_EVAL_EVERY added
- Cross-link to PIPELINE_MATURITY.md

## Test plan

- [x] \`uv run ty check\` passes
- [x] \`uv run ruff check packages/ tests/\` passes (no code changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)