### PR TITLE
chore: sync uv.lock to 0.13.1

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -427,7 +427,7 @@ wheels = [
 
 [[package]]
 name = "ltx-2-mlx"
-version = "0.13.0"
+version = "0.13.1"
 source = { virtual = "." }
 dependencies = [
     { name = "ltx-core-mlx" },
@@ -467,7 +467,7 @@ provides-extras = ["trainer", "dev", "all"]
 
 [[package]]
 name = "ltx-core-mlx"
-version = "0.13.0"
+version = "0.13.1"
 source = { editable = "packages/ltx-core-mlx" }
 dependencies = [
     { name = "huggingface-hub" },
@@ -490,7 +490,7 @@ requires-dist = [
 
 [[package]]
 name = "ltx-pipelines-mlx"
-version = "0.13.0"
+version = "0.13.1"
 source = { editable = "packages/ltx-pipelines-mlx" }
 dependencies = [
     { name = "ltx-core-mlx" },
@@ -509,7 +509,7 @@ requires-dist = [
 
 [[package]]
 name = "ltx-trainer-mlx"
-version = "0.13.0"
+version = "0.13.1"
 source = { editable = "packages/ltx-trainer" }
 dependencies = [
     { name = "ltx-core-mlx" },


### PR DESCRIPTION
Lockfile-only update: bumps `ltx-2-mlx` / `ltx-core-mlx` /
`ltx-pipelines-mlx` from `0.13.0` → `0.13.1` to match the
released `pyproject.toml` versions on `main`. No transitive
dependency changes.

Catches the drift introduced when v0.13.0 (PR #12) and v0.13.1
(PR #13) bumped the source versions but neither touched `uv.lock`.
Future `uv sync` runs by contributors will now stay clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)