### PR TITLE
fix(decode): use frame_rate kwarg in VideoDecoder wrapper

### DIFF
--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/utils/blocks.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/utils/blocks.py
@@ -222,12 +222,12 @@ class VideoDecoder:
         self,
         video_latent: mx.array,
         output_path: str,
-        fps: float = 24.0,
+        frame_rate: float = 24.0,
         audio_path: str | None = None,
     ) -> str:
         """Stream-decode the latent into an mp4 with optional audio mux."""
         decoder = self.load()
-        decoder.decode_and_stream(video_latent, output_path, fps=fps, audio_path=audio_path)
+        decoder.decode_and_stream(video_latent, output_path, frame_rate=frame_rate, audio_path=audio_path)
         return output_path
 
 


### PR DESCRIPTION
The newly added frame rate param caused a generation bug due to param naming inconsistency.  Tested locally via CLI pipeline.

Previously, this was failing at the decode stage with an error because it was stil looking for "fps".

```
[Decoding video + audio + muxing] done in 5.1s
Traceback (most recent call last):
  File "/Users/plz12345/Git/ltx-2-mlx/.venv/bin/ltx-2-mlx", line 10, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/plz12345/Git/ltx-2-mlx/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/cli.py", line 535, in main
    commands[args.command](args)
  File "/Users/plz12345/Git/ltx-2-mlx/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/cli.py", line 639, in _cmd_generate
    pipe.generate_and_save(**kwargs)
  File "/Users/plz12345/Git/ltx-2-mlx/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ti2vid_two_stages.py", line 617, in generate_and_save
    result = self._decode_and_save_video(video_latent, audio_latent, output_path, frame_rate=frame_rate)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/plz12345/Git/ltx-2-mlx/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/_base.py", line 270, in _decode_and_save_video
    return _impl(
           ^^^^^^
  File "/Users/plz12345/Git/ltx-2-mlx/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/utils/_orchestration.py", line 162, in decode_and_save_video
    video_decoder.decode_and_stream(video_latent, output_path, frame_rate=frame_rate, audio_path=audio_path)
TypeError: VideoDecoder.decode_and_stream() got an unexpected keyword argument 'frame_rate'
```