### PR TITLE
feat: multi-anchor I2V for `--one-stage` and `--distilled`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -471,6 +471,36 @@ ltx-2-mlx generate \
 
 Flags: `--two-stage` (Euler), `--two-stages-hq` (res_2s), `--cfg-scale` (default 3.0), `--stg-scale` (default 0.0), `--stage1-steps` (default 30 standard, 15 HQ), `--stage2-steps` (default 3), `--image`.
 
+### Multi-Anchor I2V (`--image` repeatable)
+
+All `generate` modes (`--one-stage`, `--two-stage`, `--two-stages-hq`, `--distilled`) support multiple `--image` flags. Each anchor takes `PATH FRAME_IDX STRENGTH` where `FRAME_IDX` is the **pixel frame index** (0-based; for a 97-frame video the last frame is 96).
+
+- `frame_idx=0` → `VideoConditionByLatentIndex`: hard-replaces the first latent frame (strongly preserved)
+- `frame_idx>0` → `VideoConditionByKeyframeIndex`: appends soft reference tokens at that temporal position
+
+```bash
+# Anchor both ends — model animates the transition
+ltx-2-mlx generate \
+  --prompt "woman stands up from chair and walks to kitchen sink" \
+  --two-stage \
+  --image sitting.jpg 0 1.0 \
+  --image standing.jpg 96 1.0 \
+  --image at_sink.jpg 136 1.0 \
+  -f 137 --frame-rate 24 -o output.mp4
+
+# Seamless loop — same image at start and end
+ltx-2-mlx generate \
+  --prompt "flowing water rippling" \
+  --two-stage \
+  --image frame.jpg 0 1.0 \
+  --image frame.jpg 96 1.0 \
+  -f 97 --frame-rate 24 -o loop.mp4
+```
+
+**Mode recommendations for multi-anchor:** `--two-stage` or `--two-stages-hq` (dev model + CFG) respects anchors most faithfully. `--distilled` (8 steps, no CFG) also honors them — soft keyframe anchors are hints, not law, so the model may drift from them at longer durations, but a distilled start+end smoke test (512×512×25) tracked both anchors cleanly. `--one-stage` works but is slower than `--two-stage` at large resolutions.
+
+**Frame count constraint:** `(num_frames - 1) % 8 == 0`. Valid counts: 9, 17, 25, 33, 41, 49, 57, 65, 73, 81, 89, 97, 105, 113, 121, 129, 137, …
+
 ### Audio-to-Video Example
 
 ```bash

--- a/packages/ltx-core-mlx/src/ltx_core_mlx/conditioning/types/keyframe_cond.py
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/conditioning/types/keyframe_cond.py
@@ -92,7 +92,8 @@ class VideoConditionByKeyframeIndex:
     to tokens from previously appended keyframes.
 
     Args:
-        frame_idx: Latent frame index for this keyframe (0-based).
+        frame_idx: Pixel frame index for this keyframe (0-based). E.g. for a
+            97-frame video the last frame is 96. NOT a latent frame index.
         keyframe_latent: Clean latent for this keyframe, (B, H*W, C).
         spatial_dims: (F, H, W) latent spatial dimensions.
         frame_rate: Frame rate for position computation.

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/cli.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/cli.py
@@ -40,32 +40,6 @@ def _add_base_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--quiet", "-q", action="store_true", help="Suppress progress output")
 
 
-def _legacy_single_image(images, *, mode_label: str) -> str | None:
-    """Reduce a list of ImageConditioningInput to a single legacy path.
-
-    one-stage and distilled pipelines accept only the legacy ``image=path``
-    (frame_idx=0, strength=1.0). Multi-anchor I2V is a two-stage / HQ
-    feature. Errors out clearly if the user passed >1 anchor or a non-
-    trivial frame_idx/strength on these modes.
-    """
-    if not images:
-        return None
-    if len(images) > 1:
-        raise SystemExit(
-            f"{mode_label}: multi-image I2V (>1 --image) requires --two-stage "
-            "or --two-stages-hq. The single-stage / distilled paths only "
-            "support a single legacy anchor."
-        )
-    img = images[0]
-    if img.frame_idx != 0 or img.strength != 1.0:
-        raise SystemExit(
-            f"{mode_label}: --image FRAME_IDX/STRENGTH overrides require "
-            "--two-stage or --two-stages-hq. Got "
-            f"frame_idx={img.frame_idx}, strength={img.strength}."
-        )
-    return img.path
-
-
 def _build_tile_count_config(args: argparse.Namespace):
     """Return a TileCountConfig from --tile-frames / --tile-spatial / --tile-overlap.
 
@@ -188,8 +162,9 @@ examples:
             "PATH alone defaults to FRAME_IDX=0 STRENGTH=1.0 (legacy single-image I2V). "
             "Repeatable to anchor multiple frames (e.g. --image foo.jpg 0 1.0 "
             "--image foo.jpg 96 1.0 to anchor both ends and preserve identity). "
-            "FRAME_IDX is the target latent frame index; 0 replaces, others guide via "
-            "VideoConditionByKeyframeIndex. Mirrors upstream LTX_2_3 --image."
+            "FRAME_IDX is the pixel frame index (0-based); 0 replaces the first latent "
+            "frame directly, others guide via VideoConditionByKeyframeIndex. "
+            "Mirrors upstream LTX_2_3 --image."
         ),
     )
     gen.add_argument("--steps", type=int, default=None, help="Denoising steps for one-stage (default: 8)")
@@ -624,12 +599,6 @@ def _cmd_generate(args: argparse.Namespace) -> None:
         pipe.verbose = not args.quiet
         if lora_paths:
             pipe._pending_loras = lora_paths
-        # one-stage accepts only a single legacy `image=path` (frame_idx=0,
-        # strength=1.0). Multi-anchor is unsupported here — would require
-        # the same combined_image_conditionings refactor as the two-stage
-        # paths. For now, error out if the user passed >1 anchor or a
-        # non-trivial strength/frame_idx.
-        legacy_image = _legacy_single_image(args.images, mode_label="--one-stage")
         kwargs: dict = dict(
             prompt=prompt,
             output_path=args.output,
@@ -638,7 +607,7 @@ def _cmd_generate(args: argparse.Namespace) -> None:
             num_frames=args.frames,
             frame_rate=args.frame_rate,
             seed=args.seed,
-            image=legacy_image,
+            images=args.images,
         )
         # The dev one-stage pipeline uses `num_steps` (single sampler), not stage1/stage2.
         if args.stage1_steps is not None:
@@ -668,8 +637,6 @@ def _cmd_generate(args: argparse.Namespace) -> None:
         pipe.verbose = not args.quiet
         if lora_paths:
             pipe._pending_loras = lora_paths
-        # distilled accepts only a single legacy `image=path` for now.
-        legacy_image = _legacy_single_image(args.images, mode_label="--distilled")
         kwargs: dict = dict(
             prompt=prompt,
             output_path=args.output,
@@ -678,7 +645,7 @@ def _cmd_generate(args: argparse.Namespace) -> None:
             num_frames=args.frames,
             frame_rate=args.frame_rate,
             seed=args.seed,
-            image=legacy_image,
+            images=args.images,
         )
         if args.stage1_steps is not None:
             kwargs["stage1_steps"] = args.stage1_steps

--- a/uv.lock
+++ b/uv.lock
@@ -427,7 +427,7 @@ wheels = [
 
 [[package]]
 name = "ltx-2-mlx"
-version = "0.14.11"
+version = "0.14.12"
 source = { virtual = "." }
 dependencies = [
     { name = "ltx-core-mlx" },
@@ -467,7 +467,7 @@ provides-extras = ["trainer", "dev", "all"]
 
 [[package]]
 name = "ltx-core-mlx"
-version = "0.14.11"
+version = "0.14.12"
 source = { editable = "packages/ltx-core-mlx" }
 dependencies = [
     { name = "huggingface-hub" },
@@ -490,7 +490,7 @@ requires-dist = [
 
 [[package]]
 name = "ltx-pipelines-mlx"
-version = "0.14.11"
+version = "0.14.12"
 source = { editable = "packages/ltx-pipelines-mlx" }
 dependencies = [
     { name = "ltx-core-mlx" },
@@ -509,7 +509,7 @@ requires-dist = [
 
 [[package]]
 name = "ltx-trainer-mlx"
-version = "0.14.11"
+version = "0.14.12"
 source = { editable = "packages/ltx-trainer" }
 dependencies = [
     { name = "ltx-core-mlx" },


### PR DESCRIPTION
### Summary

The single-stage and distilled `generate` paths previously routed `--image`
through `_legacy_single_image()`, which raised `SystemExit` on more than one
anchor or any non-trivial `frame_idx`/`strength`. Multi-anchor I2V was therefore
limited to `--two-stage` / `--two-stages-hq`.

Both `TI2VidOneStagePipeline` and the distilled pipeline already accept `images=`
and route through `combined_image_conditionings` — the CLI guard was the only
thing blocking these modes. This PR removes the guard and passes
`images=args.images` on both paths.

Anchor semantics (unchanged, now reachable on all `generate` modes):
- `frame_idx=0` → `VideoConditionByLatentIndex`: hard-replaces the first latent
  frame (strongly preserved).
- `frame_idx>0` → `VideoConditionByKeyframeIndex`: appends a soft keyframe anchor
  at that temporal position.

### Changes

- **`cli.py`** — remove `_legacy_single_image`; `--one-stage` and `--distilled`
  now pass `images=args.images`. Fix `--image` help text: `frame_idx` is a
  **pixel** frame index (0-based), not a latent index.
- **`keyframe_cond.py`** — `VideoConditionByKeyframeIndex.frame_idx` docstring
  corrected to "pixel frame index (0-based)".
- **`CLAUDE.md`** — new "Multi-Anchor I2V" section documenting the repeatable
  `--image PATH FRAME_IDX STRENGTH` form across all `generate` modes.
- **`uv.lock`** (separate commit) — resync to `0.14.12`; the 0.14.12 release
  bumped the workspace `pyproject` versions but left the lockfile at `0.14.11`.

### Validation

Start+end anchor smoke tests at 512×512×25 (start image @ frame 0, end image @
frame 24):

| Mode | E2E | Frame 0 (hard) | Final frame (soft) | Time |
|------|-----|----------------|--------------------|------|
| `--distilled` | ✅ | reproduces start image | tracks end-anchor pose | 29.5s |
| `--one-stage` | ✅ | reproduces start image | tracks end-anchor pose | 465s |

Soft keyframe anchors are hints, not law — they may drift at longer durations,
but both held cleanly at this length.

### Notes

- `--two-stage` / `--two-stages-hq` behavior is unchanged.
- Purely additive: the only paths affected are ones that previously errored out.
