### PR TITLE
fix(pipelines): extend _pre_denoise_flush coverage to remaining 14 sites

### DIFF
--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/a2vid_two_stage.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/a2vid_two_stage.py
@@ -80,6 +80,7 @@ class A2VidPipelineTwoStage(TI2VidTwoStagesPipeline):
         video_factory = create_multimodal_guider_factory(video_gp, negative_context=neg_video_embeds)
         audio_factory = create_multimodal_guider_factory(audio_gp, negative_context=neg_audio_embeds)
 
+        self._pre_denoise_flush(video_state, audio_state)
         return guided_denoise_loop(
             model=x0_model,
             video_state=video_state,
@@ -329,6 +330,7 @@ class A2VidPipelineTwoStage(TI2VidTwoStagesPipeline):
             initial_latent=audio_tokens,
         )
 
+        self._pre_denoise_flush(video_state_2, audio_state_2)
         output_2 = denoise_loop(
             model=x0_model,
             video_state=video_state_2,

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/distilled.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/distilled.py
@@ -213,6 +213,7 @@ class DistilledPipeline(TI2VidTwoStagesPipeline):
 
         x0_model = X0Model(stage1_dit)
 
+        self._pre_denoise_flush(video_state, audio_state)
         output_1 = denoise_loop(
             model=x0_model,
             video_state=video_state,
@@ -295,6 +296,7 @@ class DistilledPipeline(TI2VidTwoStagesPipeline):
             tiler_2 = VideoModalityTiler(self._tile_count, latent_shape=(F, H_full, W_full))
             stage2_x0_model = X0Model(TiledLTXModel(self.dit, tiler_2))
 
+        self._pre_denoise_flush(video_state_2, audio_state_2)
         output_2 = denoise_loop(
             model=stage2_x0_model,
             video_state=video_state_2,

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ic_lora.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ic_lora.py
@@ -413,6 +413,7 @@ class ICLoraPipeline(BasePipeline):
         sigmas_1 = DISTILLED_SIGMAS[: stage1_steps + 1] if stage1_steps else DISTILLED_SIGMAS
         x0_model = X0Model(self.dit)
 
+        self._pre_denoise_flush(video_state, audio_state)
         output_1 = denoise_loop(
             model=x0_model,
             video_state=video_state,
@@ -519,6 +520,7 @@ class ICLoraPipeline(BasePipeline):
             initial_latent=audio_tokens_1,
         )
 
+        self._pre_denoise_flush(video_state_2, audio_state_2)
         output_2 = denoise_loop(
             model=x0_model,
             video_state=video_state_2,

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/keyframe_interpolation.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/keyframe_interpolation.py
@@ -280,6 +280,7 @@ class KeyframeInterpolationPipeline(TI2VidTwoStagesPipeline):
             video_factory = create_multimodal_guider_factory(vgp, negative_context=video_neg)
             audio_factory = create_multimodal_guider_factory(agp, negative_context=audio_neg)
 
+            self._pre_denoise_flush(video_state_1, audio_state_1)
             output_1 = guided_denoise_loop(
                 model=x0_model,
                 video_state=video_state_1,
@@ -291,6 +292,7 @@ class KeyframeInterpolationPipeline(TI2VidTwoStagesPipeline):
                 sigmas=sigmas_1,
             )
         else:
+            self._pre_denoise_flush(video_state_1, audio_state_1)
             output_1 = denoise_loop(
                 model=x0_model,
                 video_state=video_state_1,
@@ -377,6 +379,7 @@ class KeyframeInterpolationPipeline(TI2VidTwoStagesPipeline):
         )
 
         # Stage 2 denoising: simple (no CFG), matching reference
+        self._pre_denoise_flush(video_state_2, audio_state_2)
         output_2 = denoise_loop(
             model=x0_model,
             video_state=video_state_2,

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/lipdub.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/lipdub.py
@@ -236,6 +236,7 @@ class LipDubPipeline(ICLoraPipeline):
 
         sigmas_1 = DISTILLED_SIGMAS[: stage1_steps + 1] if stage1_steps else DISTILLED_SIGMAS
         x0_model = X0Model(self.dit)
+        self._pre_denoise_flush(video_state, audio_state)
         output_1 = denoise_loop(
             model=x0_model,
             video_state=video_state,
@@ -327,6 +328,7 @@ class LipDubPipeline(ICLoraPipeline):
         )
         audio_state_2 = ref_cond.apply(audio_state_2, num_noisy_tokens=audio_T)
 
+        self._pre_denoise_flush(video_state_2, audio_state_2)
         output_2 = denoise_loop(
             model=x0_model,
             video_state=video_state_2,

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/retake.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/retake.py
@@ -357,6 +357,7 @@ class RetakePipeline(BasePipeline):
         video_factory = create_multimodal_guider_factory(video_gp, negative_context=neg_video_embeds)
         audio_factory = create_multimodal_guider_factory(audio_gp, negative_context=neg_audio_embeds)
 
+        self._pre_denoise_flush(video_state, audio_state)
         output = guided_denoise_loop(
             model=x0_model,
             video_state=video_state,
@@ -526,6 +527,7 @@ class RetakePipeline(BasePipeline):
         video_factory = create_multimodal_guider_factory(video_gp, negative_context=neg_video_embeds)
         audio_factory = create_multimodal_guider_factory(audio_gp, negative_context=neg_audio_embeds)
 
+        self._pre_denoise_flush(video_state, audio_state)
         output = guided_denoise_loop(
             model=x0_model,
             video_state=video_state,

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ti2vid_one_stage.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ti2vid_one_stage.py
@@ -236,6 +236,7 @@ class TI2VidOneStagePipeline(TI2VidTwoStagesPipeline):
             self.image_conditioner.free()
             aggressive_cleanup()
 
+        self._pre_denoise_flush(video_state, audio_state)
         output = guided_denoise_loop(
             model=x0_model,
             video_state=video_state,


### PR DESCRIPTION
## Context

Follow-up to #22 (merged as 3d466ed). The original PR added
`_pre_denoise_flush()` on `BasePipeline.generate()` plus the two
two-stage variants (5 sites). The macOS Metal watchdog
(`MTLCommandBufferErrorInternal` code 14) can fire on **any** denoise
loop where the accumulated pre-denoise lazy graph (VAE encode +
conditioning blend + noise add) is submitted as a single oversized
command buffer — not just the three pipelines covered initially.

## Change

Extend the flush to the 14 remaining call sites across the heavier
pipelines, where the bug is more likely than on distilled I2V:

| Pipeline | Sites |
|---|---|
| `ti2vid_one_stage` (dev one-stage + CFG @ target res) | 1 |
| `distilled` (two-stage distilled T2V/I2V) | 2 |
| `a2vid_two_stage` (audio-to-video) | 2 |
| `ic_lora` (and `hdr_ic_lora` via inheritance) | 2 |
| `retake` (retake + extend) | 2 |
| `keyframe_interpolation` (stage 1 dev/distilled branches + stage 2) | 3 |
| `lipdub` | 2 |

All edits are mechanical: one `self._pre_denoise_flush(video_state, audio_state)`
line immediately before each denoise call. No semantic change —
`mx.eval()` just forces materialisation that would happen anyway on the
next forward.

## Test plan

- [x] Unit suites: 484 tests pass, 3 pre-existing ffmpeg-subprocess
      failures unchanged (not caused by these edits).
- [x] `test_block_streaming.py` 7/7 — verified the flush stacks
      with `StreamingLTXModel` (wrapper invoked inside denoise loop,
      after the flush).
- [x] `test_modality_tiling.py` 8/8 — verified compatible with
      `TiledLTXModel`.
- [x] `test_hdr.py` 11/11 — `HDRICLoraPipeline` inherits the
      `_pre_denoise_flush` calls from `ICLoraPipeline`.
- [x] Smoke-import of all 10 modified pipelines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)