### PR TITLE
fix(audio_vae): work around mlx 0.31.2 Metal strided-scatter bug (silent audio)

### DIFF
--- a/packages/ltx-core-mlx/src/ltx_core_mlx/model/audio_vae/bwe.py
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/model/audio_vae/bwe.py
@@ -91,8 +91,10 @@ class HannSincResampler:
         # 2. Zero-insert between samples (conv_transpose1d style):
         #    output length = (T_padded - 1) * ratio + 1
         zi_len = (T_padded - 1) * ratio + 1
+        # NOTE: strided slice assignment, NOT .at[].add() — same mlx 0.31.2
+        # Metal scatter bug as in vocoder.UpSample1d (see issue #34).
         upsampled = mx.zeros((B, zi_len))
-        upsampled = upsampled.at[:, ::ratio].add(x_padded)
+        upsampled[:, ::ratio] = x_padded
 
         # 3. Full convolution via zero-pad + valid conv1d
         #    Full conv output = zi_len + K - 1

--- a/packages/ltx-core-mlx/src/ltx_core_mlx/model/audio_vae/vocoder.py
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/model/audio_vae/vocoder.py
@@ -121,8 +121,13 @@ class UpSample1d(nn.Module):
         """x: (B, T, C) -> (B, T*2, C)"""
         B, T, C = x.shape
         # Insert zeros between samples: (B, T, C) -> (B, T*2, C)
+        # NOTE: strided slice assignment, NOT .at[].add() — the Metal scatter
+        # kernel mis-indexes strided .at[].add() in mlx 0.31.2
+        # (ml-explore/mlx#3477, fix #3483 merged but unreleased), collapsing
+        # audio to ≈-50 dB noise. Destination rows are freshly zeroed, so
+        # assignment is equivalent. See issue #34.
         x_up = mx.zeros((B, T * 2, C))
-        x_up = x_up.at[:, ::2, :].add(x)
+        x_up[:, ::2, :] = x
 
         # Reshape for grouped conv1d: (B*C, T*2, 1)
         x_up = x_up.transpose(0, 2, 1).reshape(B * C, T * 2, 1)

--- a/tests/test_audio_vocoder_regression.py
+++ b/tests/test_audio_vocoder_regression.py
@@ -1,0 +1,92 @@
+"""Non-regression tests for the mlx 0.31.2 Metal strided-scatter bug.
+
+mlx 0.31.2 shipped a Metal scatter kernel (ml-explore/mlx#3266) that
+mis-indexes the source of strided ``.at[].add()`` updates
+(``y[2k] <- x[2k]`` instead of ``y[2k] <- x[k]``; CPU is unaffected,
+small shapes are unaffected). This silently collapsed the BigVGAN
+vocoder output to ~-50 dB noise via the zero-insert in
+``UpSample1d`` / ``HannSincResampler``. Fixed upstream by
+ml-explore/mlx#3483 (unreleased as of 2026-06). See issue #34.
+
+Run with: pytest tests/test_audio_vocoder_regression.py -v
+"""
+
+from __future__ import annotations
+
+import math
+
+import mlx.core as mx
+import numpy as np
+import pytest
+
+from tests.conftest import MODEL_DIR
+
+skip_no_weights = pytest.mark.skipif(MODEL_DIR is None, reason="q8 weights not found")
+
+
+def test_mlx_strided_scatter_add_canary():
+    """Framework canary: strided ``.at[].add()`` must match NumPy semantics.
+
+    Broken on the Metal (GPU) stream in mlx 0.31.2 — 872/2048 wrong
+    elements for this shape. Passes on 0.31.1 and on mlx main. If this
+    test fails, the installed mlx release mis-executes strided
+    scatter-adds and audio output cannot be trusted.
+    """
+    B, T, C = 2, 64, 8
+    x = (mx.arange(B * T * C, dtype=mx.float32).reshape(B, T, C) % 7 - 3) / 3.0
+    y = mx.zeros((B, T * 2, C)).at[:, ::2, :].add(x)
+    mx.eval(y)
+
+    expected = np.zeros((B, T * 2, C), dtype=np.float32)
+    expected[:, ::2, :] = np.array(x)
+    wrong = int((np.array(y) != expected).sum())
+    assert wrong == 0, (
+        f"strided .at[].add() mis-indexed {wrong} elements — known mlx 0.31.2 "
+        "Metal bug (ml-explore/mlx#3477); upgrade/downgrade mlx. The vocoder "
+        "itself is guarded by slice assignment, see issue #34."
+    )
+
+
+def test_strided_zero_insert_assignment_matches_add_semantics():
+    """The workaround (slice assignment into zeros) equals the intended add.
+
+    Guards the patched zero-insert pattern in ``UpSample1d`` and
+    ``HannSincResampler`` against semantic drift, independent of weights.
+    """
+    for B, T, C, stride in [(2, 64, 8, 2), (1, 269, 24, 2), (16, 887, 1, 3)]:
+        x = mx.random.normal((B, T, C))
+        out_len = T * stride if stride == 2 else (T - 1) * stride + 1
+        y = mx.zeros((B, out_len, C))
+        y[:, ::stride, :] = x[:, : (out_len + stride - 1) // stride, :]
+        mx.eval(y)
+
+        yn = np.array(y)
+        expected = np.zeros((B, out_len, C), dtype=np.float32)
+        expected[:, ::stride, :] = np.array(x)[:, : (out_len + stride - 1) // stride, :]
+        np.testing.assert_array_equal(yn, expected)
+
+
+@skip_no_weights
+def test_vocoder_rms_floor():
+    """BigVGAN vocoder output must not collapse to noise.
+
+    On a fixed random mel, a healthy vocoder produces ≈ -14 dB RMS;
+    the mlx 0.31.2 strided-scatter bug produced ≈ -51 dB. The -30 dB
+    floor separates the two regimes with wide margin. This is the test
+    that would have caught the silent-audio regression immediately.
+    """
+    from ltx_pipelines_mlx.utils.blocks import AudioDecoder
+
+    _, vocoder = AudioDecoder(MODEL_DIR).load()
+
+    mx.random.seed(456)
+    mel = (mx.random.normal((1, 2, 269, 64)) * 0.5).astype(mx.bfloat16)
+    wav = vocoder(mel)
+    mx.eval(wav)
+
+    w = wav.astype(mx.float32)
+    rms_db = 20 * math.log10(max(float(mx.sqrt(mx.mean(w * w))), 1e-12))
+    assert rms_db > -30.0, (
+        f"vocoder output collapsed to noise: RMS = {rms_db:.1f} dB "
+        "(healthy ≈ -14 dB; mlx 0.31.2 strided-scatter bug ≈ -51 dB — see issue #34)"
+    )


### PR DESCRIPTION
## Summary

Workaround for the **mlx 0.31.2 Metal strided-scatter regression** that silently collapsed all generated audio to ≈ −50 dB noise. Full investigation, bisection and decision record in #34.

- `UpSample1d` (vocoder.py) and `HannSincResampler` (bwe.py): replace strided `.at[].add()` zero-insert with strided **slice assignment** — destinations are freshly zeroed, so the operation is semantically identical, and it avoids the broken Metal kernel entirely.
- Add `tests/test_audio_vocoder_regression.py` (3 tests, incl. the RMS-floor test that would have caught the regression immediately).

## Root cause (upstream)

mlx 0.31.2's Metal scatter kernel (from ml-explore/mlx#3266) mis-indexes the source of strided `.at[].add()`: `y[2k] ← x[2k]` instead of `y[2k] ← x[k]`. CPU unaffected, small shapes unaffected. Already fixed upstream by ml-explore/mlx#3483 (merged 2026-05-07, **not in any release** — latest is 0.31.2). Also reported as ml-explore/mlx#3477.

## Validation

| Check | mlx 0.31.1 | mlx 0.31.2 | mlx main (0.32.0.dev) |
|---|---|---|---|
| `.at[strided].add()` on Metal | ✅ correct | ❌ broken | ✅ correct |
| `test_vocoder_rms_floor` pre-patch | ✅ −13.7 dB | ❌ **−50.7 dB** | — |
| `test_vocoder_rms_floor` post-patch | ✅ −13.7 dB | ✅ **−13.7 dB** | — |
| Numeric neutrality (fixed-mel output pre/post patch, 0.31.1) | ✅ identical (RMS −13.7 dB, absmax 0.9180, sum −426.564) | — | — |

- `pytest tests/test_audio_vocoder_regression.py`: 3/3 pass on 0.31.1; on 0.31.2 the vocoder + semantics tests pass and only the framework canary fails (by design — it flags the broken mlx release).
- ruff check + format clean; intendant audit unchanged (93, pre-existing LO001 only).

## Notes / open points (from #34)

- No `mlx!=0.31.2` constraint added in this PR — debatable, see #34 challenge points.
- The canary test intentionally fails on mlx 0.31.2 environments; if CI runs on 0.31.2 it will be red until mlx ships the fix (or the canary gets an xfail-on-0.31.2 marker — reviewer's call).

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)
