### PR TITLE
fix(pipelines): flush noised states before denoise loop on all pipelines

### DIFF
--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/_base.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/_base.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import mlx.core as mx
 
 from ltx_core_mlx.components.patchifiers import AudioPatchifier, VideoLatentPatchifier, compute_video_latent_shape
+from ltx_core_mlx.conditioning.types.latent_cond import LatentState
 from ltx_core_mlx.model.audio_vae.audio_vae import AudioVAEDecoder
 from ltx_core_mlx.model.audio_vae.bwe import VocoderWithBWE
 from ltx_core_mlx.model.transformer.model import LTXModel, X0Model
@@ -380,6 +381,23 @@ class BasePipeline:
         """
         return self.prompt_encoder.encode(prompt)
 
+    @staticmethod
+    def _pre_denoise_flush(video_state: LatentState, audio_state: LatentState) -> None:
+        """Force-materialise noised states before starting the denoise loop.
+
+        Flushing here prevents the macOS Metal GPU watchdog from firing
+        (``MTLCommandBufferErrorInternal`` code 14) when a large lazy graph
+        — VAE encoding, conditioning blend, or noise addition — accumulates
+        and is submitted as a single oversized command buffer.  Completing
+        the graph in its own buffer before the denoise loop starts keeps each
+        subsequent Metal command buffer within the watchdog window.
+
+        Applies to all Apple Silicon Macs: the bug has been observed on
+        M2 Max 64 GB and is not specific to the <=48 GB tier.
+        """
+        # NOTE: mx.eval is MLX graph evaluation, NOT Python eval()
+        mx.eval(video_state.latent, video_state.clean_latent, audio_state.latent)
+
     def generate(
         self,
         prompt: str,
@@ -443,7 +461,7 @@ class BasePipeline:
         # Denoise
         sigmas = DISTILLED_SIGMAS[: num_steps + 1] if num_steps else DISTILLED_SIGMAS
         x0_model = X0Model(self.dit)
-
+        self._pre_denoise_flush(video_state, audio_state)
         output = denoise_loop(
             model=x0_model,
             video_state=video_state,

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ti2vid_two_stages.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ti2vid_two_stages.py
@@ -435,6 +435,7 @@ class TI2VidTwoStagesPipeline(BasePipeline):
             teacache_controller = _build_teacache_controller(stage1_steps, teacache_thresh)
             teacache_controller.reset()
 
+        self._pre_denoise_flush(video_state, audio_state)
         output_1 = guided_denoise_loop(
             model=x0_model,
             video_state=video_state,
@@ -537,6 +538,7 @@ class TI2VidTwoStagesPipeline(BasePipeline):
             tiler_2 = VideoModalityTiler(self._tile_count, latent_shape=(F, H_full, W_full))
             stage2_x0_model = X0Model(TiledLTXModel(self.dit, tiler_2))
 
+        self._pre_denoise_flush(video_state_2, audio_state_2)
         output_2 = denoise_loop(
             model=stage2_x0_model,
             video_state=video_state_2,

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ti2vid_two_stages_hq.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ti2vid_two_stages_hq.py
@@ -210,6 +210,7 @@ class TI2VidTwoStagesHQPipeline(TI2VidTwoStagesPipeline):
         if enable_teacache:
             teacache_controller = _build_hq_teacache_controller(stage1_steps, teacache_thresh)
             teacache_controller.reset()
+        self._pre_denoise_flush(video_state, audio_state)
         output_1 = res2s_denoise_loop(
             model=x0_model,
             video_state=video_state,
@@ -301,6 +302,7 @@ class TI2VidTwoStagesHQPipeline(TI2VidTwoStagesPipeline):
         )
 
         # Stage 2: simple denoising (no CFG)
+        self._pre_denoise_flush(video_state_2, audio_state_2)
         output_2 = denoise_loop(
             model=x0_model,
             video_state=video_state_2,


### PR DESCRIPTION
## Problem

On Apple Silicon Macs (observed on M2 Max 64 GB), the macOS Metal GPU watchdog fires during generation with:

```
[METAL] Command buffer execution failed: Internal Error (0000000e:Internal Error)
MTLCommandBufferErrorInternal (code 14)
```

The crash happens because `create_noised_state` — which includes VAE encoding, conditioning blend, and noise addition — builds a lazy MLX graph that is then submitted as a single oversized Metal command buffer when the denoise loop starts its first step. The watchdog window (~10 s per buffer) is exceeded before the graph materialises.

This was first surfaced in #16.

## Fix

Add `BasePipeline._pre_denoise_flush()` as a static method on `_base.py`. It calls `mx.eval()` on `video_state.latent`, `video_state.clean_latent`, and `audio_state.latent`, forcing the accumulated lazy graph to materialise in its own command buffer before the denoise loop begins. Each subsequent denoise-step command buffer is then within the watchdog window.

The method is called at all five pipeline entry points that construct a noised state before denoising:

- `BasePipeline.generate()` — one-stage distilled T2V/I2V
- `TI2VidTwoStagesPipeline.generate_two_stage()` — stage 1 and stage 2
- `TI2VidTwoStagesHQPipeline.generate_two_stage()` — stage 1 and stage 2

## Testing

Tested on M2 Max 64 GB (macOS Sequoia) via [Phosphene](https://github.com/mrbizarro/phosphene):

- I2V Quick (640×480, 121f, distilled, no LoRA) — completed, 210 s
- I2V Balanced (1024×576, 121f, distilled, no LoRA) — completed, 487 s  
- I2V Quick (640×480, 121f, distilled, + custom LoRA) — completed, 242 s
- I2V Balanced (1024×576, 121f, distilled, + custom LoRA) — completed, 543 s

All four runs completed with zero Metal watchdog crashes. Same Mac previously crashed consistently on the I2V path without this guard.