### PR TITLE
fix: fail loud when spatial upsampler weights are missing

### DIFF
--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ti2vid_two_stages.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ti2vid_two_stages.py
@@ -224,7 +224,16 @@ class TI2VidTwoStagesPipeline(BasePipeline):
         aggressive_cleanup()
 
     def _load_upsampler(self) -> None:
-        """Load upsampler from config and weights."""
+        """Load the spatial upsampler from config and weights.
+
+        Raises:
+            FileNotFoundError: when no upsampler weights file is present in the
+                model dir. Stage 2 upscales the latent through this module
+                unconditionally; with a randomly-initialised ``LatentUpsampler``
+                the output decodes into a periodic pixel-shuffle grid ("mosaic")
+                with no other error. A missing file must therefore fail loud
+                rather than silently degrade.
+        """
         import json
 
         # Try new v1.1+ naming, then old naming
@@ -235,6 +244,18 @@ class TI2VidTwoStagesPipeline(BasePipeline):
                 weights_path = resolved
                 break
 
+        if not weights_path.exists():
+            raise FileNotFoundError(
+                f"Spatial upsampler weights not found in {self.model_dir} "
+                "(looked for spatial_upscaler_x2_v1_1.safetensors and "
+                "ltx-2.3-spatial-upscaler-x2*.safetensors). The two-stage and "
+                "distilled pipelines require it for stage-2 upscaling; without "
+                "it the latent is upscaled by an untrained module and the "
+                "output degrades into a periodic 'mosaic' grid. Download it, "
+                "e.g.: hf download dgrauet/ltx-2.3-mlx-q8 "
+                f"spatial_upscaler_x2_v1_1.safetensors --local-dir {self.model_dir}"
+            )
+
         config_path = self.model_dir / f"{weights_path.stem}_config.json"
         if config_path.exists():
             config = json.loads(config_path.read_text()).get("config", {})
@@ -242,13 +263,12 @@ class TI2VidTwoStagesPipeline(BasePipeline):
         else:
             self.upsampler = LatentUpsampler()
 
-        if weights_path.exists():
-            raw = load_split_safetensors(weights_path)
-            # Old format keys are prefixed with the stem; new format uses bare keys.
-            stem_prefix = weights_path.stem + "."
-            if raw and all(k.startswith(stem_prefix) for k in raw):
-                raw = {k[len(stem_prefix) :]: v for k, v in raw.items()}
-            self.upsampler.load_weights(list(raw.items()))
+        raw = load_split_safetensors(weights_path)
+        # Old format keys are prefixed with the stem; new format uses bare keys.
+        stem_prefix = weights_path.stem + "."
+        if raw and all(k.startswith(stem_prefix) for k in raw):
+            raw = {k[len(stem_prefix) :]: v for k, v in raw.items()}
+        self.upsampler.load_weights(list(raw.items()))
         aggressive_cleanup()
 
     def load(self) -> None:

--- a/tests/test_two_stage.py
+++ b/tests/test_two_stage.py
@@ -7,6 +7,7 @@ instantiation — all without requiring model weights.
 from pathlib import Path
 
 import mlx.core as mx
+import pytest
 
 from ltx_core_mlx.model.video_vae.video_vae import EncoderPerChannelStatistics, VideoEncoder
 
@@ -270,6 +271,36 @@ class TestTwoStagePipelineInstantiation:
         from ltx_pipelines_mlx.ti2vid_two_stages import TI2VidTwoStagesPipeline
 
         assert issubclass(KeyframeInterpolationPipeline, TI2VidTwoStagesPipeline)
+
+
+# ---------------------------------------------------------------------------
+# Upsampler weights must be present — silent fallback is forbidden
+# ---------------------------------------------------------------------------
+class TestUpsamplerMissingWeights:
+    """Regression: a missing spatial upscaler must fail loud, not run untrained.
+
+    When ``spatial_upscaler_x2_v1_1.safetensors`` was absent from the model
+    dir, ``_load_upsampler`` silently kept a randomly-initialised
+    ``LatentUpsampler`` (no ``load_weights`` call). Stage 2 then ran the latent
+    through an untrained Conv3d + pixel-shuffle, decoding into a periodic grid
+    ("mosaic") with no error or warning. The loader must raise instead.
+    """
+
+    def test_missing_weights_raises_filenotfound(self, tmp_path):
+        from ltx_pipelines_mlx.ti2vid_two_stages import TI2VidTwoStagesPipeline
+
+        model_dir = tmp_path / "fake_model"
+        model_dir.mkdir()
+        pipe = TI2VidTwoStagesPipeline(model_dir=str(model_dir), low_memory=True)
+        assert pipe.upsampler is None
+
+        with pytest.raises(FileNotFoundError) as exc:
+            pipe._load_upsampler()
+
+        # The message must name the missing file so the user knows what to fetch.
+        assert "spatial_upscaler_x2_v1_1" in str(exc.value)
+        # And no untrained upsampler may be left behind for stage 2 to use.
+        assert pipe.upsampler is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

When `spatial_upscaler_x2_v1_1.safetensors` is **absent** from the model dir, `_load_upsampler` instantiated a `LatentUpsampler` but only called `load_weights` inside `if weights_path.exists():` — silently keeping a **randomly-initialised** module. The two-stage and distilled pipelines upscale the stage-1 latent through this module **unconditionally** (`distilled.py:237`), so an untrained upsampler decodes into a periodic pixel-shuffle grid (**"mosaic"**) with no error or warning.

Observed in the wild on a **q4** model dir that never had the upscaler downloaded (the upscaler is variant-independent and was only fetched into the q8 dir). The run completed cleanly — no crash, no Metal error — making it look like a model-quality issue rather than a missing-file issue.

### Symptom vs. fixed (same seed, q4 distilled)

The whole clip was a regular tessellation of iridescent motifs over a flat field with a central vignette (the only surviving RoPE/positional structure). With the weights present, the same seed produces a coherent frame.

## Fix

Raise a clear `FileNotFoundError` — naming the missing file and the `hf download …` command to fetch it — **before** constructing the upsampler, instead of degrading silently. Mirrors the project's "no silent failures" principle (cf. the LoRA / I2V silent-drop fixes). Covers all six callers: two-stage, HQ, distilled, keyframe, a2v.

## Test

`TestUpsamplerMissingWeights::test_missing_weights_raises_filenotfound` — RED (`DID NOT RAISE FileNotFoundError`) before the fix, GREEN after. Asserts the raise, the message content, and that no untrained upsampler is left behind.

```
41 passed (test_two_stage, test_upsampler_shapes, test_block_streaming, test_modality_tiling)
ruff: All checks passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)