### PR TITLE
feat: versioned safetensors loading

### DIFF
--- a/packages/ltx-core-mlx/src/ltx_core_mlx/loader/sft_loader.py
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/loader/sft_loader.py
@@ -6,12 +6,22 @@ Ported from ltx-core/src/ltx_core/loader/sft_loader.py
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 import mlx.core as mx
 from safetensors import safe_open
 
 from ltx_core_mlx.loader.primitives import StateDict
 from ltx_core_mlx.loader.sd_ops import SDOps
+
+_KNOWN_MLX_EXTENSIONS = {".safetensors", ".npz", ".npy", ".gguf"}
+
+
+def _load_weights(path: str) -> dict[str, mx.array]:
+    """Load weights, handling extensionless HF cache blobs via explicit format."""
+    if Path(path).suffix in _KNOWN_MLX_EXTENSIONS:
+        return mx.load(path)
+    return mx.load(path, format="safetensors")
 
 
 class SafetensorsStateDictLoader:
@@ -43,7 +53,7 @@ class SafetensorsStateDictLoader:
 
         model_paths = path if isinstance(path, list) else [path]
         for shard_path in model_paths:
-            weights = mx.load(shard_path)
+            weights = _load_weights(shard_path)
             for name, value in weights.items():
                 expected_name = name if sd_ops is None else sd_ops.apply_to_key(name)
                 if expected_name is None:

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/_base.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/_base.py
@@ -258,6 +258,21 @@ class BasePipeline:
             )
         return self._load_transformer_with_optional_streaming(dev_path)
 
+    @staticmethod
+    def _resolve_safetensors(model_dir: Path, stem: str) -> Path:
+        """Return the path for a (possibly versioned) safetensors file.
+
+        Tries ``{stem}.safetensors`` first (exact match), then globs for
+        ``{stem}-*.safetensors`` (e.g. ``transformer-distilled-1.1.safetensors``).
+        Returns the canonical exact path when nothing matches so callers
+        surface a clear FileNotFoundError.
+        """
+        exact = model_dir / f"{stem}.safetensors"
+        if exact.exists():
+            return exact
+        matches = sorted(model_dir.glob(f"{stem}*.safetensors"))
+        return matches[-1] if matches else exact
+
     def _load_transformer_with_optional_streaming(self, transformer_path: Path) -> LTXModel:
         """Load a transformer from ``transformer_path``; honors ``_pending_loras``.
 
@@ -359,8 +374,7 @@ class BasePipeline:
         if self.dit is None:
             transformer_path = model_dir / "transformer.safetensors"
             if not transformer_path.exists():
-                # Fallback: try transformer-distilled.safetensors (mlx-forge dual-variant layout)
-                transformer_path = model_dir / "transformer-distilled.safetensors"
+                transformer_path = self._resolve_safetensors(model_dir, "transformer-distilled")
 
             self.dit = self._load_transformer_with_optional_streaming(transformer_path)
 

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/_base.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/_base.py
@@ -262,16 +262,17 @@ class BasePipeline:
     def _resolve_safetensors(model_dir: Path, stem: str) -> Path:
         """Return the path for a (possibly versioned) safetensors file.
 
-        Tries ``{stem}.safetensors`` first (exact match), then globs for
-        ``{stem}-*.safetensors`` (e.g. ``transformer-distilled-1.1.safetensors``).
-        Returns the canonical exact path when nothing matches so callers
+        Prefers explicitly versioned files (``{stem}-*.safetensors``, e.g.
+        ``transformer-distilled-1.1.safetensors``) over the unversioned exact
+        name, taking the alphabetically latest when multiple versions exist.
+        Falls back to ``{stem}.safetensors`` when no versioned file is found,
+        and returns the canonical exact path when nothing exists so callers
         surface a clear FileNotFoundError.
         """
-        exact = model_dir / f"{stem}.safetensors"
-        if exact.exists():
-            return exact
-        matches = sorted(model_dir.glob(f"{stem}*.safetensors"))
-        return matches[-1] if matches else exact
+        versioned = sorted(model_dir.glob(f"{stem}-*.safetensors"))
+        if versioned:
+            return versioned[-1]
+        return model_dir / f"{stem}.safetensors"
 
     def _load_transformer_with_optional_streaming(self, transformer_path: Path) -> LTXModel:
         """Load a transformer from ``transformer_path``; honors ``_pending_loras``.

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/_base.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/_base.py
@@ -268,6 +268,11 @@ class BasePipeline:
         Falls back to ``{stem}.safetensors`` when no versioned file is found,
         and returns the canonical exact path when nothing exists so callers
         surface a clear FileNotFoundError.
+
+        Note: selection is lexicographic, not semantic. This is correct for the
+        current single-digit minor scheme (``1.0`` < ``1.1``) but would order
+        ``-1.10`` *below* ``-1.9``. Revisit with a numeric version key if LTX
+        ever ships double-digit minors.
         """
         versioned = sorted(model_dir.glob(f"{stem}-*.safetensors"))
         if versioned:

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/distilled.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/distilled.py
@@ -94,7 +94,7 @@ class DistilledPipeline(TI2VidTwoStagesPipeline):
         if self.dit is None:
             transformer_path = self.model_dir / "transformer.safetensors"
             if not transformer_path.exists():
-                transformer_path = self.model_dir / "transformer-distilled.safetensors"
+                transformer_path = self._resolve_safetensors(self.model_dir, "transformer-distilled")
             self.dit = self._load_transformer_with_optional_streaming(transformer_path)
 
         self._load_vae_encoder()

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ic_lora.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ic_lora.py
@@ -109,7 +109,7 @@ class ICLoraPipeline(BasePipeline):
         if self.dit is None:
             transformer_path = model_dir / "transformer.safetensors"
             if not transformer_path.exists():
-                transformer_path = model_dir / "transformer-distilled.safetensors"
+                transformer_path = self._resolve_safetensors(model_dir, "transformer-distilled")
             self.dit = self._load_transformer_with_optional_streaming(transformer_path)
 
         # VAE encoder (for encoding control videos and I2V images)
@@ -210,7 +210,7 @@ class ICLoraPipeline(BasePipeline):
 
         transformer_path = self.model_dir / "transformer.safetensors"
         if not transformer_path.exists():
-            transformer_path = self.model_dir / "transformer-distilled.safetensors"
+            transformer_path = self._resolve_safetensors(self.model_dir, "transformer-distilled")
         self.dit = self._load_transformer_with_optional_streaming(transformer_path)
         logger.info("Reloaded clean transformer for Stage 2")
 

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ti2vid_two_stages.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ti2vid_two_stages.py
@@ -223,13 +223,19 @@ class TI2VidTwoStagesPipeline(BasePipeline):
         object.__setattr__(self.dit, "_lora_sources", existing)
         aggressive_cleanup()
 
-    def _load_upsampler(self, name: str = "spatial_upscaler_x2_v1_1") -> None:
+    def _load_upsampler(self) -> None:
         """Load upsampler from config and weights."""
         import json
 
-        config_path = self.model_dir / f"{name}_config.json"
-        weights_path = self.model_dir / f"{name}.safetensors"
+        # Try new v1.1+ naming, then old naming
+        weights_path = self.model_dir / "spatial_upscaler_x2_v1_1.safetensors"
+        for stem in ["ltx-2.3-spatial-upscaler-x2", "spatial_upscaler_x2_v1_1"]:
+            resolved = self._resolve_safetensors(self.model_dir, stem)
+            if resolved.exists():
+                weights_path = resolved
+                break
 
+        config_path = self.model_dir / f"{weights_path.stem}_config.json"
         if config_path.exists():
             config = json.loads(config_path.read_text()).get("config", {})
             self.upsampler = LatentUpsampler.from_config(config)
@@ -237,8 +243,12 @@ class TI2VidTwoStagesPipeline(BasePipeline):
             self.upsampler = LatentUpsampler()
 
         if weights_path.exists():
-            weights = load_split_safetensors(weights_path, prefix=f"{name}.")
-            self.upsampler.load_weights(list(weights.items()))
+            raw = load_split_safetensors(weights_path)
+            # Old format keys are prefixed with the stem; new format uses bare keys.
+            stem_prefix = weights_path.stem + "."
+            if raw and all(k.startswith(stem_prefix) for k in raw):
+                raw = {k[len(stem_prefix) :]: v for k, v in raw.items()}
+            self.upsampler.load_weights(list(raw.items()))
         aggressive_cleanup()
 
     def load(self) -> None:

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ti2vid_two_stages.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ti2vid_two_stages.py
@@ -11,6 +11,8 @@ Ported from ltx-pipelines/src/ltx_pipelines/ti2vid_two_stages.py
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import mlx.core as mx
 from mlx_arsenal.diffusion import TeaCacheController
 
@@ -140,7 +142,8 @@ class TI2VidTwoStagesPipeline(BasePipeline):
             self._swap_to_distilled_streamer()
             return
 
-        lora_path = self.model_dir / self._distilled_lora
+        lora_stem = Path(self._distilled_lora).stem
+        lora_path = self._resolve_safetensors(self.model_dir, lora_stem)
         if not lora_path.exists():
             raise FileNotFoundError(
                 f"Distilled LoRA not found: {lora_path}\n"
@@ -186,10 +189,11 @@ class TI2VidTwoStagesPipeline(BasePipeline):
         from ltx_core_mlx.loader.sd_ops import LTXV_LORA_COMFY_RENAMING_MAP
 
         if abs(self._distilled_lora_strength - 1.0) <= 1e-6:
-            distilled_path = self.model_dir / "transformer-distilled.safetensors"
+            distilled_path = self._resolve_safetensors(self.model_dir, "transformer-distilled")
             if not distilled_path.exists():
                 raise FileNotFoundError(
-                    f"Pre-fused distilled transformer not found at {distilled_path}. "
+                    f"Pre-fused distilled transformer not found in {self.model_dir} "
+                    "(expected transformer-distilled*.safetensors). "
                     "low_ram_streaming for two-stage at LoRA strength 1.0 requires "
                     "the distilled file. Use: --model dgrauet/ltx-2.3-mlx-q8"
                 )

--- a/packages/ltx-trainer/src/ltx_trainer_mlx/model_loader.py
+++ b/packages/ltx-trainer/src/ltx_trainer_mlx/model_loader.py
@@ -67,16 +67,19 @@ def load_transformer(
     if transformer_file is not None:
         tf_path = model_dir / transformer_file
     else:
-        # Auto-detect transformer file
-        for candidate in [
-            "transformer.safetensors",
-            "transformer-distilled.safetensors",
-            "transformer-dev.safetensors",
-        ]:
-            tf_path = model_dir / candidate
-            if tf_path.exists():
+        # Auto-detect transformer file, supporting versioned names (e.g. *-1.1.safetensors)
+        tf_path = None
+        for stem in ["transformer", "transformer-distilled", "transformer-dev"]:
+            exact = model_dir / f"{stem}.safetensors"
+            if exact.exists():
+                tf_path = exact
                 break
-        else:
+            if stem != "transformer":  # bare 'transformer*' glob is too broad
+                versioned = sorted(model_dir.glob(f"{stem}*.safetensors"))
+                if versioned:
+                    tf_path = versioned[-1]
+                    break
+        if tf_path is None:
             raise FileNotFoundError(f"No transformer safetensors found in {model_dir}")
 
     logger.info("Loading transformer from %s", tf_path.name)

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,5 +1,7 @@
 """Tests for the loader module: sd_ops, primitives, and fuse_loras."""
 
+from pathlib import Path
+
 import mlx.core as mx
 
 from ltx_core_mlx.loader.fuse_loras import _fuse_delta_with_float, _prepare_deltas, apply_loras
@@ -216,3 +218,45 @@ class TestApplyLoras:
         # scales and biases should not appear as standalone entries
         # (they're handled with their weight key)
         assert "layer.weight" in result.sd
+
+
+# ---------------------------------------------------------------------------
+# _load_weights — extensionless HF cache blob fallback
+# ---------------------------------------------------------------------------
+class TestLoadWeights:
+    """Unit tests for sft_loader._load_weights."""
+
+    def test_loads_extensionless_blob(self, tmp_path: Path) -> None:
+        """An extensionless safetensors blob (HF GUID cache file) loads via explicit format.
+
+        ``mx.load`` cannot infer the format without a known suffix, so the
+        fallback must pass ``format="safetensors"``. Covers the bf16/uint32
+        dtype mix the numpy backend would choke on.
+        """
+        from ltx_core_mlx.loader.sft_loader import _load_weights
+
+        named = tmp_path / "x.safetensors"
+        mx.save_safetensors(
+            str(named),
+            {"w": mx.array([1.5, 2.5], dtype=mx.bfloat16), "q": mx.array([1, 2, 3], dtype=mx.uint32)},
+        )
+        blob = tmp_path / "9f8e7d6c5b4a"  # GUID-like, no extension
+        named.rename(blob)
+
+        weights = _load_weights(str(blob))
+
+        assert set(weights) == {"w", "q"}
+        assert weights["w"].dtype == mx.bfloat16
+        assert mx.allclose(weights["w"], mx.array([1.5, 2.5], dtype=mx.bfloat16)).item()
+
+    def test_known_extension_uses_plain_load(self, tmp_path: Path) -> None:
+        """A normal ``.safetensors`` path still loads via the inferring branch."""
+        from ltx_core_mlx.loader.sft_loader import _load_weights
+
+        path = tmp_path / "x.safetensors"
+        mx.save_safetensors(str(path), {"w": mx.array([1.0, 2.0], dtype=mx.float32)})
+
+        weights = _load_weights(str(path))
+
+        assert list(weights) == ["w"]
+        assert mx.allclose(weights["w"], mx.array([1.0, 2.0])).item()

--- a/tests/test_trainer_core.py
+++ b/tests/test_trainer_core.py
@@ -173,14 +173,14 @@ class TestModelLoaderAutoDetect:
 
     def _auto_detect(self, model_dir: Path) -> Path:
         """Run the same auto-detect logic as load_transformer without loading weights."""
-        for candidate in [
-            "transformer.safetensors",
-            "transformer-distilled.safetensors",
-            "transformer-dev.safetensors",
-        ]:
-            tf_path = model_dir / candidate
-            if tf_path.exists():
-                return tf_path
+        for stem in ["transformer", "transformer-distilled", "transformer-dev"]:
+            exact = model_dir / f"{stem}.safetensors"
+            if exact.exists():
+                return exact
+            if stem != "transformer":
+                versioned = sorted(model_dir.glob(f"{stem}*.safetensors"))
+                if versioned:
+                    return versioned[-1]
         raise FileNotFoundError(f"No transformer safetensors found in {model_dir}")
 
     def test_finds_transformer(self, tmp_path: Path) -> None:

--- a/tests/test_two_stage.py
+++ b/tests/test_two_stage.py
@@ -312,27 +312,28 @@ class TestResolveSafetensors:
 
     def _resolve(self, model_dir: Path, stem: str) -> Path:
         from ltx_pipelines_mlx._base import BasePipeline
+
         return BasePipeline._resolve_safetensors(model_dir, stem)
 
-    def test_exact_exists(self, tmp_path: Path) -> None:
-        """Returns exact path when unversioned file is present."""
+    def test_exact_only(self, tmp_path: Path) -> None:
+        """Falls back to exact path when no versioned file exists."""
         (tmp_path / "transformer-distilled.safetensors").touch()
         result = self._resolve(tmp_path, "transformer-distilled")
         assert result.name == "transformer-distilled.safetensors"
 
-    def test_versioned_fallback(self, tmp_path: Path) -> None:
-        """Falls back to versioned file when exact name is absent."""
+    def test_versioned_preferred(self, tmp_path: Path) -> None:
+        """Versioned file is returned when present."""
         (tmp_path / "transformer-distilled-1.1.safetensors").touch()
         result = self._resolve(tmp_path, "transformer-distilled")
         assert result.name == "transformer-distilled-1.1.safetensors"
         assert result.exists()
 
-    def test_exact_beats_versioned(self, tmp_path: Path) -> None:
-        """Exact match wins when both exact and versioned files exist."""
+    def test_versioned_beats_exact(self, tmp_path: Path) -> None:
+        """Versioned wins over unversioned when both exist."""
         (tmp_path / "transformer-distilled.safetensors").touch()
         (tmp_path / "transformer-distilled-1.1.safetensors").touch()
         result = self._resolve(tmp_path, "transformer-distilled")
-        assert result.name == "transformer-distilled.safetensors"
+        assert result.name == "transformer-distilled-1.1.safetensors"
 
     def test_latest_version_selected(self, tmp_path: Path) -> None:
         """When multiple versioned files exist, the alphabetically last is returned."""

--- a/tests/test_two_stage.py
+++ b/tests/test_two_stage.py
@@ -4,6 +4,8 @@ Tests the denorm/renorm roundtrip, res2s with guidance, and pipeline
 instantiation — all without requiring model weights.
 """
 
+from pathlib import Path
+
 import mlx.core as mx
 
 from ltx_core_mlx.model.video_vae.video_vae import EncoderPerChannelStatistics, VideoEncoder
@@ -300,3 +302,55 @@ class TestStage2Dims:
 
         H_full_correct = H_half * 2
         assert H_full_correct == H_target
+
+
+# ---------------------------------------------------------------------------
+# BasePipeline._resolve_safetensors
+# ---------------------------------------------------------------------------
+class TestResolveSafetensors:
+    """Unit tests for BasePipeline._resolve_safetensors."""
+
+    def _resolve(self, model_dir: Path, stem: str) -> Path:
+        from ltx_pipelines_mlx._base import BasePipeline
+        return BasePipeline._resolve_safetensors(model_dir, stem)
+
+    def test_exact_exists(self, tmp_path: Path) -> None:
+        """Returns exact path when unversioned file is present."""
+        (tmp_path / "transformer-distilled.safetensors").touch()
+        result = self._resolve(tmp_path, "transformer-distilled")
+        assert result.name == "transformer-distilled.safetensors"
+
+    def test_versioned_fallback(self, tmp_path: Path) -> None:
+        """Falls back to versioned file when exact name is absent."""
+        (tmp_path / "transformer-distilled-1.1.safetensors").touch()
+        result = self._resolve(tmp_path, "transformer-distilled")
+        assert result.name == "transformer-distilled-1.1.safetensors"
+        assert result.exists()
+
+    def test_exact_beats_versioned(self, tmp_path: Path) -> None:
+        """Exact match wins when both exact and versioned files exist."""
+        (tmp_path / "transformer-distilled.safetensors").touch()
+        (tmp_path / "transformer-distilled-1.1.safetensors").touch()
+        result = self._resolve(tmp_path, "transformer-distilled")
+        assert result.name == "transformer-distilled.safetensors"
+
+    def test_latest_version_selected(self, tmp_path: Path) -> None:
+        """When multiple versioned files exist, the alphabetically last is returned."""
+        (tmp_path / "transformer-distilled-1.0.safetensors").touch()
+        (tmp_path / "transformer-distilled-1.1.safetensors").touch()
+        result = self._resolve(tmp_path, "transformer-distilled")
+        assert result.name == "transformer-distilled-1.1.safetensors"
+
+    def test_no_match_returns_canonical(self, tmp_path: Path) -> None:
+        """Returns the canonical (exact) path when nothing exists, for clear error messages."""
+        result = self._resolve(tmp_path, "transformer-distilled")
+        assert result.name == "transformer-distilled.safetensors"
+        assert not result.exists()
+
+    def test_lora_versioned_fallback(self, tmp_path: Path) -> None:
+        """Works for LoRA stems too."""
+        stem = "ltx-2.3-22b-distilled-lora-384"
+        (tmp_path / f"{stem}-1.1.safetensors").touch()
+        result = self._resolve(tmp_path, stem)
+        assert result.name == f"{stem}-1.1.safetensors"
+        assert result.exists()

--- a/uv.lock
+++ b/uv.lock
@@ -427,7 +427,7 @@ wheels = [
 
 [[package]]
 name = "ltx-2-mlx"
-version = "0.14.7"
+version = "0.14.8"
 source = { virtual = "." }
 dependencies = [
     { name = "ltx-core-mlx" },
@@ -467,7 +467,7 @@ provides-extras = ["trainer", "dev", "all"]
 
 [[package]]
 name = "ltx-core-mlx"
-version = "0.14.7"
+version = "0.14.8"
 source = { editable = "packages/ltx-core-mlx" }
 dependencies = [
     { name = "huggingface-hub" },
@@ -490,7 +490,7 @@ requires-dist = [
 
 [[package]]
 name = "ltx-pipelines-mlx"
-version = "0.14.7"
+version = "0.14.8"
 source = { editable = "packages/ltx-pipelines-mlx" }
 dependencies = [
     { name = "ltx-core-mlx" },
@@ -509,7 +509,7 @@ requires-dist = [
 
 [[package]]
 name = "ltx-trainer-mlx"
-version = "0.14.7"
+version = "0.14.8"
 source = { editable = "packages/ltx-trainer" }
 dependencies = [
     { name = "ltx-core-mlx" },


### PR DESCRIPTION
LTX2.3 Model dirs contain versioned filenames (e.g.
transformer-distilled-1.1.safetensors). This PR makes the loader
handle them correctly end-to-end:

- Dynamic resolution for LoRAs and transformers — picks the
  alphabetically latest versioned file when present, no hardcoded names
- Upscaler file naming and key prefix fixes
- Versioned safetensors now win over unversioned when both exist in the
  same model dir (previously the unversioned exact name took priority,
  silently loading the older file)
- If a user only had the newer file, to safe disk space, the pipeline would fail hard due to the hardcoded naming
- Weight loader falls back to safe_open for extensionless HF cache
  blobs, which mx.load can't parse without a known extension