### PR TITLE
fix(ic_lora): align reference-video frame count to (1 + 8k) before VAE encode

### DIFF
--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/iclora_utils.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/iclora_utils.py
@@ -17,8 +17,10 @@ import mlx.core as mx
 import numpy as np
 from safetensors import safe_open
 
+from ltx_core_mlx.components.patchifiers import compute_video_latent_shape
 from ltx_core_mlx.conditioning.types.attention_strength_wrapper import ConditioningItemAttentionStrengthWrapper
 from ltx_core_mlx.conditioning.types.reference_video_cond import VideoConditionByReferenceLatent
+from ltx_core_mlx.utils.ffmpeg import probe_video_info
 from ltx_core_mlx.utils.positions import compute_video_positions
 from ltx_core_mlx.utils.video import load_video_frames_normalized
 
@@ -109,8 +111,6 @@ def append_ic_lora_reference_video_conditionings(
     minus the ``tiling_config`` arg (our VAE encoder doesn't expose a tiled-encode
     entry point; tiled video VAE happens at the decoder side via streaming).
     """
-    from ltx_core_mlx.components.patchifiers import compute_video_latent_shape
-
     scale = reference_downscale_factor
     if scale != 1 and (height % scale != 0 or width % scale != 0):
         raise ValueError(
@@ -122,7 +122,17 @@ def append_ic_lora_reference_video_conditionings(
     ref_width = ref_W_lat * 32
 
     for video_path, strength in video_conditioning:
-        video = load_video_frames_normalized(video_path, ref_height, ref_width, num_frames)
+        # The video VAE encoder requires a (1 + 8k)-frame input. Source files
+        # produced by LTX itself are saved 8k-trimmed (``_decode_and_save_video``
+        # drops the leading frame), so feeding them through unchanged fails the
+        # encoder's ``space_to_depth`` reshape. Probe the source, clamp to the
+        # caller's target, and round down to the nearest (1 + 8k). Mirrors
+        # ``RetakePipeline._encode_source_video``.
+        info = probe_video_info(video_path)
+        max_frames = min(num_frames, info.num_frames)
+        k = max(1, (max_frames - 1) // 8)
+        vae_compatible_frames = 1 + k * 8
+        video = load_video_frames_normalized(video_path, ref_height, ref_width, vae_compatible_frames)
         video = (video * 2.0 - 1.0).astype(mx.bfloat16)
         encoded_video = video_encoder.encode(video)
         _mx_eval(encoded_video)

--- a/tests/test_iclora_frame_alignment.py
+++ b/tests/test_iclora_frame_alignment.py
@@ -1,0 +1,119 @@
+"""Regression tests for IC-LoRA reference-video frame alignment (issue #27).
+
+The video VAE encoder requires a (1 + 8k)-frame input. Source files produced
+by LTX itself are 8k-trimmed on save, so passing them through unchanged hits
+``space_to_depth`` with an unreshapeable frame count. The helper must round
+the loader's frame count down to (1 + 8k) before invoking the encoder.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import mlx.core as mx
+import pytest
+
+from ltx_pipelines_mlx import iclora_utils
+
+
+@dataclass
+class _FakeVideoInfo:
+    """Stand-in for ltx_core_mlx.utils.ffmpeg.VideoInfo."""
+
+    width: int = 1280
+    height: int = 704
+    num_frames: int = 72
+    fps: float = 24.0
+    duration: float = 3.0
+    has_audio: bool = False
+
+
+class _FakeEncoder:
+    """Capture-only encoder; returns a tensor with the right rank but the
+    actual values are not exercised — we only assert what got loaded."""
+
+    def encode(self, video: mx.array) -> mx.array:
+        b = video.shape[0]
+        f_lat = max(1, (video.shape[2] - 1) // 8 + 1)
+        return mx.zeros((b, 128, f_lat, 1, 1))
+
+
+@pytest.fixture
+def captured_load(monkeypatch):
+    """Patch probe_video_info + loader; capture the frame count passed to the loader."""
+    calls: list[int] = []
+
+    def fake_probe(_path: str) -> _FakeVideoInfo:
+        return _FakeVideoInfo(num_frames=72)
+
+    def fake_load(_path, height: int, width: int, max_frames: int) -> mx.array:
+        calls.append(max_frames)
+        return mx.zeros((1, 3, max_frames, height, width), dtype=mx.bfloat16)
+
+    monkeypatch.setattr(iclora_utils, "probe_video_info", fake_probe)
+    monkeypatch.setattr(iclora_utils, "load_video_frames_normalized", fake_load)
+    return calls
+
+
+def _invoke(num_frames: int, scale: int = 2) -> None:
+    """Helper: invoke the helper with a single conditioning at the given target."""
+    iclora_utils.append_ic_lora_reference_video_conditionings(
+        conditionings=[],
+        video_conditioning=[("/fake/path.mp4", 1.0)],
+        height=704,
+        width=1280,
+        num_frames=num_frames,
+        video_encoder=_FakeEncoder(),
+        reference_downscale_factor=scale,
+    )
+
+
+class TestFrameAlignment:
+    """The bug from issue #27: 8k-frame source + naive load → unreshapeable."""
+
+    def test_short_source_aligns_to_1_plus_8k(self, captured_load):
+        # File has 72 frames; caller asks for 121. Loader must get 65 (= 1 + 8*8).
+        _invoke(num_frames=121)
+        assert captured_load == [65], f"expected loader to receive 65 frames, got {captured_load}"
+
+    def test_aligned_source_passes_through(self, captured_load, monkeypatch):
+        # File has exactly 73 frames (1 + 8*9); target 121. min=73, k=9, vae=73.
+        monkeypatch.setattr(iclora_utils, "probe_video_info", lambda _p: _FakeVideoInfo(num_frames=73))
+        _invoke(num_frames=121)
+        assert captured_load == [73]
+
+    def test_long_source_capped_at_target(self, captured_load, monkeypatch):
+        # File has 200 frames; target 73 (= 1 + 8*9). min=73, k=9, vae=73.
+        monkeypatch.setattr(iclora_utils, "probe_video_info", lambda _p: _FakeVideoInfo(num_frames=200))
+        _invoke(num_frames=73)
+        assert captured_load == [73]
+
+    def test_long_source_with_misaligned_target_rounds_down(self, captured_load, monkeypatch):
+        # File has 200 frames; target 121 (= 1 + 8*15). min=121, k=15, vae=121. ✓
+        # And a non-aligned target (90): min=90, k=(90-1)//8=11, vae=89.
+        monkeypatch.setattr(iclora_utils, "probe_video_info", lambda _p: _FakeVideoInfo(num_frames=200))
+        _invoke(num_frames=90)
+        assert captured_load == [89]
+
+    def test_multiple_conditionings_each_aligned(self, captured_load, monkeypatch):
+        # Two refs of different lengths; each one independently aligned.
+        infos = iter([_FakeVideoInfo(num_frames=72), _FakeVideoInfo(num_frames=49)])
+        monkeypatch.setattr(iclora_utils, "probe_video_info", lambda _p: next(infos))
+        iclora_utils.append_ic_lora_reference_video_conditionings(
+            conditionings=[],
+            video_conditioning=[("/a.mp4", 1.0), ("/b.mp4", 1.0)],
+            height=704,
+            width=1280,
+            num_frames=121,
+            video_encoder=_FakeEncoder(),
+            reference_downscale_factor=2,
+        )
+        # 72 → k=8 → 65; 49 → k=6 → 49
+        assert captured_load == [65, 49]
+
+    def test_one_frame_minimum(self, captured_load, monkeypatch):
+        # Pathological: source has 1 frame. k = max(1, 0) = 1, vae = 9.
+        # The loader will return 1 frame anyway (file capacity), but we send 9.
+        monkeypatch.setattr(iclora_utils, "probe_video_info", lambda _p: _FakeVideoInfo(num_frames=1))
+        _invoke(num_frames=121)
+        assert captured_load == [9]


### PR DESCRIPTION
## Summary

Fixes #27 — `ICLoraPipeline.generate_and_save(video_conditioning=[(path, strength)])` crashes reproducibly at `ltx_core_mlx/model/video_vae/sampling.py:121` (`space_to_depth`) for any source whose frame count isn't `1 + 8k`. Caught by [@R0drig0Diaz](https://github.com/R0drig0Diaz) — diagnosis was byte-identical across two semantically-different inputs (raw RGB + canny edges) and reproduced at a second spatial scale (HDR variant with `reference_downscale_factor=1`).

## Diagnosis

The video VAE encoder's first `space_to_depth` reshape over the temporal axis uses stride 2 and assumes `(1 + 8k)` frames. Source files produced by LTX itself are saved 8k-trimmed (`_decode_and_save_video` drops the leading frame on write), so a 72-frame LTX `.mp4` fed into the IC-LoRA `video_conditioning` path fails — the reshape's input size is always exactly +1 frame larger than what the encoder can accept. The reporter's two crashes:

| variant | LoRA | encode resolution | actual size | target size | diff |
|---|---|---|---|---|---|
| Union Control | `ref=2` | 640×352 | 14,950,400 | 14,745,600 | +1 half-res frame |
| HDR | `ref=1` | 1280×704 | 65,781,760 | 64,880,640 | +1 full-res frame |

Same arithmetic, two scales.

## Fix

Mirrors `RetakePipeline._encode_source_video` — probe the source, clamp to the caller's target, round down to `(1 + 8k)`:

```python
info = probe_video_info(video_path)
max_frames = min(num_frames, info.num_frames)
k = max(1, (max_frames - 1) // 8)
vae_compatible_frames = 1 + k * 8
video = load_video_frames_normalized(video_path, ref_height, ref_width, vae_compatible_frames)
```

Applies to every `ICLoraPipeline` subclass — including `HDRICLoraPipeline` and `LipDubPipeline`'s video-reference path — because all three go through `append_ic_lora_reference_video_conditionings` in `iclora_utils.py`.

Also lifts a local `from ltx_core_mlx.components.patchifiers import compute_video_latent_shape` to module scope. Same anti-pattern that caused the `UnboundLocalError` previously fixed in `ic_lora.py` (commit 23127d6). Not load-bearing here (no `if` branch shadowing), but matches the cleanup precedent.

## Closes-but-not-by-this-PR notes

The issue lists three sub-bugs; the other two (scoping traps at `ic_lora.py:261` and `ic_lora.py:501`) were already resolved on `main` since 23127d6 (the reporter was on stale HEAD `0e753b6`).

## Test plan

- [x] 6 new unit tests in `tests/test_iclora_frame_alignment.py` covering: short source aligned, exact `1+8k` source pass-through, long source capped at target, misaligned target rounded down, multiple conditionings independently aligned, 1-frame pathological case.
- [x] `uv run pytest tests/test_iclora_frame_alignment.py` — 6/6 pass in 0.5s.
- [x] Full suite verified — only failures are 3 pre-existing weight-gated tests that fail on `main` too (unrelated).
- [x] `ruff check` clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)