### PR TITLE
(perf): VAE decode memory improvements

### DIFF
--- a/packages/ltx-core-mlx/src/ltx_core_mlx/model/video_vae/video_vae.py
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/model/video_vae/video_vae.py
@@ -434,6 +434,13 @@ class VideoDecoder(nn.Module):
         """
         ffmpeg = find_ffmpeg()
         tiling = _compute_decode_tiling(latent.shape, frame_rate=frame_rate)
+        if tiling is not None and tiling.temporal_config is not None:
+            tc = tiling.temporal_config
+            logger.info(
+                "vae-decode tiled: tile_frames=%d overlap=%d",
+                tc.tile_size_in_frames,
+                tc.tile_overlap_in_frames,
+            )
 
         # Estimate output dimensions from latent
         _, _, _F_lat, H_lat, W_lat = latent.shape

--- a/packages/ltx-core-mlx/src/ltx_core_mlx/model/video_vae/video_vae.py
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/model/video_vae/video_vae.py
@@ -392,7 +392,9 @@ class VideoDecoder(nn.Module):
                 yield_len = curr_temporal_slice.start - previous_temporal_slice.start
                 if yield_len > 0:
                     safe_weights = mx.maximum(previous_weights, 1e-8)
-                    yield (previous_chunk / safe_weights)[:, :, :yield_len, :, :]
+                    chunk = (previous_chunk / safe_weights)[:, :, :yield_len, :, :]
+                    mx.eval(chunk)
+                    yield chunk
 
             previous_chunk = buffer
             previous_weights = weights
@@ -401,7 +403,9 @@ class VideoDecoder(nn.Module):
         # Yield remaining chunk
         if previous_chunk is not None and previous_weights is not None:
             safe_weights = mx.maximum(previous_weights, 1e-8)
-            yield previous_chunk / safe_weights
+            chunk = previous_chunk / safe_weights
+            mx.eval(chunk)
+            yield chunk
 
     def decode_and_stream(
         self,
@@ -466,16 +470,13 @@ class VideoDecoder(nn.Module):
         for chunk in self.tiled_decode(latent, tiling):  # (B, 3, T, H, W)
             if pipe_broken:
                 break
-            # chunk is already materialized by tiled_decode — async_eval is a no-op
-            # but kept for compatibility if the yield path changes.
-            mx.async_eval(chunk)
             num_frames = chunk.shape[2]
             for i in range(num_frames):
                 frame = chunk[:, :, i, :, :]
                 frame = mx.clip(frame, -1.0, 1.0)
                 frame = ((frame + 1.0) * 127.5).astype(mx.uint8)
                 frame_hwc = frame[0].transpose(1, 2, 0)  # (H, W, 3)
-                mx.eval(frame_hwc)  # sync before write — async_eval can race memoryview
+                mx.eval(frame_hwc)  # required: memoryview races GPU writes without this sync
                 try:
                     proc.stdin.write(bytes(memoryview(frame_hwc)))
                 except BrokenPipeError:

--- a/packages/ltx-core-mlx/src/ltx_core_mlx/model/video_vae/video_vae.py
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/model/video_vae/video_vae.py
@@ -56,6 +56,7 @@ from ltx_core_mlx.utils.memory import aggressive_cleanup
 
 logger: logging.Logger = logging.getLogger(__name__)
 
+
 def _compute_decode_tiling(
     latent_shape: tuple[int, ...],
     peak_budget_gb: float = 8.0,
@@ -69,7 +70,7 @@ def _compute_decode_tiling(
     _, _, F_lat, H_lat, W_lat = latent_shape
     budget_bytes = int(peak_budget_gb * 1024**3)
 
-    # Block-3 peak memory: 512 channels × 4 temporal frames × (4H spatial) × (4W spatial) × 4 bytes
+    # Block-3 peak memory: 512 channels x 4 temporal frames x (4H spatial) x (4W spatial) x 4 bytes
     block3_bytes_per_lat_frame = 512 * 4 * (H_lat * 4) * (W_lat * 4) * 4
 
     if block3_bytes_per_lat_frame * F_lat <= budget_bytes:
@@ -78,7 +79,7 @@ def _compute_decode_tiling(
     # How many latent frames fit within the budget?
     max_lat_frames = max(2, budget_bytes // block3_bytes_per_lat_frame)
 
-    # Convert latent frames → output pixel frames (8× temporal upsampling), with a 16-frame minimum
+    # Convert latent frames -> output pixel frames (8x temporal upsampling), with a 16-frame minimum
     tile_frames = max(16, max_lat_frames * 8)
 
     # Overlap ≈ 1 second of pixel frames at the given frame rate, rounded down to a multiple of 8,
@@ -296,8 +297,8 @@ class VideoDecoder(nn.Module):
         """
         if tiling_config is None:
             pixels = self.decode(latent)
-            mx.eval(pixels)      # materialize now — frees block-3 intermediate activations
-            aggressive_cleanup() # release GPU cache before caller begins streaming
+            mx.eval(pixels)  # materialize now — frees block-3 intermediate activations
+            aggressive_cleanup()  # release GPU cache before caller begins streaming
             yield pixels
             del pixels
             return

--- a/packages/ltx-core-mlx/src/ltx_core_mlx/model/video_vae/video_vae.py
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/model/video_vae/video_vae.py
@@ -64,14 +64,15 @@ def _compute_decode_tiling(
 ) -> TilingConfig | None:
     """Return a TilingConfig that keeps peak VAE decode memory under budget, or None.
 
-    Peak memory occurs at the block-3 intermediate tensor (the second DepthToSpaceUpsample), which has shape (1, 512, F_lat*4, H_lat*4, W_lat*4) at float32. We size tiles so thi tensor stays within budget. Returns None when the full video already fits — no tiling,
-    no overhead.
+    Peak memory occurs at the block-3 intermediate tensor (the second
+    DepthToSpaceUpsample), shape (1, 512, F_lat*4, H_lat*4, W_lat*4) in bf16.
+    Returns None when the full video fits within budget — no tiling, no overhead.
     """
     _, _, F_lat, H_lat, W_lat = latent_shape
     budget_bytes = int(peak_budget_gb * 1024**3)
 
-    # Block-3 peak memory: 512 channels x 4 temporal frames x (4H spatial) x (4W spatial) x 4 bytes
-    block3_bytes_per_lat_frame = 512 * 4 * (H_lat * 4) * (W_lat * 4) * 4
+    # Block-3 peak tensor: 512ch x 4 temporal x (4H spatial) x (4W spatial) x 2 bytes (bf16).
+    block3_bytes_per_lat_frame = 512 * 4 * (H_lat * 4) * (W_lat * 4) * 2
 
     if block3_bytes_per_lat_frame * F_lat <= budget_bytes:
         return None  # Full video fits in budget — no tiling needed
@@ -409,9 +410,14 @@ class VideoDecoder(nn.Module):
         """Decode latent and stream frames to ffmpeg.
 
         Automatically applies temporal tiling when the full-volume decode would
-        exceed 8 GB peak activation memory (block 3 intermediate). At typical
-        resolutions (≤720p, ≤20s) this falls through to a single-pass decode
-        with no tiling overhead.
+        exceed the memory budget (``LTX2_VAE_DECODE_BUDGET_GB``, default 8 GB).
+        Budget is measured against the block-3 bf16 activation
+        (512 x 4 x 4H_lat x 4W_lat x 2 bytes per latent frame). At 8 GB:
+
+        - 720p  (H_lat=22, W_lat=40): ~55 MB/frame → tiling at ~47s @25fps
+        - 1080p (H_lat=33, W_lat=60): ~124 MB/frame → tiling at ~22s @25fps
+
+        Falls through to a single-pass decode with no overhead for shorter clips.
 
         Args:
             latent: (B, C, F, H, W) latent.

--- a/packages/ltx-core-mlx/src/ltx_core_mlx/model/video_vae/video_vae.py
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/model/video_vae/video_vae.py
@@ -25,6 +25,7 @@ via :func:`~ltx_2_mlx.model.video_vae.ops.remap_encoder_weight_keys`.
 from __future__ import annotations
 
 import logging
+import os
 import subprocess
 from collections.abc import Iterator
 from typing import Any
@@ -59,7 +60,6 @@ logger: logging.Logger = logging.getLogger(__name__)
 
 def _compute_decode_tiling(
     latent_shape: tuple[int, ...],
-    peak_budget_gb: float = 8.0,
     frame_rate: float = 24.0,
 ) -> TilingConfig | None:
     """Return a TilingConfig that keeps peak VAE decode memory under budget, or None.
@@ -67,7 +67,11 @@ def _compute_decode_tiling(
     Peak memory occurs at the block-3 intermediate tensor (the second
     DepthToSpaceUpsample), shape (1, 512, F_lat*4, H_lat*4, W_lat*4) in bf16.
     Returns None when the full video fits within budget — no tiling, no overhead.
+
+    Budget is controlled by the ``LTX2_VAE_DECODE_BUDGET_GB`` environment variable
+    (default 8.0 GB). Raise it on Mac Studio 64/128 GB to reduce or eliminate tiling.
     """
+    peak_budget_gb = float(os.environ.get("LTX2_VAE_DECODE_BUDGET_GB", "8.0"))
     _, _, F_lat, H_lat, W_lat = latent_shape
     budget_bytes = int(peak_budget_gb * 1024**3)
 

--- a/packages/ltx-core-mlx/src/ltx_core_mlx/model/video_vae/video_vae.py
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/model/video_vae/video_vae.py
@@ -451,31 +451,41 @@ class VideoDecoder(nn.Module):
         proc = subprocess.Popen(cmd, stdin=subprocess.PIPE, stderr=subprocess.PIPE)
         assert proc.stdin is not None
 
-        try:
-            for chunk in self.tiled_decode(latent, tiling):  # (B, 3, T, H, W)
-                # chunk is already materialized by tiled_decode — async_eval is a no-op
-                # but kept for compatibility if the yield path changes.
-                mx.async_eval(chunk)
-                num_frames = chunk.shape[2]
-                for i in range(num_frames):
-                    frame = chunk[:, :, i, :, :]
-                    frame = mx.clip(frame, -1.0, 1.0)
-                    frame = ((frame + 1.0) * 127.5).astype(mx.uint8)
-                    frame_hwc = frame[0].transpose(1, 2, 0)  # (H, W, 3)
-                    mx.eval(frame_hwc)  # sync before write — async_eval can race memoryview
+        frames_written = 0
+        pipe_broken = False
+        for chunk in self.tiled_decode(latent, tiling):  # (B, 3, T, H, W)
+            if pipe_broken:
+                break
+            # chunk is already materialized by tiled_decode — async_eval is a no-op
+            # but kept for compatibility if the yield path changes.
+            mx.async_eval(chunk)
+            num_frames = chunk.shape[2]
+            for i in range(num_frames):
+                frame = chunk[:, :, i, :, :]
+                frame = mx.clip(frame, -1.0, 1.0)
+                frame = ((frame + 1.0) * 127.5).astype(mx.uint8)
+                frame_hwc = frame[0].transpose(1, 2, 0)  # (H, W, 3)
+                mx.eval(frame_hwc)  # sync before write — async_eval can race memoryview
+                try:
                     proc.stdin.write(bytes(memoryview(frame_hwc)))
-                    del frame, frame_hwc
-                    if i % 8 == 0:
-                        aggressive_cleanup()
-                del chunk
-                aggressive_cleanup()
-        except BrokenPipeError:
-            pass  # ffmpeg may close early with -shortest; output is still valid
-        finally:
-            if proc.stdin and not proc.stdin.closed:
-                proc.stdin.close()
-            proc.wait()
+                except BrokenPipeError:
+                    logger.warning(
+                        "ffmpeg pipe closed after %d frames (expected %d); output may be truncated",
+                        frames_written,
+                        latent.shape[2] * 8 - 7,
+                    )
+                    pipe_broken = True
+                    break
+                frames_written += 1
+                del frame, frame_hwc
+                if i % 8 == 0:
+                    aggressive_cleanup()
+            del chunk
             aggressive_cleanup()
+        if proc.stdin and not proc.stdin.closed:
+            proc.stdin.close()
+        proc.wait()
+        aggressive_cleanup()
 
 
 class VideoEncoder(nn.Module):

--- a/packages/ltx-core-mlx/src/ltx_core_mlx/model/video_vae/video_vae.py
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/model/video_vae/video_vae.py
@@ -333,7 +333,9 @@ class VideoDecoder(nn.Module):
             curr_temporal_slice = temporal_group_tiles[0].out_coords[2]
             temporal_len = curr_temporal_slice.stop - curr_temporal_slice.start
 
-            # Initialize accumulation buffers for this temporal group
+            # Initialize accumulation buffers for this temporal group.
+            # TODO: switch to bfloat16 (matching decoder output dtype) to halve
+            # buffer memory — deferred to isolate decode RAM auditing to its own PR.
             buffer = mx.zeros((latent.shape[0], 3, temporal_len, out_H, out_W))
             weights = mx.zeros_like(buffer)
 
@@ -430,6 +432,10 @@ class VideoDecoder(nn.Module):
 
         - 720p  (H_lat=22, W_lat=40): ~55 MB/frame → tiling at ~47s @25fps
         - 1080p (H_lat=33, W_lat=60): ~124 MB/frame → tiling at ~22s @25fps
+
+        Note: the budget covers the block-3 activation of a single tile decode.
+        The tiling accumulation buffer (fp32, B x 3 x T x H x W) and its weights
+        twin live on top of this; at 1080p / >100 frames they add several GB.
 
         Falls through to a single-pass decode with no overhead for shorter clips.
 

--- a/packages/ltx-core-mlx/src/ltx_core_mlx/model/video_vae/video_vae.py
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/model/video_vae/video_vae.py
@@ -231,11 +231,15 @@ class VideoDecoder(nn.Module):
         std = self.per_channel_statistics.std.reshape(1, 1, 1, 1, -1)
         return latent * std + mean
 
-    def decode(self, latent: mx.array) -> mx.array:
+    def decode(self, latent: mx.array, *, _materialize_stages: bool = False) -> mx.array:
         """Decode latent to pixel frames.
 
         Args:
             latent: (B, C, F, H, W) latent in PyTorch layout.
+            _materialize_stages: If True, force-eval after each upsample stage so
+                prior activations can be freed before the next (larger) stage begins.
+                Only set by :meth:`tiled_decode`; the no-tiling path omits this to
+                avoid breaking kernel fusion across upsample stages.
 
         Returns:
             Pixels (B, 3, F, H, W) in [-1, 1], same dtype as ``latent``.
@@ -268,6 +272,9 @@ class VideoDecoder(nn.Module):
                 if tf > 1:
                     x = x[:, 1:, :, :, :]
                 upsample_idx += 1
+                if _materialize_stages:
+                    # Free prior-stage activations before the next, larger stage.
+                    mx.eval(x)
 
         # Pre-activation PixelNorm + SiLU before final conv
         x = self.conv_out(nn.silu(pixel_norm(x)))
@@ -332,7 +339,7 @@ class VideoDecoder(nn.Module):
 
             for tile in temporal_group_tiles:
                 # Decode tile and immediately materialize to free intermediate activations
-                decoded_tile = self.decode(latent[tile.in_coords])
+                decoded_tile = self.decode(latent[tile.in_coords], _materialize_stages=True)
                 mx.eval(decoded_tile)
                 aggressive_cleanup()
 

--- a/packages/ltx-core-mlx/src/ltx_core_mlx/model/video_vae/video_vae.py
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/model/video_vae/video_vae.py
@@ -92,8 +92,7 @@ def _compute_decode_tiling(
     # duration regardless of fps (e.g. 24→24 frames, 30→24, 48→40, 60→56).
     one_second_frames = max(8, (int(frame_rate) // 8) * 8)
     overlap = min(one_second_frames, (tile_frames // 32) * 8)
-    if overlap >= tile_frames:
-        overlap = 0
+    assert overlap < tile_frames, f"overlap {overlap} >= tile_frames {tile_frames}"
 
     return TilingConfig(
         temporal_config=TemporalTilingConfig(

--- a/packages/ltx-core-mlx/src/ltx_core_mlx/model/video_vae/video_vae.py
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/model/video_vae/video_vae.py
@@ -45,6 +45,7 @@ from ltx_core_mlx.model.video_vae.sampling import (
     unpatchify_spatial,
 )
 from ltx_core_mlx.model.video_vae.tiling import (
+    TemporalTilingConfig,
     Tile,
     TilingConfig,
     prepare_tiles_for_decoding,
@@ -54,6 +55,46 @@ from ltx_core_mlx.utils.ffmpeg import find_ffmpeg
 from ltx_core_mlx.utils.memory import aggressive_cleanup
 
 logger: logging.Logger = logging.getLogger(__name__)
+
+def _compute_decode_tiling(
+    latent_shape: tuple[int, ...],
+    peak_budget_gb: float = 8.0,
+    frame_rate: float = 24.0,
+) -> TilingConfig | None:
+    """Return a TilingConfig that keeps peak VAE decode memory under budget, or None.
+
+    Peak memory occurs at the block-3 intermediate tensor (the second DepthToSpaceUpsample), which has shape (1, 512, F_lat*4, H_lat*4, W_lat*4) at float32. We size tiles so thi tensor stays within budget. Returns None when the full video already fits — no tiling,
+    no overhead.
+    """
+    _, _, F_lat, H_lat, W_lat = latent_shape
+    budget_bytes = int(peak_budget_gb * 1024**3)
+
+    # Block-3 peak memory: 512 channels × 4 temporal frames × (4H spatial) × (4W spatial) × 4 bytes
+    block3_bytes_per_lat_frame = 512 * 4 * (H_lat * 4) * (W_lat * 4) * 4
+
+    if block3_bytes_per_lat_frame * F_lat <= budget_bytes:
+        return None  # Full video fits in budget — no tiling needed
+
+    # How many latent frames fit within the budget?
+    max_lat_frames = max(2, budget_bytes // block3_bytes_per_lat_frame)
+
+    # Convert latent frames → output pixel frames (8× temporal upsampling), with a 16-frame minimum
+    tile_frames = max(16, max_lat_frames * 8)
+
+    # Overlap ≈ 1 second of pixel frames at the given frame rate, rounded down to a multiple of 8,
+    # at most 25% of tile size. Scaling with frame_rate keeps the blend window a consistent
+    # duration regardless of fps (e.g. 24→24 frames, 30→24, 48→40, 60→56).
+    one_second_frames = max(8, (int(frame_rate) // 8) * 8)
+    overlap = min(one_second_frames, (tile_frames // 32) * 8)
+    if overlap >= tile_frames:
+        overlap = 0
+
+    return TilingConfig(
+        temporal_config=TemporalTilingConfig(
+            tile_size_in_frames=tile_frames,
+            tile_overlap_in_frames=overlap,
+        )
+    )
 
 
 def _add_at(buffer: mx.array, coords: tuple[slice, ...], values: mx.array) -> mx.array:
@@ -254,7 +295,11 @@ class VideoDecoder(nn.Module):
             Video chunks (B, 3, T, H, W) in [-1, 1], by temporal slices.
         """
         if tiling_config is None:
-            yield self.decode(latent)
+            pixels = self.decode(latent)
+            mx.eval(pixels)      # materialize now — frees block-3 intermediate activations
+            aggressive_cleanup() # release GPU cache before caller begins streaming
+            yield pixels
+            del pixels
             return
 
         tiles = prepare_tiles_for_decoding(latent.shape, tiling_config)
@@ -281,8 +326,11 @@ class VideoDecoder(nn.Module):
             weights = mx.zeros_like(buffer)
 
             for tile in temporal_group_tiles:
-                # Decode tile
+                # Decode tile and immediately materialize to free intermediate activations
                 decoded_tile = self.decode(latent[tile.in_coords])
+                mx.eval(decoded_tile)
+                aggressive_cleanup()
+
                 mask = tile.blend_mask
 
                 temporal_offset = tile.out_coords[2].start - curr_temporal_slice.start
@@ -305,6 +353,8 @@ class VideoDecoder(nn.Module):
 
                 buffer = _add_at(buffer, chunk_coords, decoded_slice * mask_slice)
                 weights = _add_at(weights, chunk_coords, mask_slice)
+                # Force accumulation buffers to materialize so decoded_tile's graph can be freed
+                mx.eval(buffer, weights)
 
                 del decoded_tile, mask, decoded_slice, mask_slice
                 aggressive_cleanup()
@@ -357,7 +407,10 @@ class VideoDecoder(nn.Module):
     ) -> None:
         """Decode latent and stream frames to ffmpeg.
 
-        Decodes one temporal chunk at a time to avoid OOM.
+        Automatically applies temporal tiling when the full-volume decode would
+        exceed 8 GB peak activation memory (block 3 intermediate). At typical
+        resolutions (≤720p, ≤20s) this falls through to a single-pass decode
+        with no tiling overhead.
 
         Args:
             latent: (B, C, F, H, W) latent.
@@ -366,6 +419,7 @@ class VideoDecoder(nn.Module):
             audio_path: Optional audio file to mux.
         """
         ffmpeg = find_ffmpeg()
+        tiling = _compute_decode_tiling(latent.shape, frame_rate=frame_rate)
 
         # Estimate output dimensions from latent
         _, _, _F_lat, H_lat, W_lat = latent.shape
@@ -397,22 +451,23 @@ class VideoDecoder(nn.Module):
         assert proc.stdin is not None
 
         try:
-            # Decode full volume and stream frames
-            pixels = self.decode(latent)
-            mx.async_eval(pixels)
-
-            num_frames = pixels.shape[2]
-            for i in range(num_frames):
-                frame = pixels[:, :, i, :, :]  # (B, 3, H, W)
-                frame = mx.clip(frame, -1.0, 1.0)
-                frame = ((frame + 1.0) * 127.5).astype(mx.uint8)
-                # (1, 3, H, W) -> (H, W, 3)
-                frame_hwc = frame[0].transpose(1, 2, 0)
-                mx.eval(frame_hwc)  # must be sync — async_eval can write before data is ready
-                proc.stdin.write(bytes(memoryview(frame_hwc)))
-                del frame, frame_hwc
-                if i % 8 == 0:
-                    aggressive_cleanup()
+            for chunk in self.tiled_decode(latent, tiling):  # (B, 3, T, H, W)
+                # chunk is already materialized by tiled_decode — async_eval is a no-op
+                # but kept for compatibility if the yield path changes.
+                mx.async_eval(chunk)
+                num_frames = chunk.shape[2]
+                for i in range(num_frames):
+                    frame = chunk[:, :, i, :, :]
+                    frame = mx.clip(frame, -1.0, 1.0)
+                    frame = ((frame + 1.0) * 127.5).astype(mx.uint8)
+                    frame_hwc = frame[0].transpose(1, 2, 0)  # (H, W, 3)
+                    mx.eval(frame_hwc)  # sync before write — async_eval can race memoryview
+                    proc.stdin.write(bytes(memoryview(frame_hwc)))
+                    del frame, frame_hwc
+                    if i % 8 == 0:
+                        aggressive_cleanup()
+                del chunk
+                aggressive_cleanup()
         except BrokenPipeError:
             pass  # ffmpeg may close early with -shortest; output is still valid
         finally:

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/_base.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/_base.py
@@ -100,7 +100,7 @@ class BasePipeline:
         self.prompt_encoder = _PromptEncoderBlock(self.model_dir, gemma_model_id)
         self.image_conditioner = _ImageConditionerBlock(self.model_dir)
         self.audio_conditioner = _AudioConditionerBlock(self.model_dir)
-        self.video_decoder_block = _VideoDecoderBlock(self.model_dir)
+        self.video_decoder_block = _VideoDecoderBlock(self.model_dir, verbose=self.verbose)
         self.audio_decoder_block = _AudioDecoderBlock(self.model_dir)
 
         self.dit: LTXModel | None = None

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/a2vid_two_stage.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/a2vid_two_stage.py
@@ -374,8 +374,7 @@ class A2VidPipelineTwoStage(TI2VidTwoStagesPipeline):
         else:
             temp_audio = None
 
-        assert self.vae_decoder is not None
-        self.vae_decoder.decode_and_stream(
+        self.video_decoder_block.decode_and_stream(
             video_latent,
             output_path,
             frame_rate=frame_rate,

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/utils/blocks.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/utils/blocks.py
@@ -39,6 +39,7 @@ Differences vs upstream:
 
 from __future__ import annotations
 
+import sys
 from collections.abc import Callable
 from pathlib import Path
 
@@ -49,6 +50,7 @@ from ltx_core_mlx.model.audio_vae.bwe import VocoderWithBWE
 from ltx_core_mlx.model.upsampler.model import LatentUpsampler
 from ltx_core_mlx.model.video_vae.video_vae import VideoDecoder as _VideoVAEDecoder
 from ltx_core_mlx.model.video_vae.video_vae import VideoEncoder as _VideoVAEEncoder
+from ltx_core_mlx.model.video_vae.video_vae import _compute_decode_tiling
 from ltx_core_mlx.text_encoders.gemma.encoders.base_encoder import GemmaLanguageModel
 from ltx_core_mlx.text_encoders.gemma.feature_extractor import GemmaFeaturesExtractorV2
 from ltx_core_mlx.utils.memory import aggressive_cleanup
@@ -201,8 +203,9 @@ class VideoDecoder:
     mux with an audio file in one shot.
     """
 
-    def __init__(self, model_dir: str | Path) -> None:
+    def __init__(self, model_dir: str | Path, verbose: bool = True) -> None:
         self.model_dir = _resolve_model_dir(model_dir)
+        self.verbose = verbose
         self._decoder: _VideoVAEDecoder | None = None
 
     def load(self) -> _VideoVAEDecoder:
@@ -226,6 +229,15 @@ class VideoDecoder:
         audio_path: str | None = None,
     ) -> str:
         """Stream-decode the latent into an mp4 with optional audio mux."""
+        if self.verbose:
+            tiling = _compute_decode_tiling(video_latent.shape, frame_rate=frame_rate)
+            if tiling is not None and tiling.temporal_config is not None:
+                tc = tiling.temporal_config
+                print(
+                    f"[vae-decode tiled: tile_frames={tc.tile_size_in_frames} overlap={tc.tile_overlap_in_frames}]",
+                    file=sys.stderr,
+                    flush=True,
+                )
         decoder = self.load()
         decoder.decode_and_stream(video_latent, output_path, frame_rate=frame_rate, audio_path=audio_path)
         return output_path

--- a/tests/test_decode_tiling.py
+++ b/tests/test_decode_tiling.py
@@ -3,22 +3,19 @@
 All tests are pure arithmetic — no model weights, no GPU work, sub-second.
 """
 
-import pytest
-
 from ltx_core_mlx.model.video_vae.tiling import TemporalTilingConfig
 from ltx_core_mlx.model.video_vae.video_vae import _compute_decode_tiling
 
-
 # Latent shape (B, C, F_lat, H_lat, W_lat) used across tests.
-# 4×4 spatial keeps block-3 bytes small so we can control the budget precisely.
+# 4x4 spatial keeps block-3 bytes small so we can control the budget precisely.
 # block3_bytes_per_lat_frame = 512 * 4 * (4*4) * (4*4) * 4 = 2,097,152 (~2 MB)
-_SMALL_LATENT = (1, 128, 100, 4, 4)  # 100 latent frames → ~200 MB total, triggers at budget < 200 MB
+_SMALL_LATENT = (1, 128, 100, 4, 4)  # 100 latent frames -> ~200 MB total, triggers at budget < 200 MB
 _BYTES_PER_LAT_FRAME = 512 * 4 * (4 * 4) * (4 * 4) * 4  # 2 MB
 
 
 class TestNoTilingNeeded:
     def test_returns_none_when_video_fits(self):
-        # 2 latent frames × 2 MB = 4 MB << 1 GB budget
+        # 2 latent frames x 2 MB = 4 MB << 1 GB budget
         shape = (1, 128, 2, 4, 4)
         result = _compute_decode_tiling(shape, peak_budget_gb=1.0)
         assert result is None

--- a/tests/test_decode_tiling.py
+++ b/tests/test_decode_tiling.py
@@ -8,68 +8,72 @@ from ltx_core_mlx.model.video_vae.video_vae import _compute_decode_tiling
 
 # Latent shape (B, C, F_lat, H_lat, W_lat) used across tests.
 # 4x4 spatial keeps block-3 bytes small so we can control the budget precisely.
-# block3_bytes_per_lat_frame = 512 * 4 * (4*4) * (4*4) * 4 = 2,097,152 (~2 MB)
-_SMALL_LATENT = (1, 128, 100, 4, 4)  # 100 latent frames -> ~200 MB total, triggers at budget < 200 MB
-_BYTES_PER_LAT_FRAME = 512 * 4 * (4 * 4) * (4 * 4) * 4  # 2 MB
+# block3_bytes_per_lat_frame = 512 * 4 * (4*4) * (4*4) * 2 = 1,048,576 (~1 MB)
+_SMALL_LATENT = (1, 128, 100, 4, 4)  # 100 latent frames -> ~100 MB total, triggers at budget < 100 MB
+_BYTES_PER_LAT_FRAME = 512 * 4 * (4 * 4) * (4 * 4) * 2  # 1 MB (bf16)
 
 
 class TestNoTilingNeeded:
-    def test_returns_none_when_video_fits(self):
-        # 2 latent frames x 2 MB = 4 MB << 1 GB budget
+    def test_returns_none_when_video_fits(self, monkeypatch):
+        # 2 latent frames x 1 MB = 2 MB << 1 GB budget
+        monkeypatch.setenv("LTX2_VAE_DECODE_BUDGET_GB", "1.0")
         shape = (1, 128, 2, 4, 4)
-        result = _compute_decode_tiling(shape, peak_budget_gb=1.0)
+        result = _compute_decode_tiling(shape)
         assert result is None
 
-    def test_returns_none_exactly_at_budget(self):
+    def test_returns_none_exactly_at_budget(self, monkeypatch):
         # budget == total bytes → should NOT tile (≤ check)
         budget_bytes = _BYTES_PER_LAT_FRAME * 100
         budget_gb = budget_bytes / 1024**3
-        result = _compute_decode_tiling(_SMALL_LATENT, peak_budget_gb=budget_gb)
+        monkeypatch.setenv("LTX2_VAE_DECODE_BUDGET_GB", str(budget_gb))
+        result = _compute_decode_tiling(_SMALL_LATENT)
         assert result is None
 
-    def test_triggers_just_above_budget(self):
+    def test_triggers_just_above_budget(self, monkeypatch):
         # One byte under exact fit → should tile
         budget_bytes = _BYTES_PER_LAT_FRAME * 100 - 1
         budget_gb = budget_bytes / 1024**3
-        result = _compute_decode_tiling(_SMALL_LATENT, peak_budget_gb=budget_gb)
+        monkeypatch.setenv("LTX2_VAE_DECODE_BUDGET_GB", str(budget_gb))
+        result = _compute_decode_tiling(_SMALL_LATENT)
         assert result is not None
 
 
 class TestTilingConfig:
     """When tiling triggers, the returned config must satisfy TemporalTilingConfig constraints."""
 
-    # budget=0.1 GB gives tile_frames=424 (well above 16), large enough that the
+    # budget=0.05 GB gives tile_frames=408 (well above 16), large enough that the
     # fps-scaling overlap formula is exercised rather than the 25% cap.
-    _BUDGET = 0.1
+    _BUDGET = "0.05"
 
-    def _cfg(self, fps: float) -> TemporalTilingConfig:
-        result = _compute_decode_tiling(_SMALL_LATENT, peak_budget_gb=self._BUDGET, frame_rate=fps)
+    def _cfg(self, fps: float, monkeypatch) -> TemporalTilingConfig:
+        monkeypatch.setenv("LTX2_VAE_DECODE_BUDGET_GB", self._BUDGET)
+        result = _compute_decode_tiling(_SMALL_LATENT, frame_rate=fps)
         assert result is not None
         assert result.temporal_config is not None
         return result.temporal_config
 
-    def test_tile_size_gte_16(self):
-        cfg = self._cfg(24.0)
+    def test_tile_size_gte_16(self, monkeypatch):
+        cfg = self._cfg(24.0, monkeypatch)
         assert cfg.tile_size_in_frames >= 16
 
-    def test_tile_size_divisible_by_8(self):
-        cfg = self._cfg(24.0)
+    def test_tile_size_divisible_by_8(self, monkeypatch):
+        cfg = self._cfg(24.0, monkeypatch)
         assert cfg.tile_size_in_frames % 8 == 0
 
-    def test_overlap_divisible_by_8(self):
+    def test_overlap_divisible_by_8(self, monkeypatch):
         for fps in (24.0, 30.0, 48.0, 60.0):
-            cfg = self._cfg(fps)
+            cfg = self._cfg(fps, monkeypatch)
             assert cfg.tile_overlap_in_frames % 8 == 0, f"overlap not multiple of 8 at {fps} fps"
 
-    def test_overlap_less_than_tile(self):
+    def test_overlap_less_than_tile(self, monkeypatch):
         for fps in (24.0, 30.0, 48.0, 60.0):
-            cfg = self._cfg(fps)
+            cfg = self._cfg(fps, monkeypatch)
             assert cfg.tile_overlap_in_frames < cfg.tile_size_in_frames
 
-    def test_config_passes_tiling_validation(self):
+    def test_config_passes_tiling_validation(self, monkeypatch):
         # TemporalTilingConfig.__post_init__ raises on invalid values
         for fps in (24.0, 30.0, 48.0, 60.0):
-            cfg = self._cfg(fps)
+            cfg = self._cfg(fps, monkeypatch)
             TemporalTilingConfig(
                 tile_size_in_frames=cfg.tile_size_in_frames,
                 tile_overlap_in_frames=cfg.tile_overlap_in_frames,
@@ -79,52 +83,52 @@ class TestTilingConfig:
 class TestFrameRateScaling:
     """Overlap should grow with frame rate to keep the blend window ~1 second."""
 
-    _BUDGET = 0.1  # large enough tiles that fps scaling, not 25% cap, dominates
+    _BUDGET = "0.05"  # large enough tiles that fps scaling, not 25% cap, dominates
 
-    def _overlap(self, fps: float) -> int:
-        result = _compute_decode_tiling(_SMALL_LATENT, peak_budget_gb=self._BUDGET, frame_rate=fps)
+    def _overlap(self, fps: float, monkeypatch) -> int:
+        monkeypatch.setenv("LTX2_VAE_DECODE_BUDGET_GB", self._BUDGET)
+        result = _compute_decode_tiling(_SMALL_LATENT, frame_rate=fps)
         assert result is not None and result.temporal_config is not None
         return result.temporal_config.tile_overlap_in_frames
 
-    def test_24fps_overlap(self):
-        # (int(24) // 8) * 8 = 24
-        assert self._overlap(24.0) == 24
+    def test_24fps_overlap(self, monkeypatch):
+        assert self._overlap(24.0, monkeypatch) == 24
 
-    def test_30fps_overlap(self):
-        # (int(30) // 8) * 8 = 24  (rounds down to same as 24fps)
-        assert self._overlap(30.0) == 24
+    def test_30fps_overlap(self, monkeypatch):
+        assert self._overlap(30.0, monkeypatch) == 24
 
-    def test_48fps_overlap(self):
-        # (int(48) // 8) * 8 = 48
-        assert self._overlap(48.0) == 48
+    def test_48fps_overlap(self, monkeypatch):
+        assert self._overlap(48.0, monkeypatch) == 48
 
-    def test_60fps_overlap(self):
-        # (int(60) // 8) * 8 = 56
-        assert self._overlap(60.0) == 56
+    def test_60fps_overlap(self, monkeypatch):
+        assert self._overlap(60.0, monkeypatch) == 56
 
-    def test_overlap_nondecreasing_with_fps(self):
+    def test_overlap_nondecreasing_with_fps(self, monkeypatch):
         fps_values = [24.0, 30.0, 48.0, 60.0]
-        overlaps = [self._overlap(fps) for fps in fps_values]
+        overlaps = [self._overlap(fps, monkeypatch) for fps in fps_values]
         assert overlaps == sorted(overlaps), f"overlaps not monotone: {list(zip(fps_values, overlaps))}"
 
 
 class TestEdgeCases:
-    def test_minimum_tile_size_enforced(self):
+    def test_minimum_tile_size_enforced(self, monkeypatch):
         # Tiny budget forces max_lat_frames=2 → tile_frames=max(16,16)=16
-        result = _compute_decode_tiling(_SMALL_LATENT, peak_budget_gb=1e-6)
+        monkeypatch.setenv("LTX2_VAE_DECODE_BUDGET_GB", "1e-6")
+        result = _compute_decode_tiling(_SMALL_LATENT)
         assert result is not None
         assert result.temporal_config is not None
         assert result.temporal_config.tile_size_in_frames >= 16
 
-    def test_overlap_zero_when_tile_too_small(self):
+    def test_overlap_zero_when_tile_too_small(self, monkeypatch):
         # With tile_frames=16: (16//32)*8 = 0 → overlap=0
-        result = _compute_decode_tiling(_SMALL_LATENT, peak_budget_gb=1e-6)
+        monkeypatch.setenv("LTX2_VAE_DECODE_BUDGET_GB", "1e-6")
+        result = _compute_decode_tiling(_SMALL_LATENT)
         assert result is not None
         assert result.temporal_config is not None
         assert result.temporal_config.tile_overlap_in_frames == 0
 
-    def test_default_fps_is_24(self):
-        r1 = _compute_decode_tiling(_SMALL_LATENT, peak_budget_gb=0.1)
-        r2 = _compute_decode_tiling(_SMALL_LATENT, peak_budget_gb=0.1, frame_rate=24.0)
+    def test_default_fps_is_24(self, monkeypatch):
+        monkeypatch.setenv("LTX2_VAE_DECODE_BUDGET_GB", "0.05")
+        r1 = _compute_decode_tiling(_SMALL_LATENT)
+        r2 = _compute_decode_tiling(_SMALL_LATENT, frame_rate=24.0)
         assert r1 is not None and r2 is not None
         assert r1.temporal_config == r2.temporal_config

--- a/tests/test_decode_tiling.py
+++ b/tests/test_decode_tiling.py
@@ -1,0 +1,133 @@
+"""Unit tests for _compute_decode_tiling.
+
+All tests are pure arithmetic — no model weights, no GPU work, sub-second.
+"""
+
+import pytest
+
+from ltx_core_mlx.model.video_vae.tiling import TemporalTilingConfig
+from ltx_core_mlx.model.video_vae.video_vae import _compute_decode_tiling
+
+
+# Latent shape (B, C, F_lat, H_lat, W_lat) used across tests.
+# 4×4 spatial keeps block-3 bytes small so we can control the budget precisely.
+# block3_bytes_per_lat_frame = 512 * 4 * (4*4) * (4*4) * 4 = 2,097,152 (~2 MB)
+_SMALL_LATENT = (1, 128, 100, 4, 4)  # 100 latent frames → ~200 MB total, triggers at budget < 200 MB
+_BYTES_PER_LAT_FRAME = 512 * 4 * (4 * 4) * (4 * 4) * 4  # 2 MB
+
+
+class TestNoTilingNeeded:
+    def test_returns_none_when_video_fits(self):
+        # 2 latent frames × 2 MB = 4 MB << 1 GB budget
+        shape = (1, 128, 2, 4, 4)
+        result = _compute_decode_tiling(shape, peak_budget_gb=1.0)
+        assert result is None
+
+    def test_returns_none_exactly_at_budget(self):
+        # budget == total bytes → should NOT tile (≤ check)
+        budget_bytes = _BYTES_PER_LAT_FRAME * 100
+        budget_gb = budget_bytes / 1024**3
+        result = _compute_decode_tiling(_SMALL_LATENT, peak_budget_gb=budget_gb)
+        assert result is None
+
+    def test_triggers_just_above_budget(self):
+        # One byte under exact fit → should tile
+        budget_bytes = _BYTES_PER_LAT_FRAME * 100 - 1
+        budget_gb = budget_bytes / 1024**3
+        result = _compute_decode_tiling(_SMALL_LATENT, peak_budget_gb=budget_gb)
+        assert result is not None
+
+
+class TestTilingConfig:
+    """When tiling triggers, the returned config must satisfy TemporalTilingConfig constraints."""
+
+    # budget=0.1 GB gives tile_frames=424 (well above 16), large enough that the
+    # fps-scaling overlap formula is exercised rather than the 25% cap.
+    _BUDGET = 0.1
+
+    def _cfg(self, fps: float) -> TemporalTilingConfig:
+        result = _compute_decode_tiling(_SMALL_LATENT, peak_budget_gb=self._BUDGET, frame_rate=fps)
+        assert result is not None
+        assert result.temporal_config is not None
+        return result.temporal_config
+
+    def test_tile_size_gte_16(self):
+        cfg = self._cfg(24.0)
+        assert cfg.tile_size_in_frames >= 16
+
+    def test_tile_size_divisible_by_8(self):
+        cfg = self._cfg(24.0)
+        assert cfg.tile_size_in_frames % 8 == 0
+
+    def test_overlap_divisible_by_8(self):
+        for fps in (24.0, 30.0, 48.0, 60.0):
+            cfg = self._cfg(fps)
+            assert cfg.tile_overlap_in_frames % 8 == 0, f"overlap not multiple of 8 at {fps} fps"
+
+    def test_overlap_less_than_tile(self):
+        for fps in (24.0, 30.0, 48.0, 60.0):
+            cfg = self._cfg(fps)
+            assert cfg.tile_overlap_in_frames < cfg.tile_size_in_frames
+
+    def test_config_passes_tiling_validation(self):
+        # TemporalTilingConfig.__post_init__ raises on invalid values
+        for fps in (24.0, 30.0, 48.0, 60.0):
+            cfg = self._cfg(fps)
+            TemporalTilingConfig(
+                tile_size_in_frames=cfg.tile_size_in_frames,
+                tile_overlap_in_frames=cfg.tile_overlap_in_frames,
+            )  # must not raise
+
+
+class TestFrameRateScaling:
+    """Overlap should grow with frame rate to keep the blend window ~1 second."""
+
+    _BUDGET = 0.1  # large enough tiles that fps scaling, not 25% cap, dominates
+
+    def _overlap(self, fps: float) -> int:
+        result = _compute_decode_tiling(_SMALL_LATENT, peak_budget_gb=self._BUDGET, frame_rate=fps)
+        assert result is not None and result.temporal_config is not None
+        return result.temporal_config.tile_overlap_in_frames
+
+    def test_24fps_overlap(self):
+        # (int(24) // 8) * 8 = 24
+        assert self._overlap(24.0) == 24
+
+    def test_30fps_overlap(self):
+        # (int(30) // 8) * 8 = 24  (rounds down to same as 24fps)
+        assert self._overlap(30.0) == 24
+
+    def test_48fps_overlap(self):
+        # (int(48) // 8) * 8 = 48
+        assert self._overlap(48.0) == 48
+
+    def test_60fps_overlap(self):
+        # (int(60) // 8) * 8 = 56
+        assert self._overlap(60.0) == 56
+
+    def test_overlap_nondecreasing_with_fps(self):
+        fps_values = [24.0, 30.0, 48.0, 60.0]
+        overlaps = [self._overlap(fps) for fps in fps_values]
+        assert overlaps == sorted(overlaps), f"overlaps not monotone: {list(zip(fps_values, overlaps))}"
+
+
+class TestEdgeCases:
+    def test_minimum_tile_size_enforced(self):
+        # Tiny budget forces max_lat_frames=2 → tile_frames=max(16,16)=16
+        result = _compute_decode_tiling(_SMALL_LATENT, peak_budget_gb=1e-6)
+        assert result is not None
+        assert result.temporal_config is not None
+        assert result.temporal_config.tile_size_in_frames >= 16
+
+    def test_overlap_zero_when_tile_too_small(self):
+        # With tile_frames=16: (16//32)*8 = 0 → overlap=0
+        result = _compute_decode_tiling(_SMALL_LATENT, peak_budget_gb=1e-6)
+        assert result is not None
+        assert result.temporal_config is not None
+        assert result.temporal_config.tile_overlap_in_frames == 0
+
+    def test_default_fps_is_24(self):
+        r1 = _compute_decode_tiling(_SMALL_LATENT, peak_budget_gb=0.1)
+        r2 = _compute_decode_tiling(_SMALL_LATENT, peak_budget_gb=0.1, frame_rate=24.0)
+        assert r1 is not None and r2 is not None
+        assert r1.temporal_config == r2.temporal_config

--- a/tests/test_vae_shapes.py
+++ b/tests/test_vae_shapes.py
@@ -207,6 +207,47 @@ class TestVideoDecoder:
         assert tiled_out.shape == baseline.shape
         assert mx.allclose(baseline, tiled_out, atol=1e-6).item()
 
+    def test_tiled_decode_multi_tile_matches_decode(self):
+        """tiled_decode with >=2 tiles exercises the previous_chunk blend path.
+
+        F_lat=5 → 33 pixel frames. With tile_size_in_frames=16 (2 latent frames)
+        and tile_overlap_in_frames=8 (1 latent frame), prepare_tiles_for_decoding
+        returns multiple tiles and the previous_chunk accumulation + blend math is
+        exercised.
+
+        Note: tiled output is NOT numerically close to decoder.decode() because the
+        VAE uses causal temporal convolutions — each tile starts with zero-padded
+        context instead of full causal history from the prior tile. Pixel-space
+        blending smooths the transition visually but does not reproduce the
+        non-tiled output. This test verifies shape, multi-tile execution, and
+        finite values; not numerical identity with the non-tiled path.
+        """
+        mx.random.seed(0)
+        decoder = VideoDecoder()
+        mx.eval(decoder.parameters())
+
+        latent = mx.random.normal((1, 128, 5, 3, 3))
+        mx.eval(latent)
+
+        cfg = TilingConfig(
+            temporal_config=TemporalTilingConfig(
+                tile_size_in_frames=16,
+                tile_overlap_in_frames=8,
+            )
+        )
+        chunks = list(decoder.tiled_decode(latent, cfg))
+        tiled_out = mx.concatenate(chunks, axis=2) if len(chunks) > 1 else chunks[0]
+        mx.eval(tiled_out)
+
+        # Multi-tile path was exercised
+        assert len(chunks) > 1
+        # Output shape matches non-tiled decode
+        baseline = decoder.decode(latent)
+        mx.eval(baseline)
+        assert tiled_out.shape == baseline.shape
+        # Blend produced finite values (no NaN/inf from weight accumulation)
+        assert mx.isfinite(tiled_out).all().item()
+
 
 # ---------------------------------------------------------------------------
 # Encoder tests

--- a/tests/test_vae_shapes.py
+++ b/tests/test_vae_shapes.py
@@ -8,6 +8,7 @@ from ltx_core_mlx.model.video_vae.convolution import Conv3dBlock
 from ltx_core_mlx.model.video_vae.ops import PerChannelStatistics
 from ltx_core_mlx.model.video_vae.resnet import ResBlock3d, ResBlockStage
 from ltx_core_mlx.model.video_vae.sampling import DepthToSpaceUpsample as UpsampleConv
+from ltx_core_mlx.model.video_vae.tiling import TemporalTilingConfig, TilingConfig
 from ltx_core_mlx.model.video_vae.video_vae import VideoDecoder, VideoEncoder
 
 # ---------------------------------------------------------------------------
@@ -173,6 +174,38 @@ class TestVideoDecoder:
         prefixes = {k.split(".")[0] for k in flat}
         expected = {"conv_in", "conv_out", "up_blocks", "per_channel_statistics"}
         assert prefixes == expected, f"Unexpected prefixes: {prefixes - expected}"
+
+    def test_tiled_decode_single_tile_matches_decode(self):
+        """tiled_decode with one tile covering the full latent must match decode exactly.
+
+        A single tile means no blending across boundaries — the accumulated buffer
+        divides by weights of 1.0 everywhere, reducing to identity. Any divergence
+        indicates a bug in the accumulation or yield path.
+        """
+        mx.random.seed(0)
+        decoder = VideoDecoder()
+        mx.eval(decoder.parameters())
+
+        # (B=1, C=128, F_lat=2, H_lat=3, W_lat=3) → 16 pixel frames, 96x96
+        latent = mx.random.normal((1, 128, 2, 3, 3))
+        mx.eval(latent)
+
+        baseline = decoder.decode(latent)
+        mx.eval(baseline)
+
+        # tile_size_in_frames=32 → latent tile size = 32//8 = 4 frames > F_lat=2 → single tile
+        cfg = TilingConfig(
+            temporal_config=TemporalTilingConfig(
+                tile_size_in_frames=32,
+                tile_overlap_in_frames=0,
+            )
+        )
+        chunks = list(decoder.tiled_decode(latent, cfg))
+        tiled_out = mx.concatenate(chunks, axis=2) if len(chunks) > 1 else chunks[0]
+        mx.eval(tiled_out)
+
+        assert tiled_out.shape == baseline.shape
+        assert mx.allclose(baseline, tiled_out, atol=1e-6).item()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Note, this one was AI-assisted, after finding the current choke points while testing on a 32GB M5 Macbook Air.  VAE decode would throw it into heavy swap usage even though the rest of the pipeline stages never touched it.  I've been running with this code in my main pipeline flow (8/3 --distilled) for almost a week.  VAE memory only becomes an issue now if I make the resoution too high for the hardware (720p > 10 seconds of video).

## VAE decode memory optimizations

### Problem

`VideoDecoder.stream_to_ffmpeg` decoded the full latent volume in a single
`self.decode()` call before streaming frames. At typical resolutions the
block-3 intermediate tensor (512 ch × 4× temporal × 4× spatial upsampling
at float32) can peak at 8–20+ GB for long or HD clips, causing OOM or heavy
swap before a single frame leaves the decoder.

The `tiled_decode` path also held on to intermediate activations across tiles
because neither the tile decode nor the accumulation buffers were evaluated
eagerly.

### Changes

**`_compute_decode_tiling` (new)** — pure arithmetic function that derives a
`TilingConfig` from the latent shape and an 8 GB peak-activation budget.
Estimates the block-3 bottleneck tensor size (`512 × 4F × 4H × 4W × float32`)
and returns `None` when the full video already fits, avoiding tiling overhead
for typical resolutions (≤720p, ≤~20s). When tiling is needed, tile size and
overlap are sized so overlap is approximately one second of output frames,
rounded to the nearest 8 frames (VAE temporal stride requirement), capped at
25% of tile size.

**`stream_to_ffmpeg`** — replaced the single `self.decode(latent)` + frame
loop with a `_compute_decode_tiling` call followed by
`self.tiled_decode(latent, tiling)`. At common resolutions `tiling` is `None`
and the code path is equivalent to before; at large resolutions tiling is
applied automatically without any caller change.

**`tiled_decode` — no-tiling path** — added `mx.eval` + `aggressive_cleanup`
after `self.decode` so block-3 intermediate activations are freed before the
caller begins streaming frames.

**`tiled_decode` — tiling path** — added `mx.eval` + `aggressive_cleanup`
immediately after each tile decode, and `mx.eval(buffer, weights)` after each
accumulation step. This breaks the lazy graph so the previous tile's
intermediate activations become evictable before the next tile decode begins.

### Tests (`tests/test_decode_tiling.py`)

17 pure-arithmetic tests (no weights, no GPU) covering `_compute_decode_tiling`:

- No tiling when video fits in budget; triggers one byte over
- `TemporalTilingConfig` constraints: tile size ≥ 16, divisible by 8,
  overlap < tile size, passes `__post_init__` validation
- Frame rate scaling: overlap grows monotonically with fps
  (24→24, 30→24, 48→48, 60→56 frames)
- Edge cases: minimum tile size enforced, zero overlap when tile is too small, default fps=24
