### PR TITLE
fix: accurate transformer load time via mx.eval

### DIFF
--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/utils/_orchestration.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/utils/_orchestration.py
@@ -85,6 +85,7 @@ def load_transformer(
     else:
         apply_quantization(dit, weights)
         dit.load_weights(list(weights.items()))
+    mx.eval(dit.parameters())
     aggressive_cleanup()
     return dit
 


### PR DESCRIPTION
Before [Loading transformer (transformer-distilled.safetensors)] ... [Loading transformer (transformer-distilled.safetensors)] done in 0.1s

After [Loading transformer (transformer-distilled.safetensors)] ... [Loading transformer (transformer-distilled.safetensors)] done in 1.8s