### PR TITLE
feat: audio LoRA training — preprocessing, slicer, and gradient checkpointing

### DIFF
--- a/packages/ltx-core-mlx/src/ltx_core_mlx/model/transformer/model.py
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/model/transformer/model.py
@@ -219,6 +219,11 @@ class LTXModel(nn.Module):
             for _ in range(config.num_layers)
         ]
 
+        # Training-only: recompute each block in the backward pass instead of
+        # storing all 48 blocks' activations. Caps activation memory at ~1 block
+        # so backprop through the dev model fits on 64 GB. No effect on inference.
+        self.gradient_checkpointing = False
+
     def _embed_timestep_scalar(
         self,
         timestep: mx.array,
@@ -473,6 +478,46 @@ class LTXModel(nn.Module):
             num_layers = self.config.num_layers if block_provider is not None else len(self.transformer_blocks)
             for block_idx in range(num_layers):
                 block = block_provider(block_idx) if block_provider is not None else self.transformer_blocks[block_idx]
+
+                if self.gradient_checkpointing:
+                    # Recompute this block in the backward pass to cap activation
+                    # memory. The block's trainable params MUST be passed as an
+                    # explicit mx.checkpoint input (and rebound via update inside),
+                    # otherwise mx.checkpoint — which only tracks gradients w.r.t.
+                    # its inputs — gives the LoRA params zero gradient (they stay
+                    # at init and the adapter is a no-op). Pattern from mlx_lm's
+                    # tuner.trainer.grad_checkpoint. Conditioning is captured as
+                    # constants; mx.eval guards are skipped (illegal under autodiff).
+                    def _run_block(params, vh, ah, _block=block, _bidx=block_idx):
+                        _block.update(params)
+                        return _block(
+                            video_hidden=vh,
+                            audio_hidden=ah,
+                            video_adaln_params=video_adaln_emb,
+                            audio_adaln_params=audio_adaln_emb,
+                            video_prompt_adaln_params=video_prompt_emb,
+                            audio_prompt_adaln_params=audio_prompt_emb,
+                            av_ca_video_params=av_ca_video_emb,
+                            av_ca_audio_params=av_ca_audio_emb,
+                            av_ca_a2v_gate_params=av_ca_a2v_gate_emb,
+                            av_ca_v2a_gate_params=av_ca_v2a_gate_emb,
+                            video_text_embeds=video_text_embeds,
+                            audio_text_embeds=audio_text_embeds,
+                            video_rope_freqs=video_rope_freqs,
+                            audio_rope_freqs=audio_rope_freqs,
+                            video_cross_rope_freqs=video_cross_rope_freqs,
+                            audio_cross_rope_freqs=audio_cross_rope_freqs,
+                            video_attention_mask=video_attention_mask,
+                            audio_attention_mask=audio_attention_mask,
+                            perturbations=perturbations,
+                            block_idx=_bidx,
+                        )
+
+                    video_hidden, audio_hidden = mx.checkpoint(_run_block)(
+                        block.trainable_parameters(), video_hidden, audio_hidden
+                    )
+                    continue
+
                 video_hidden, audio_hidden = block(
                     video_hidden=video_hidden,
                     audio_hidden=audio_hidden,

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/cli.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/cli.py
@@ -489,6 +489,11 @@ examples:
     # --- train ---
     trn = sub.add_parser("train", help="Train a LoRA or full model (requires ltx-trainer-mlx)")
     trn.add_argument("--config", "-c", required=True, help="Path to training config YAML file")
+    trn.add_argument(
+        "--low-ram",
+        action="store_true",
+        help="Enable gradient checkpointing (recompute blocks in backward) to fit the dev model on 64 GB",
+    )
 
     # --- preprocess ---
     pre = sub.add_parser("preprocess", help="Preprocess videos into latents + conditions for training")
@@ -505,6 +510,48 @@ examples:
     )
     pre.add_argument("--captions", default=None, help="Directory with .txt caption files (same stems as videos)")
     pre.add_argument("--caption-ext", default=".txt", help="Caption file extension (default: .txt)")
+    pre.add_argument(
+        "--with-audio",
+        action="store_true",
+        help="Also encode each clip's audio into audio_latents/ for joint audio-video training",
+    )
+    pre.add_argument(
+        "--frame-rate",
+        type=float,
+        default=None,
+        help="Override fps written into latents + used to size audio tokens (default: probed per clip)",
+    )
+
+    # --- slice ---
+    slc = sub.add_parser("slice", help="Slice long videos into normalized training clips (audio retained)")
+    slc.add_argument("sources", nargs="+", help="Video files or directories to slice")
+    slc.add_argument("--output", "-o", required=True, help="Root output directory (one subfolder per source)")
+    slc.add_argument("--interval", type=float, default=4.0, help="Clip length in seconds (default: 4.0)")
+    slc.add_argument("--timecodes", default=None, help="Optional start,end timecode list file (overrides --interval)")
+    slc.add_argument("--res", default="384x384", help="Target resolution WxH, both divisible by 32 (default: 384x384)")
+    slc.add_argument("--fps", type=float, default=24.0, help="Output frame rate (default: 24.0)")
+    slc.add_argument(
+        "--fit",
+        choices=["crop", "pad"],
+        default="crop",
+        help="Aspect handling: crop=center-crop (default), pad=letterbox",
+    )
+    slc.add_argument("--min-length", type=float, default=2.0, help="Drop clips shorter than this (default: 2.0s)")
+    slc.add_argument(
+        "--max-clips", type=int, default=None, help="Cap clips per source (build a pool to cull; default: all)"
+    )
+    slc.add_argument(
+        "--sample",
+        choices=["even", "sequential"],
+        default="even",
+        help="When --max-clips is set: even=spread across source (default), sequential=first N",
+    )
+    slc.add_argument("--skip-start", type=float, default=0.0, help="Skip N seconds at the start of each source (intro)")
+    slc.add_argument("--skip-end", type=float, default=0.0, help="Skip N seconds at the end of each source (outro)")
+    slc.add_argument(
+        "--caption-template", default=None, help="If set, write this text to a .txt next to each clip for editing"
+    )
+    slc.add_argument("--crf", type=int, default=18, help="x264 quality, lower = better (default: 18)")
 
     args = parser.parse_args()
 
@@ -531,6 +578,7 @@ examples:
         "info": _cmd_info,
         "train": _cmd_train,
         "preprocess": _cmd_preprocess,
+        "slice": _cmd_slice,
     }
     commands[args.command](args)
 
@@ -1105,8 +1153,17 @@ def _cmd_train(args: argparse.Namespace) -> None:
 
     config = LtxTrainerConfig(**raw_config)
 
+    if getattr(args, "low_ram", False):
+        # Gradient checkpointing: recompute transformer blocks in the backward
+        # pass to cap activation memory (lets the dev model backprop fit on 64 GB).
+        config.optimization.enable_gradient_checkpointing = True
+        print("Low-RAM training: gradient checkpointing enabled.")
+
     trainer = LtxvTrainer(config)
-    saved_path, stats = trainer.train()
+    # When stdout isn't a TTY (nohup / redirect), the rich progress bar suppresses
+    # itself and shows nothing. Disable it so the per-step logger lines fire instead,
+    # giving redirected/background runs a readable loss trace.
+    saved_path, stats = trainer.train(disable_progress_bars=not sys.stdout.isatty())
 
     print("\nTraining complete!")
     print(f"  Weights saved to: {saved_path}")
@@ -1134,6 +1191,35 @@ def _cmd_preprocess(args: argparse.Namespace) -> None:
         max_frames=args.max_frames,
         captions_dir=args.captions,
         caption_ext=args.caption_ext,
+        with_audio=args.with_audio,
+        frame_rate=args.frame_rate,
+    )
+
+
+def _cmd_slice(args: argparse.Namespace) -> None:
+    """Slice long videos into normalized training clips."""
+    try:
+        from ltx_trainer_mlx.slice_clips import slice_videos
+    except ImportError:
+        print("Error: ltx-trainer-mlx is not installed.")
+        print("Install it with: uv pip install -e 'packages/ltx-trainer[all]'")
+        sys.exit(1)
+
+    slice_videos(
+        sources=args.sources,
+        out_dir=args.output,
+        interval=args.interval,
+        timecodes_file=args.timecodes,
+        res=args.res,
+        fps=args.fps,
+        fit=args.fit,
+        min_length=args.min_length,
+        max_clips=args.max_clips,
+        sample=args.sample,
+        skip_start=args.skip_start,
+        skip_end=args.skip_end,
+        caption_template=args.caption_template,
+        crf=args.crf,
     )
 
 

--- a/packages/ltx-trainer/configs/lora_av_whisper.yaml
+++ b/packages/ltx-trainer/configs/lora_av_whisper.yaml
@@ -1,0 +1,101 @@
+# LTX-2 Joint Audio+Video LoRA — whisper / ASMR
+#
+# Trains a LoRA with the AUDIO branch loss enabled (generate_audio: true) to bias
+# the joint model toward soft / breathy / whispering acoustics. LTX-2.3 has no
+# audio-only mode — this is a normal LoRA whose loss also covers the audio tokens.
+#
+# Captioning note: describe the SCENE + how they speak (soft, slow, breathy,
+# whispering, close-mic, ASMR). Do NOT transcribe words — the model learns acoustic
+# character, not intelligible speech.
+#
+# Workflow:
+#   1. Slice long ASMR sources into 384x384, ~4s clips (audio retained):
+#      ltx-2-mlx slice ~/asmr_sources/*.mp4 --interval 4 --fps 24 --res 384x384 \
+#        --caption-template "a person whispering softly into a microphone, intimate ASMR, close-up" \
+#        -o ./whisper_clips
+#      (output goes into per-source subfolders; flatten/collect into one dir of clips
+#       + matching .txt before preprocessing, or point --videos at a single folder)
+#
+#   2. Preprocess (video + text + audio latents):
+#      ltx-2-mlx preprocess --videos ./whisper_clips --captions ./whisper_clips \
+#        --with-audio --height 384 --width 384 --max-frames 97 --frame-rate 24 \
+#        --model dgrauet/ltx-2.3-mlx-q8 -o ./whisper_data
+#
+#   3. Train:
+#      ltx-2-mlx train --config packages/ltx-trainer/configs/lora_av_whisper.yaml
+
+model:
+  # Local path to the model snapshot dir (run `huggingface-cli download dgrauet/ltx-2.3-mlx-q8`
+  # then point this at .../snapshots/<hash>). ~ is expanded.
+  model_path: ~/.cache/huggingface/hub/models--dgrauet--ltx-2.3-mlx-q8/snapshots/latest
+  # Train the LoRA on the non-distilled DEV base (correct target for a style LoRA
+  # used in the dev-based one-stage / two-stage inference pipelines).
+  transformer_file: transformer-dev.safetensors
+  text_encoder_path: mlx-community/gemma-3-12b-it-4bit
+  training_mode: lora
+
+lora:
+  rank: 32
+  alpha: 32
+  dropout: 0.0
+  # Audio-only: target ONLY the attention modules that write to audio_hidden, so
+  # no trainable param touches the video output (video stays identical to base —
+  # no visual fighting). The video loss term is gradient-inert w.r.t. these params,
+  # making this effectively audio-only training without a custom strategy.
+  #   audio_attn1         - audio self-attention
+  #   audio_attn2         - audio <- text cross-attention
+  #   video_to_audio_attn - audio <- video (keeps lip/scene sync; reads video, writes audio)
+  # Deliberately EXCLUDES attn1/attn2 (video self/text) and audio_to_video_attn
+  # (the audio->video leak channel).
+  target_modules:
+    - audio_attn1
+    - audio_attn2
+    - video_to_audio_attn
+
+optimization:
+  learning_rate: 1.5e-4
+  steps: 2000
+  batch_size: 1
+  gradient_accumulation_steps: 1
+  max_grad_norm: 1.0
+  weight_decay: 0.0
+  # ON: checkpointing is mandatory to fit 64 GB (no-ckpt stores all 48 layers'
+  # activations -> 84 GB even at 192). At low res (192, ~432 video tokens) the
+  # per-block recompute is ~4x cheaper than at 384, so checkpointing here is both
+  # memory-safe (~15-20 GB) AND fast (~5-8 s/step expected vs 20 s at 384).
+  enable_gradient_checkpointing: true
+  scheduler_type: linear
+  scheduler_params:
+    start_factor: 1.0
+    end_factor: 0.1
+
+data:
+  # Path to directory created by `ltx-2-mlx preprocess --with-audio`
+  preprocessed_data_root: ./whisper_data
+
+training_strategy:
+  name: text_to_video
+  generate_audio: true   # <-- trains the audio branch
+
+flow_matching:
+  timestep_sampling_mode: shifted_logit_normal
+
+validation:
+  prompts:
+    - 'a blonde woman sitting in a chair close to a microphone, (woman, whispering): "can you hear me? come a little closer, I have something to tell you", intimate ASMR'
+  video_dims: [192, 192, 97]  # width, height, frames (~4s @ 24fps); low res = audio LoRA, video is just context
+  frame_rate: 24.0
+  inference_steps: 8
+  interval: 200   # validation render ~1 min each (the only real time cost beyond training); still an early sample ~step 200. Checkpoints stay every 100.
+  guidance_scale: 4.0
+  stg_scale: 0.0
+  seed: 42
+  generate_audio: true   # render audio in validation mp4s
+  skip_initial_validation: true
+
+checkpoints:
+  interval: 100
+  keep_last_n: 25   # keep all 20 (you have the disk); pick the best afterward (~365 MB each ≈ 7 GB)
+
+seed: 42
+output_dir: ./outputs/lora_av_whisper

--- a/packages/ltx-trainer/configs/lora_av_whisper.yaml
+++ b/packages/ltx-trainer/configs/lora_av_whisper.yaml
@@ -75,7 +75,7 @@ data:
 
 training_strategy:
   name: text_to_video
-  generate_audio: true   # <-- trains the audio branch
+  generate_audio: true # <-- trains the audio branch
 
 flow_matching:
   timestep_sampling_mode: shifted_logit_normal
@@ -83,19 +83,19 @@ flow_matching:
 validation:
   prompts:
     - 'a blonde woman sitting in a chair close to a microphone, (woman, whispering): "can you hear me? come a little closer, I have something to tell you", intimate ASMR'
-  video_dims: [192, 192, 97]  # width, height, frames (~4s @ 24fps); low res = audio LoRA, video is just context
+  video_dims: [192, 192, 97] # width, height, frames (~4s @ 24fps); low res = audio LoRA, video is just context
   frame_rate: 24.0
   inference_steps: 8
-  interval: 200   # validation render ~1 min each (the only real time cost beyond training); still an early sample ~step 200. Checkpoints stay every 100.
+  interval: 200 # validation render ~1 min each (the only real time cost beyond training); still an early sample ~step 200. Checkpoints stay every 100.
   guidance_scale: 4.0
   stg_scale: 0.0
   seed: 42
-  generate_audio: true   # render audio in validation mp4s
+  generate_audio: true # render audio in validation mp4s
   skip_initial_validation: true
 
 checkpoints:
   interval: 100
-  keep_last_n: 25   # keep all 20 (you have the disk); pick the best afterward (~365 MB each ≈ 7 GB)
+  keep_last_n: 20 # keep all 20 (you have the disk); pick the best afterward (~365 MB each ≈ 7 GB)
 
 seed: 42
 output_dir: ./outputs/lora_av_whisper

--- a/packages/ltx-trainer/src/ltx_trainer_mlx/config.py
+++ b/packages/ltx-trainer/src/ltx_trainer_mlx/config.py
@@ -22,6 +22,11 @@ class ModelConfig(ConfigBaseModel):
         description="Model path - local path to safetensors checkpoint file",
     )
 
+    transformer_file: str | None = Field(
+        default=None,
+        description="Explicit transformer safetensors filename (e.g. 'transformer-dev.safetensors'). "
+        "If None, auto-detects (distilled before dev).",
+    )
     text_encoder_path: str | Path | None = Field(
         default=None,
         description="Path to text encoder (required for LTX-2/Gemma models)",
@@ -41,16 +46,20 @@ class ModelConfig(ConfigBaseModel):
     @field_validator("model_path")
     @classmethod
     def validate_model_path(cls, v: str | Path) -> str | Path:
-        """Validate that model_path is an existing local path (not a URL)."""
+        """Validate that model_path is an existing local path (not a URL).
+
+        Expands ``~`` so configs can use home-relative paths.
+        """
         is_url = str(v).startswith(("http://", "https://"))
 
         if is_url:
             raise ValueError(f"Model path cannot be a URL: {v}")
 
-        if not Path(v).exists():
+        expanded = Path(v).expanduser()
+        if not expanded.exists():
             raise ValueError(f"Model path does not exist: {v}")
 
-        return v
+        return str(expanded)
 
 
 class LoraConfig(ConfigBaseModel):

--- a/packages/ltx-trainer/src/ltx_trainer_mlx/model_loader.py
+++ b/packages/ltx-trainer/src/ltx_trainer_mlx/model_loader.py
@@ -18,6 +18,7 @@ from pathlib import Path
 
 from ltx_core_mlx.model.audio_vae.audio_vae import AudioVAEDecoder
 from ltx_core_mlx.model.audio_vae.bwe import VocoderWithBWE
+from ltx_core_mlx.model.audio_vae.encoder import AudioVAEEncoder
 from ltx_core_mlx.model.transformer.model import LTXModel, LTXModelConfig
 from ltx_core_mlx.model.video_vae.video_vae import VideoDecoder, VideoEncoder
 from ltx_core_mlx.text_encoders.gemma.encoders.base_encoder import GemmaLanguageModel
@@ -172,6 +173,37 @@ def load_audio_vae_decoder(
     return model
 
 
+def load_audio_vae_encoder(
+    model_dir: str | Path,
+) -> AudioVAEEncoder:
+    """Load the audio VAE encoder.
+
+    Mirrors :func:`load_audio_vae_decoder`. Used by the preprocessor to turn
+    clip waveforms into audio latents for joint audio-video training.
+
+    Args:
+        model_dir: Directory containing ``audio_vae.safetensors``.
+
+    Returns:
+        Loaded ``AudioVAEEncoder``.
+    """
+    model_dir = Path(model_dir)
+    logger.debug("Loading audio VAE encoder from %s", model_dir)
+
+    model = AudioVAEEncoder()
+    audio_weights = load_split_safetensors(model_dir / "audio_vae.safetensors", prefix="audio_vae.encoder.")
+    # Also load per_channel_statistics (used to normalize the encoder output).
+    all_audio = load_split_safetensors(model_dir / "audio_vae.safetensors", prefix="audio_vae.")
+    for k, v in all_audio.items():
+        if k.startswith("per_channel_statistics."):
+            audio_weights[k] = v
+    audio_weights = remap_audio_vae_keys(audio_weights)
+    model.load_weights(list(audio_weights.items()))
+    aggressive_cleanup()
+
+    return model
+
+
 def load_vocoder(
     model_dir: str | Path,
 ) -> VocoderWithBWE:
@@ -252,6 +284,7 @@ def load_model(
     with_audio_vae_decoder: bool = True,
     with_vocoder: bool = True,
     with_text_encoder: bool = True,
+    transformer_file: str | None = None,
 ) -> LtxModelComponents:
     """Load LTX-2 model components from a model directory.
 
@@ -267,6 +300,8 @@ def load_model(
         with_audio_vae_decoder: Whether to load the audio VAE decoder.
         with_vocoder: Whether to load the vocoder.
         with_text_encoder: Whether to load the text encoder.
+        transformer_file: Explicit transformer safetensors filename. If None,
+            ``load_transformer`` auto-detects (distilled before dev).
 
     Returns:
         ``LtxModelComponents`` containing all loaded model components.
@@ -280,7 +315,7 @@ def load_model(
 
     # Load transformer
     logger.debug("Loading transformer...")
-    transformer = load_transformer(model_dir)
+    transformer = load_transformer(model_dir, transformer_file=transformer_file)
 
     # Load video VAE encoder
     video_vae_encoder = None

--- a/packages/ltx-trainer/src/ltx_trainer_mlx/preprocess.py
+++ b/packages/ltx-trainer/src/ltx_trainer_mlx/preprocess.py
@@ -90,9 +90,7 @@ def preprocess_dataset(
         raise FileNotFoundError(f"Videos directory not found: {videos_path}")
 
     # Discover video files (recursive, so per-source subfolders from `ltx slice` work)
-    video_files = sorted(
-        f for f in videos_path.rglob("*") if f.suffix.lower() in VIDEO_EXTENSIONS and f.is_file()
-    )
+    video_files = sorted(f for f in videos_path.rglob("*") if f.suffix.lower() in VIDEO_EXTENSIONS and f.is_file())
     if not video_files:
         raise ValueError(f"No video files found in {videos_path}")
 

--- a/packages/ltx-trainer/src/ltx_trainer_mlx/preprocess.py
+++ b/packages/ltx-trainer/src/ltx_trainer_mlx/preprocess.py
@@ -13,6 +13,13 @@ Output structure::
         conditions/
           condition_0000.safetensors # {video_prompt_embeds, audio_prompt_embeds, prompt_attention_mask}
           condition_0001.safetensors
+        audio_latents/               # only when with_audio=True
+          latent_0000.safetensors    # {latents}  -- (8, T, 16) audio VAE latent
+          latent_0001.safetensors
+
+Note: audio latent files share the exact filename of their video counterpart
+(``latent_XXXX.safetensors``) because ``PrecomputedDataset`` matches non-condition
+sources by identical relative path.
 """
 
 from __future__ import annotations
@@ -48,6 +55,8 @@ def preprocess_dataset(
     max_frames: int = 97,
     captions_dir: str | None = None,
     caption_ext: str = ".txt",
+    with_audio: bool = False,
+    frame_rate: float | None = None,
 ) -> None:
     """Preprocess a directory of videos into training-ready latents and conditions.
 
@@ -62,6 +71,12 @@ def preprocess_dataset(
         captions_dir: Directory with .txt caption files matching video stems.
             If None, uses video filename as caption.
         caption_ext: Extension for caption files.
+        with_audio: If True, also encode each clip's audio into ``audio_latents/``
+            for joint audio-video training. Clips that lack an audio stream are
+            skipped (and will be dropped from the dataset, since all sources must
+            match).
+        frame_rate: Override the frame rate written into the latents and used to
+            size audio tokens. None = use each clip's probed fps.
     """
     # Set Metal cache limit early to prevent GPU watchdog timeouts on 32GB Macs.
     # Without this, loading Gemma 12B (~7GB) triggers "Impacting Interactivity".
@@ -74,8 +89,10 @@ def preprocess_dataset(
     if not videos_path.exists():
         raise FileNotFoundError(f"Videos directory not found: {videos_path}")
 
-    # Discover video files
-    video_files = sorted(f for f in videos_path.iterdir() if f.suffix.lower() in VIDEO_EXTENSIONS and f.is_file())
+    # Discover video files (recursive, so per-source subfolders from `ltx slice` work)
+    video_files = sorted(
+        f for f in videos_path.rglob("*") if f.suffix.lower() in VIDEO_EXTENSIONS and f.is_file()
+    )
     if not video_files:
         raise ValueError(f"No video files found in {videos_path}")
 
@@ -109,11 +126,27 @@ def preprocess_dataset(
         target_height=target_height,
         target_width=target_width,
         max_frames=max_frames,
+        frame_rate=frame_rate,
     )
+
+    # Phase 3: Encode audio (optional; load audio VAE encoder, encode all, then free)
+    audio_latents_dir = precomputed / "audio_latents"
+    if with_audio:
+        print("Phase 3: Encoding audio latents...")
+        audio_latents_dir.mkdir(parents=True, exist_ok=True)
+        _encode_all_audio(
+            video_files=video_files,
+            latents_dir=latents_dir,
+            audio_latents_dir=audio_latents_dir,
+            model_dir=model_dir,
+            frame_rate=frame_rate,
+        )
 
     print(f"\nPreprocessing complete! {len(video_files)} samples saved to {precomputed}")
     print(f"  Latents:    {latents_dir}")
     print(f"  Conditions: {conditions_dir}")
+    if with_audio:
+        print(f"  Audio:      {audio_latents_dir}")
 
 
 def _resolve_captions(
@@ -124,21 +157,22 @@ def _resolve_captions(
     """Resolve captions for each video file."""
     captions: list[str] = []
 
-    if captions_dir is not None:
-        captions_path = Path(captions_dir)
-        for video_file in video_files:
+    captions_path = Path(captions_dir) if captions_dir is not None else None
+    for video_file in video_files:
+        # 1) explicit captions dir (match by stem), 2) sibling .txt next to the clip
+        #    (the layout `ltx slice` produces), 3) fall back to a cleaned filename.
+        caption_file = None
+        if captions_path is not None and (captions_path / f"{video_file.stem}{caption_ext}").exists():
             caption_file = captions_path / f"{video_file.stem}{caption_ext}"
-            if caption_file.exists():
-                captions.append(caption_file.read_text().strip())
-            else:
-                caption = video_file.stem.replace("_", " ").replace("-", " ")
-                logger.warning("No caption file for %s, using filename: '%s'", video_file.name, caption)
-                captions.append(caption)
-    else:
-        for video_file in video_files:
+        elif video_file.with_suffix(caption_ext).exists():
+            caption_file = video_file.with_suffix(caption_ext)
+
+        if caption_file is not None:
+            captions.append(caption_file.read_text().strip())
+        else:
             caption = video_file.stem.replace("_", " ").replace("-", " ")
+            logger.warning("No caption file for %s, using filename: '%s'", video_file.name, caption)
             captions.append(caption)
-        print("  No captions directory provided. Using video filenames as captions.")
 
     return captions
 
@@ -217,6 +251,7 @@ def _encode_all_videos(
     target_height: int | None,
     target_width: int | None,
     max_frames: int,
+    frame_rate: float | None = None,
 ) -> None:
     """Encode all videos and save as latent files."""
     from ltx_trainer_mlx.model_loader import load_video_vae_encoder
@@ -240,6 +275,7 @@ def _encode_all_videos(
                 target_height=target_height,
                 target_width=target_width,
                 max_frames=max_frames,
+                frame_rate=frame_rate,
             )
         except Exception as e:
             logger.error("Failed to encode %s: %s", video_file.name, e)
@@ -260,11 +296,15 @@ def _encode_single_video(
     target_height: int | None,
     target_width: int | None,
     max_frames: int,
+    frame_rate: float | None = None,
 ) -> None:
     """Encode a single video file into VAE latents."""
     from ltx_trainer_mlx.video_utils import read_video
 
     video, actual_fps = read_video(video_file, max_frames=max_frames)
+    # frame_rate override applies to both the saved fps (used for video positions)
+    # and the audio token count, keeping the two modalities aligned.
+    saved_fps = frame_rate if frame_rate is not None else actual_fps
     num_frames = video.shape[0]
 
     # Ensure frames % 8 == 1
@@ -308,10 +348,122 @@ def _encode_single_video(
             "num_frames": np.array([F_lat], dtype=np.int32),
             "height": np.array([H_lat], dtype=np.int32),
             "width": np.array([W_lat], dtype=np.int32),
-            "fps": np.array([actual_fps], dtype=np.float32),
+            "fps": np.array([saved_fps], dtype=np.float32),
         },
         str(output_path),
     )
+
+
+def _encode_all_audio(
+    video_files: list[Path],
+    latents_dir: Path,
+    audio_latents_dir: Path,
+    model_dir: str,
+    frame_rate: float | None = None,
+) -> None:
+    """Encode each clip's audio track into audio VAE latents.
+
+    Frame count and fps are read from the already-written video latent metadata
+    (Phase 2), so the audio duration is guaranteed to match the encoded video.
+    Clips that lack an audio stream are skipped, dropping them from the dataset.
+    """
+    from ltx_core_mlx.model.audio_vae import encode_audio
+    from ltx_core_mlx.model.audio_vae.processor import AudioProcessor
+    from ltx_core_mlx.utils.audio import load_audio
+    from ltx_core_mlx.utils.positions import compute_audio_token_count
+    from ltx_trainer_mlx.model_loader import load_audio_vae_encoder
+
+    encoder = load_audio_vae_encoder(model_dir=model_dir)
+    encoder.freeze()
+    processor = AudioProcessor(sample_rate=16000)
+
+    for i, video_file in enumerate(video_files):
+        output_path = audio_latents_dir / f"latent_{i:04d}.safetensors"
+        if output_path.exists():
+            print(f"  [{i + 1}/{len(video_files)}] Skipping (exists): {output_path.name}")
+            continue
+
+        video_latent_path = latents_dir / f"latent_{i:04d}.safetensors"
+        if not video_latent_path.exists():
+            logger.warning("No video latent for %s — skipping audio (video encode failed?)", video_file.name)
+            continue
+
+        meta = mx.load(str(video_latent_path))
+        num_latent_frames = int(meta["num_frames"].item())
+        # Invert F_lat = (valid_frames - 1) // 8 + 1
+        valid_frames = (num_latent_frames - 1) * 8 + 1
+        fps = frame_rate if frame_rate is not None else float(meta["fps"].item())
+        duration = valid_frames / fps
+
+        print(f"  [{i + 1}/{len(video_files)}] Encoding audio: {video_file.name} ({duration:.2f}s)")
+
+        try:
+            _encode_single_audio(
+                video_file=video_file,
+                output_path=output_path,
+                encoder=encoder,
+                processor=processor,
+                duration=duration,
+                target_tokens=compute_audio_token_count(valid_frames, fps),
+                encode_audio_fn=encode_audio,
+                load_audio_fn=load_audio,
+            )
+        except Exception as e:
+            logger.error("Failed to encode audio for %s: %s", video_file.name, e)
+            continue
+
+        if i % 5 == 0:
+            aggressive_cleanup()
+
+    del encoder
+    aggressive_cleanup()
+    print("  Audio encoding complete.")
+
+
+def _encode_single_audio(
+    video_file: Path,
+    output_path: Path,
+    encoder: object,
+    processor: object,
+    duration: float,
+    target_tokens: int,
+    encode_audio_fn: object,
+    load_audio_fn: object,
+) -> None:
+    """Encode a single clip's audio into an audio VAE latent of ``target_tokens`` length."""
+    audio = load_audio_fn(video_file, target_sample_rate=16000, max_duration=duration, mono=False)
+    if audio is None:
+        logger.warning("No audio stream in %s — skipping (sample dropped from dataset)", video_file.name)
+        return
+
+    latent = encode_audio_fn(audio.waveform, 16000, encoder, processor)  # (1, 8, T, 16)
+    latent = _fit_audio_tokens(latent, target_tokens)
+    _force_eval(latent)
+
+    save_safetensors(
+        {"latents": np.array(latent[0].astype(mx.float32))},  # (8, target_tokens, 16)
+        str(output_path),
+    )
+
+
+def _fit_audio_tokens(latent: mx.array, target_tokens: int) -> mx.array:
+    """Trim or edge-pad the audio latent time axis to ``target_tokens``.
+
+    Args:
+        latent: Audio latent of shape ``(1, 8, T, 16)``.
+        target_tokens: Canonical token count from ``compute_audio_token_count``.
+
+    Returns:
+        Latent of shape ``(1, 8, target_tokens, 16)``.
+    """
+    t = latent.shape[2]
+    if t == target_tokens:
+        return latent
+    if t > target_tokens:
+        return latent[:, :, :target_tokens, :]
+    # Pad by repeating the last token (avoids injecting normalized-zero artifacts).
+    pad = mx.repeat(latent[:, :, -1:, :], target_tokens - t, axis=2)
+    return mx.concatenate([latent, pad], axis=2)
 
 
 def _resize_video(video: mx.array, target_h: int, target_w: int) -> mx.array:
@@ -342,8 +494,22 @@ def _resize_video(video: mx.array, target_h: int, target_w: int) -> mx.array:
     return mx.array(np.stack(frames))
 
 
+# Files preprocessing actually loads. We deliberately exclude the ~20 GB
+# transformer variants and LoRAs — they are only needed at train time, not for
+# encoding latents/conditions, so fetching the full repo here wastes ~80 GB.
+_PREPROCESS_MODEL_PATTERNS = [
+    "connector.safetensors",  # Gemma feature extractor (load_feature_extractor)
+    "vae_encoder.safetensors",  # video VAE encoder (load_video_vae_encoder)
+    "audio_vae.safetensors",  # audio VAE encoder (load_audio_vae_encoder)
+    "*.json",  # configs / index, small
+]
+
+
 def _resolve_model_dir(model_dir: str) -> str:
     """Resolve a model directory path, downloading from HuggingFace if needed.
+
+    When given a HuggingFace repo ID, only the files preprocessing loads are
+    fetched (see ``_PREPROCESS_MODEL_PATTERNS``) — not the full repo.
 
     Args:
         model_dir: Local path or HuggingFace repo ID.
@@ -355,9 +521,9 @@ def _resolve_model_dir(model_dir: str) -> str:
     if model_path.exists():
         return str(model_path)
 
-    # Assume it's a HuggingFace repo ID — download/resolve
+    # Assume it's a HuggingFace repo ID — download only what preprocessing needs.
     from huggingface_hub import snapshot_download
 
-    print(f"  Resolving model: {model_dir}")
-    local_path = snapshot_download(model_dir)
+    print(f"  Resolving model (encoder files only): {model_dir}")
+    local_path = snapshot_download(model_dir, allow_patterns=_PREPROCESS_MODEL_PATTERNS)
     return local_path

--- a/packages/ltx-trainer/src/ltx_trainer_mlx/slice_clips.py
+++ b/packages/ltx-trainer/src/ltx_trainer_mlx/slice_clips.py
@@ -258,11 +258,11 @@ def slice_videos(
     for video_file in video_files:
         info = probe_video_info(str(video_file))
         if not info.has_audio:
-            logger.warning("Source %s has no audio stream — its clips will be unusable for audio training.", video_file.name)
+            logger.warning(
+                "Source %s has no audio stream — its clips will be unusable for audio training.", video_file.name
+            )
 
-        spans = _spans_for_source(
-            info.duration, interval, tc_path, min_length, max_clips, sample, skip_start, skip_end
-        )
+        spans = _spans_for_source(info.duration, interval, tc_path, min_length, max_clips, sample, skip_start, skip_end)
         print(f"{video_file.name}: {info.duration:.0f}s → {len(spans)} clips @ {res}/{fps}fps ({fit})")
         total += _slice_one_source(
             video_file=video_file,

--- a/packages/ltx-trainer/src/ltx_trainer_mlx/slice_clips.py
+++ b/packages/ltx-trainer/src/ltx_trainer_mlx/slice_clips.py
@@ -1,0 +1,294 @@
+"""Slice long videos into fixed-length, resolution-normalized training clips.
+
+ffmpeg-based helper for preparing ASMR / talking-head footage for joint
+audio-video LoRA training. Each source video is sliced into ``--interval``-second
+clips (or clips from an explicit timecode list), scaled+cropped to the target
+resolution **without distortion**, and re-encoded with a clean 16 kHz stereo audio
+stream so the downstream audio VAE encoder always finds a usable track.
+
+Because source videos are often long (many clips each), output is organized into a
+**per-source subfolder**::
+
+    out_dir/
+      <source_stem_a>/
+        <source_stem_a>_000.mp4
+        <source_stem_a>_000.txt   # optional caption template
+        <source_stem_a>_001.mp4
+        ...
+      <source_stem_b>/
+        ...
+
+Aspect handling (``--fit``):
+- ``crop`` (default): scale to *cover* the target, then center-crop. No distortion,
+  no bars; edges are cropped.
+- ``pad``: scale to *fit* inside the target, then letterbox-pad. No distortion, full
+  frame preserved with black bars.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from pathlib import Path
+
+from ltx_core_mlx.utils.ffmpeg import find_ffmpeg, probe_video_info
+
+logger = logging.getLogger(__name__)
+
+VIDEO_EXTENSIONS = {".mp4", ".mov", ".avi", ".mkv", ".webm"}
+AUDIO_SAMPLE_RATE = 16000
+
+
+def _build_filter(width: int, height: int, fit: str) -> str:
+    """Build the ffmpeg ``-vf`` filter for aspect-safe resizing.
+
+    Args:
+        width: Target width (must be divisible by 32 for the VAE).
+        height: Target height (must be divisible by 32 for the VAE).
+        fit: ``"crop"`` (cover + center-crop) or ``"pad"`` (fit + letterbox).
+
+    Returns:
+        Filter string for ffmpeg ``-vf``.
+    """
+    if fit == "crop":
+        return f"scale={width}:{height}:force_original_aspect_ratio=increase,crop={width}:{height},setsar=1"
+    if fit == "pad":
+        return (
+            f"scale={width}:{height}:force_original_aspect_ratio=decrease,"
+            f"pad={width}:{height}:(ow-iw)/2:(oh-ih)/2,setsar=1"
+        )
+    raise ValueError(f"Unknown fit mode: {fit!r} (expected 'crop' or 'pad')")
+
+
+def _parse_timecodes(timecodes_file: Path) -> list[tuple[float, float]]:
+    """Parse a timecode list file (``start,end`` seconds per line).
+
+    Blank lines and lines starting with ``#`` are ignored.
+
+    Args:
+        timecodes_file: Path to the timecode list.
+
+    Returns:
+        List of ``(start, end)`` second pairs.
+    """
+    spans: list[tuple[float, float]] = []
+    for raw in timecodes_file.read_text().splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        start_s, end_s = line.split(",")
+        spans.append((float(start_s), float(end_s)))
+    return spans
+
+
+def _spans_for_source(
+    duration: float,
+    interval: float,
+    timecodes_file: Path | None,
+    min_length: float,
+    max_clips: int | None,
+    sample: str,
+    skip_start: float,
+    skip_end: float,
+) -> list[tuple[float, float]]:
+    """Compute the (start, end) spans to cut from a single source.
+
+    Args:
+        duration: Source duration in seconds.
+        interval: Fixed clip length in seconds (used when no timecodes given).
+        timecodes_file: Optional explicit timecode list (overrides everything else).
+        min_length: Drop clips shorter than this many seconds.
+        max_clips: Cap the number of clips taken from this source (None = all).
+        sample: When capping, ``"even"`` spreads clips across the whole source,
+            ``"sequential"`` takes the first ``max_clips``.
+        skip_start: Skip this many seconds at the start (intro).
+        skip_end: Skip this many seconds at the end (outro).
+
+    Returns:
+        List of ``(start, end)`` spans.
+    """
+    if timecodes_file is not None:
+        return _parse_timecodes(timecodes_file)
+
+    range_end = duration - max(skip_end, 0.0)
+    candidates: list[tuple[float, float]] = []
+    start = max(skip_start, 0.0)
+    while start < range_end:
+        end = min(start + interval, range_end)
+        if end - start >= min_length:
+            candidates.append((start, end))
+        start += interval
+
+    if max_clips is not None and len(candidates) > max_clips:
+        if sample == "even":
+            if max_clips == 1:
+                idxs = [0]
+            else:
+                idxs = sorted({round(i * (len(candidates) - 1) / (max_clips - 1)) for i in range(max_clips)})
+            candidates = [candidates[i] for i in idxs]
+        else:  # sequential
+            candidates = candidates[:max_clips]
+
+    return candidates
+
+
+def _slice_one_source(
+    video_file: Path,
+    out_dir: Path,
+    width: int,
+    height: int,
+    fps: float,
+    fit: str,
+    spans: list[tuple[float, float]],
+    caption_template: str | None,
+    crf: int,
+) -> int:
+    """Slice a single source video into clips inside its own subfolder.
+
+    Returns:
+        Number of clips written.
+    """
+    ffmpeg = find_ffmpeg()
+    vf = _build_filter(width, height, fit)
+    source_out = out_dir / video_file.stem
+    source_out.mkdir(parents=True, exist_ok=True)
+
+    written = 0
+    for idx, (start, end) in enumerate(spans):
+        clip_path = source_out / f"{video_file.stem}_{idx:03d}.mp4"
+        if clip_path.exists():
+            logger.info("Skipping (exists): %s", clip_path.name)
+            written += 1
+            continue
+
+        cmd = [
+            ffmpeg,
+            "-y",
+            "-ss",
+            str(start),
+            "-i",
+            str(video_file),
+            "-t",
+            str(end - start),
+            "-r",
+            str(fps),
+            "-vf",
+            vf,
+            "-c:v",
+            "libx264",
+            "-crf",
+            str(crf),
+            "-preset",
+            "veryfast",
+            "-pix_fmt",
+            "yuv420p",
+            "-c:a",
+            "aac",
+            "-ar",
+            str(AUDIO_SAMPLE_RATE),
+            "-ac",
+            "2",
+            str(clip_path),
+        ]
+        result = subprocess.run(cmd, capture_output=True, check=False)
+        if result.returncode != 0:
+            logger.error("ffmpeg failed on %s [%s-%s]: %s", video_file.name, start, end, result.stderr.decode()[-500:])
+            continue
+
+        if caption_template is not None:
+            clip_path.with_suffix(".txt").write_text(caption_template.strip() + "\n")
+
+        written += 1
+
+    return written
+
+
+def slice_videos(
+    sources: list[str | Path],
+    out_dir: str | Path,
+    *,
+    interval: float = 4.0,
+    timecodes_file: str | Path | None = None,
+    res: str = "384x384",
+    fps: float = 24.0,
+    fit: str = "crop",
+    min_length: float = 2.0,
+    max_clips: int | None = None,
+    sample: str = "even",
+    skip_start: float = 0.0,
+    skip_end: float = 0.0,
+    caption_template: str | None = None,
+    crf: int = 18,
+) -> int:
+    """Slice one or more long videos into normalized training clips.
+
+    Args:
+        sources: Video file paths (or directories — scanned for video files).
+        out_dir: Root output directory; each source gets its own subfolder.
+        interval: Fixed clip length in seconds (ignored if ``timecodes_file`` set).
+        timecodes_file: Optional ``start,end`` list applied to every source.
+        res: Target resolution ``"WxH"`` (both divisible by 32).
+        fps: Output frame rate.
+        fit: ``"crop"`` (center-crop) or ``"pad"`` (letterbox).
+        min_length: Drop clips shorter than this (seconds).
+        max_clips: Cap clips per source (None = all). Useful for building a
+            browsable pool from very long footage that you then cull by hand.
+        sample: When capping, ``"even"`` (spread across the source) or
+            ``"sequential"`` (first N).
+        skip_start: Skip this many seconds at the start of each source (intro).
+        skip_end: Skip this many seconds at the end of each source (outro).
+        caption_template: If set, write a ``.txt`` next to each clip with this text.
+        crf: x264 quality (lower = higher quality / larger files).
+
+    Returns:
+        Total number of clips written across all sources.
+    """
+    width, height = (int(x) for x in res.lower().split("x"))
+    if width % 32 != 0 or height % 32 != 0:
+        raise ValueError(f"Resolution {res} must be divisible by 32 on both axes (VAE requirement).")
+
+    video_files = _discover_sources(sources)
+    if not video_files:
+        raise ValueError("No video files found in the given sources.")
+
+    out_dir = Path(out_dir)
+    tc_path = Path(timecodes_file) if timecodes_file is not None else None
+
+    total = 0
+    for video_file in video_files:
+        info = probe_video_info(str(video_file))
+        if not info.has_audio:
+            logger.warning("Source %s has no audio stream — its clips will be unusable for audio training.", video_file.name)
+
+        spans = _spans_for_source(
+            info.duration, interval, tc_path, min_length, max_clips, sample, skip_start, skip_end
+        )
+        print(f"{video_file.name}: {info.duration:.0f}s → {len(spans)} clips @ {res}/{fps}fps ({fit})")
+        total += _slice_one_source(
+            video_file=video_file,
+            out_dir=out_dir,
+            width=width,
+            height=height,
+            fps=fps,
+            fit=fit,
+            spans=spans,
+            caption_template=caption_template,
+            crf=crf,
+        )
+
+    print(f"\nDone. {total} clips written under {out_dir}")
+    return total
+
+
+def _discover_sources(sources: list[str | Path]) -> list[Path]:
+    """Expand source paths (files or directories) into a sorted list of video files."""
+    found: list[Path] = []
+    for src in sources:
+        p = Path(src)
+        if p.is_dir():
+            found.extend(f for f in p.iterdir() if f.suffix.lower() in VIDEO_EXTENSIONS and f.is_file())
+        elif p.is_file() and p.suffix.lower() in VIDEO_EXTENSIONS:
+            found.append(p)
+        else:
+            logger.warning("Skipping (not a video file/dir): %s", p)
+    return sorted(set(found))

--- a/packages/ltx-trainer/src/ltx_trainer_mlx/trainer.py
+++ b/packages/ltx-trainer/src/ltx_trainer_mlx/trainer.py
@@ -244,8 +244,9 @@ class LtxvTrainer:
                         }
                     )
 
-                # Fallback logging
-                if disable_progress_bars and self._global_step % 20 == 0:
+                # Fallback logging (every 5 steps so nohup/redirected runs have a
+                # usable loss trace; loss.item() is already synced every step).
+                if disable_progress_bars and self._global_step % 5 == 0:
                     elapsed = time.time() - train_start_time
                     pct = self._global_step / cfg.optimization.steps
                     if pct > 0:
@@ -325,13 +326,13 @@ class LtxvTrainer:
             audio_features = conditions.get("audio_prompt_embeds", video_features)
             mask = conditions["prompt_attention_mask"]
 
-            # Apply feature extractor to get final embeddings
-            if feature_extractor is not None:
-                video_embeds, audio_embeds = feature_extractor(
-                    video_features,
-                    audio_features=audio_features,
-                    attention_mask=mask,
-                )
+            # Precomputed conditions already hold projected video/audio embeddings
+            # (the connector ran at preprocess time). Only apply the feature
+            # extractor to raw, unprojected Gemma hidden states. The extractor is
+            # loaded whenever validation is enabled, so gate on the data, not on
+            # whether the extractor exists.
+            if "video_prompt_embeds" not in conditions and feature_extractor is not None:
+                video_embeds, audio_embeds = feature_extractor(video_features, attention_mask=mask)
             else:
                 video_embeds = video_features
                 audio_embeds = audio_features
@@ -369,7 +370,7 @@ class LtxvTrainer:
                 num_lat_frames = int(latent_data["num_frames"][0].item())
                 pixel_frames = (num_lat_frames - 1) * 8 + 1
                 fps_val = float(latent_data.get("fps", mx.array([24.0]))[0].item())
-                audio_tokens = compute_audio_token_count(pixel_frames, fps=fps_val)
+                audio_tokens = compute_audio_token_count(pixel_frames, frame_rate=fps_val)
 
                 B = video_inputs.latent.shape[0]
                 call_kwargs["audio_latent"] = mx.zeros((B, audio_tokens, 128), dtype=mx.bfloat16)
@@ -461,9 +462,13 @@ class LtxvTrainer:
             with_audio_vae_decoder=load_audio and has_validation,
             with_vocoder=load_audio and has_validation,
             with_text_encoder=False,  # Handled separately above
+            transformer_file=self._config.model.transformer_file,
         )
 
         self._transformer = components.transformer
+        # Gradient checkpointing: recompute blocks in backward to cap activation
+        # memory (lets the dev model backprop fit on 64 GB).
+        self._transformer.gradient_checkpointing = self._config.optimization.enable_gradient_checkpointing
         self._vae_decoder = components.video_vae_decoder
         self._vae_encoder = components.video_vae_encoder
         self._audio_vae = components.audio_vae_decoder

--- a/packages/ltx-trainer/src/ltx_trainer_mlx/training_strategies/base_strategy.py
+++ b/packages/ltx-trainer/src/ltx_trainer_mlx/training_strategies/base_strategy.py
@@ -212,7 +212,7 @@ class TrainingStrategy(ABC):
             num_frames=num_frames,
             height=height,
             width=width,
-            fps=fps,
+            frame_rate=fps,
         )
 
     @staticmethod

--- a/packages/ltx-trainer/src/ltx_trainer_mlx/validation_sampler.py
+++ b/packages/ltx-trainer/src/ltx_trainer_mlx/validation_sampler.py
@@ -147,11 +147,11 @@ class ValidationSampler:
         # Compute latent shapes
         F, H, W = compute_video_latent_shape(config.num_frames, config.height, config.width)
         video_shape = (1, F * H * W, 128)
-        audio_T = compute_audio_token_count(config.num_frames, fps=config.frame_rate)
+        audio_T = compute_audio_token_count(config.num_frames, frame_rate=config.frame_rate)
         audio_shape = (1, audio_T, 128)
 
         # Compute positions
-        video_positions = compute_video_positions(F, H, W, fps=config.frame_rate)
+        video_positions = compute_video_positions(F, H, W, frame_rate=config.frame_rate)
         audio_positions = compute_audio_positions(audio_T)
 
         # Build image conditioning if provided.
@@ -270,7 +270,7 @@ class ValidationSampler:
             Video tensor of shape ``(C, F, H, W)`` in ``[0, 1]``.
         """
         latent = latent.astype(mx.bfloat16)
-        decoded = self._vae_decoder(latent)
+        decoded = self._vae_decoder.decode(latent)
         _force_eval(decoded)
         # Normalise from [-1, 1] to [0, 1]
         decoded = mx.clip((decoded + 1.0) / 2.0, 0.0, 1.0)
@@ -289,7 +289,7 @@ class ValidationSampler:
         assert self._vocoder is not None
 
         latent = latent.astype(mx.bfloat16)
-        decoded_audio = self._audio_decoder(latent)
+        decoded_audio = self._audio_decoder.decode(latent)
         _force_eval(decoded_audio)
         aggressive_cleanup()
 

--- a/packages/ltx-trainer/src/ltx_trainer_mlx/video_utils.py
+++ b/packages/ltx-trainer/src/ltx_trainer_mlx/video_utils.py
@@ -142,6 +142,9 @@ def save_video(
 
 def _prepare_video_array(video_array: mx.array) -> np.ndarray:
     """Convert video array to ``(F, H, W, C)`` uint8 numpy array."""
+    # Cast bf16 -> f32 in MLX first; numpy has no bfloat16 buffer dtype.
+    if isinstance(video_array, mx.array):
+        video_array = video_array.astype(mx.float32)
     arr = np.array(video_array, copy=False)
 
     # Handle [C, F, H, W] vs [F, C, H, W] format
@@ -170,7 +173,9 @@ def _save_video_with_audio(
 
     num_frames, height, width, _ = video_np.shape
 
-    # Prepare audio as WAV-compatible PCM data
+    # Prepare audio as WAV-compatible PCM data (bf16 -> f32 in MLX first)
+    if isinstance(audio, mx.array):
+        audio = audio.astype(mx.float32)
     audio_np = np.array(audio, copy=False).astype(np.float32)
 
     # Normalise to [samples, 2] stereo

--- a/tests/test_trainer_core.py
+++ b/tests/test_trainer_core.py
@@ -417,3 +417,143 @@ class TestConfig:
                 validation={"interval": None},
                 data={"preprocessed_data_root": "/tmp/data"},
             )
+
+
+# ---------------------------------------------------------------------------
+# 7. TestGradientCheckpointing
+# ---------------------------------------------------------------------------
+
+
+class TestGradientCheckpointing:
+    """Tests for mx.checkpoint-based gradient checkpointing in LTXModel block loop.
+
+    The critical invariant: block.trainable_parameters() must be passed as an
+    explicit input to the mx.checkpoint closure so that mx.checkpoint can
+    differentiate through them.  If params are captured from the closure instead,
+    mx.checkpoint gives zero gradients for the LoRA params (silent no-op adapter).
+    """
+
+    def test_grads_match_on_off(self) -> None:
+        """Checkpointing gives identical LoRA-param grads to the non-checkpoint path."""
+        mx.random.seed(42)
+        dim, rank = 16, 4
+
+        # Frozen base + trainable LoRA adapter (both non-zero to ensure non-zero grads).
+        # mlx_lm's LoRALinear initializes lora_b=0, which zeros out lora_a's gradient;
+        # we use a custom block so both adapter matrices are randomly initialized.
+        class LoRAStyleBlock(nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.base = nn.Linear(dim, dim, bias=False)  # frozen below
+                self.lora_a = mx.random.normal((dim, rank)) * 0.1
+                self.lora_b = mx.random.normal((rank, dim)) * 0.1
+
+            def __call__(self, x: mx.array) -> mx.array:
+                return self.base(x) + (x @ self.lora_a) @ self.lora_b
+
+        block = LoRAStyleBlock()
+        block.base.freeze()  # only the base Linear is frozen; lora_a/lora_b stay trainable
+
+        x = mx.random.normal((2, dim))
+        target = mx.random.normal((2, dim))
+
+        def loss_no_ckpt(params: dict, x: mx.array, target: mx.array) -> mx.array:
+            block.update(params)
+            return mx.mean((block(x) - target) ** 2)
+
+        # Mirrors the pattern in model.py:
+        #   def _run_block(params, vh, ah, _block=block, _bidx=block_idx):
+        #       _block.update(params); return _block(...)
+        #   video_hidden, audio_hidden = mx.checkpoint(_run_block)(
+        #       block.trainable_parameters(), video_hidden, audio_hidden
+        #   )
+        def loss_ckpt(params: dict, x: mx.array, target: mx.array) -> mx.array:
+            def _run(params: dict, x: mx.array, _b: nn.Module = block) -> mx.array:
+                _b.update(params)
+                return _b(x)
+
+            return mx.mean((mx.checkpoint(_run)(params, x) - target) ** 2)
+
+        params = block.trainable_parameters()
+        grads_normal = mx.grad(loss_no_ckpt)(params, x, target)
+        grads_ckpt = mx.grad(loss_ckpt)(params, x, target)
+        mx.eval(grads_normal, grads_ckpt)
+
+        flat_normal = dict(nn.utils.tree_flatten(grads_normal))
+        flat_ckpt = dict(nn.utils.tree_flatten(grads_ckpt))
+
+        assert flat_ckpt, "trainable_parameters() returned nothing — freeze setup broken"
+        for name, g_c in flat_ckpt.items():
+            assert mx.any(g_c != 0).item(), f"Zero grad for '{name}' with checkpointing on"
+            g_n = flat_normal[name]
+            assert mx.allclose(g_n, g_c, atol=1e-5).item(), (
+                f"Grad mismatch for '{name}': max_diff={mx.max(mx.abs(g_n - g_c)).item():.2e}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# 8. TestFitAudioTokens
+# ---------------------------------------------------------------------------
+
+
+class TestFitAudioTokens:
+    """Tests for _fit_audio_tokens alignment with compute_audio_token_count.
+
+    _fit_audio_tokens must produce a token count that exactly matches
+    compute_audio_token_count(num_frames, fps) regardless of whether the raw
+    encoded latent comes in slightly over or under the canonical length.
+    """
+
+    def test_trim(self) -> None:
+        """Oversized latent is trimmed to target_tokens on the time axis."""
+        from ltx_trainer_mlx.preprocess import _fit_audio_tokens
+
+        latent = mx.zeros((1, 8, 20, 16))
+        result = _fit_audio_tokens(latent, 15)
+        assert result.shape == (1, 8, 15, 16)
+
+    def test_pad(self) -> None:
+        """Undersized latent is edge-padded to target_tokens on the time axis."""
+        from ltx_trainer_mlx.preprocess import _fit_audio_tokens
+
+        latent = mx.zeros((1, 8, 10, 16))
+        result = _fit_audio_tokens(latent, 15)
+        assert result.shape == (1, 8, 15, 16)
+
+    def test_exact_is_noop(self) -> None:
+        """Exactly-sized latent is returned with shape unchanged."""
+        from ltx_trainer_mlx.preprocess import _fit_audio_tokens
+
+        latent = mx.zeros((1, 8, 12, 16))
+        result = _fit_audio_tokens(latent, 12)
+        assert result.shape == (1, 8, 12, 16)
+
+    def test_pad_replicates_last_token(self) -> None:
+        """Padding repeats the last time step rather than injecting zeros."""
+        from ltx_trainer_mlx.preprocess import _fit_audio_tokens
+
+        sentinel = 99.0
+        latent = mx.ones((1, 8, 5, 16)) * sentinel
+        result = _fit_audio_tokens(latent, 8)
+        assert result.shape == (1, 8, 8, 16)
+        padded = result[:, :, 5:, :]
+        assert mx.allclose(padded, mx.ones_like(padded) * sentinel).item()
+
+    def test_matches_compute_audio_token_count(self) -> None:
+        """Output token count equals compute_audio_token_count for canonical params.
+
+        Verifies that trim and pad paths both converge to the exact canonical
+        count that the audio preprocessing pipeline uses.
+        """
+        from ltx_core_mlx.utils.positions import compute_audio_token_count
+        from ltx_trainer_mlx.preprocess import _fit_audio_tokens
+
+        cases = [(33, 24.0), (97, 24.0), (65, 25.0), (9, 24.0)]
+        for num_frames, fps in cases:
+            target = compute_audio_token_count(num_frames, fps)
+            for raw_t in (target - 3, target, target + 3):
+                latent = mx.zeros((1, 8, raw_t, 16))
+                result = _fit_audio_tokens(latent, target)
+                assert result.shape[2] == target, (
+                    f"frames={num_frames} fps={fps}: expected {target}, got {result.shape[2]}"
+                )


### PR DESCRIPTION
### Summary

Enables end-to-end joint audio-video LoRA training on Apple Silicon, closing the gap between what the trainer config accepted and what it could actually execute. Three logical pieces:

- **Bug fixes + gradient checkpointing** — four latent bugs in the existing trainer that would crash any audio training run (`fps=` keyword in three call sites, decoders called as functions instead of `.decode()`, bfloat16 arrays passed directly to numpy). Gradient checkpointing on `LTXModel` caps backprop activation memory at ~1 block (~26 GB) vs. storing all 48 (~84 GB), making the dev model trainable on 64 GB machines.

- **Audio preprocessing pipeline** — `preprocess --with-audio` encodes each clip's audio track via the audio VAE encoder and writes `audio_latents/` alongside video latents, sized to `compute_audio_token_count()` so the two modalities are aligned by construction. Preprocessor now does a partial HuggingFace download (connector + VAE files only, skipping the ~20 GB transformer) and discovers clips recursively so per-source subfolders work. Adds `transformer_file` config field to pin `transformer-dev.safetensors` explicitly, and expands `~` in `model_path` validation.

- **Video slicer** — new `ltx-2-mlx slice` command cuts long source videos into normalized training clips with audio retained: fixed-interval or timecode-list slicing, aspect-safe crop/pad, `--max-clips` with even or sequential sampling, per-source output subfolders.

### Behavior change: preprocess no longer downloads the full model snapshot

Previously, `preprocess` with a HuggingFace repo ID as `--model` would trigger a full `snapshot_download`, pulling the entire model (~80 GB including the ~20 GB transformer). This PR changes `_resolve_model_dir` to do a **partial download**: only the connector and VAE safetensors files needed for preprocessing are fetched. The transformer is not downloaded.

**Impact**: anyone who relied on `preprocess` to populate the full HF cache (e.g. to then run inference from the same path) will need to run `huggingface-cli download <repo>` separately, or pass the already-cached local path. The changelog entry for this release should note the change.

### Validated

Trained a 2000-step audio-style LoRA on M5 Pro 64 GB Macbook Pro (74 clips, 8 voices, 192×192, rank 32) targeting `audio_attn1 / audio_attn2 / video_to_audio_attn` only. Confirmed at inference via `generate --lora`:
- Soft-spoken and whisper registers both work easily for female voices
- Male soft-spoken works easily; male whisper responds to `(man, whispering quietly)` (needed more of a nudge, likely due to source clips
- Video output visually unchanged from base model (audio-only target modules hold)
- ~5.7 s/step with gradient checkpointing at 192×192; ~3h10m for 2000 steps vs OOM without gradient checkpointing

### Test plan

- [x] `TestGradientCheckpointing::test_grads_match_on_off` — verifies `mx.checkpoint` with explicit param input gives identical LoRA-param grads to non-checkpoint path (catches silent no-op adapter regression)
- [x] `TestFitAudioTokens` (5 tests) — verifies `_fit_audio_tokens` trims/pads to the exact count from `compute_audio_token_count` for canonical (num_frames, fps) values
- [ ] `ltx-2-mlx slice <source.mp4> --interval 4 --res 384x384 -o ./clips` — confirm per-source subfolder created, clips have audio stream
- [ ] `ltx-2-mlx preprocess --videos ./clips --with-audio --frame-rate 24 -o ./data` — confirm `audio_latents/` written with matching filenames and count equal to `latents/`
- [ ] `ltx-2-mlx train --config configs/lora_av_whisper.yaml` — confirm training starts, loss is finite, checkpoints written
- [ ] `ltx-2-mlx train --config configs/lora_av_whisper.yaml --low-ram` — confirm gradient checkpointing enabled message, peak RAM lower than without flag
- [ ] `ltx-2-mlx generate --lora <checkpoint> --prompt "(woman, whispering) ..."` — confirm audio register effect at inference