### PR TITLE
ci: pin GitHub Actions to commit SHAs + add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  # Keep the SHA-pinned GitHub Actions current via reviewable PRs. Dependabot
+  # reads the `# vX.Y.Z` comment next to each pinned SHA and bumps both together.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    # `ci:` prefix so the bot's commits pass commitlint (conventional commits).
+    commit-message:
+      prefix: "ci"
+    # One grouped PR per run instead of one PR per action.
+    groups:
+      github-actions:
+        patterns: ["*"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,21 +10,21 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
       - name: lint (ruff check)
-        uses: astral-sh/ruff-action@v3
+        uses: astral-sh/ruff-action@4919ec5cf1f49eff0871dbcea0da843445b837e6  # v3.6.1
         with:
           args: check packages/ tests/
       - name: format (ruff format)
-        uses: astral-sh/ruff-action@v3
+        uses: astral-sh/ruff-action@4919ec5cf1f49eff0871dbcea0da843445b837e6  # v3.6.1
         with:
           args: format --check packages/ tests/
 
   syntax:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: "3.12"
       - name: Validate Python syntax
@@ -48,8 +48,8 @@ jobs:
       matrix:
         python-version: ["3.11", "3.12"]
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a  # v4.2.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install ffmpeg
@@ -63,7 +63,7 @@ jobs:
   commitlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           fetch-depth: 0
-      - uses: wagoid/commitlint-github-action@v6
+      - uses: wagoid/commitlint-github-action@b948419dd99f3fd78a6548d48f94e3df7f6bf3ed  # v6.2.1

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,12 +12,12 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/create-github-app-token@v1
+      - uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547  # v1.12.0
         id: app-token
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071  # v4.4.1
         with:
           # Mint a short-lived token from the release GitHub App (not the default
           # GITHUB_TOKEN) so the release PR it opens triggers CI/relock workflows.

--- a/.github/workflows/relock-on-release.yml
+++ b/.github/workflows/relock-on-release.yml
@@ -26,19 +26,19 @@ jobs:
       startsWith(github.head_ref, 'release-please--')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/create-github-app-token@v1
+      - uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547  # v1.12.0
         id: app-token
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           ref: ${{ github.head_ref }}
           # Do NOT persist the token in .git/config. `uv lock` resolves and may build
           # dependencies (arbitrary code via PEP 517 build backends); a persisted
           # token would be readable by that code. The push step re-supplies it.
           persist-credentials: false
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a  # v4.2.0
         with:
           enable-cache: true
       - name: Install Python


### PR DESCRIPTION
Coordinated supply-chain hardening across the three repos (ltx-2-mlx, mlx-forge, smeltr). Addresses the automated security review finding (unpinned third-party actions) — done repo-wide rather than piecemeal.

## What

- **Every `uses:` pinned to a 40-char commit SHA** with a `# vX.Y.Z` comment. SHAs freeze the *current* behavior exactly — no version bumps. A mutable tag (`@v4`, or worse a branch like `@stable`) can be silently re-pointed by a compromised publisher; a SHA can't. Highest-value on the release workflows, where the GitHub App token + `contents: write` give a hijacked action real blast radius.
- **`.github/dependabot.yml`** (github-actions, weekly, grouped) so the pins don't rot — Dependabot reads the `# vX.Y.Z` comment and bumps SHA + comment together in reviewable PRs. `commit-message.prefix: ci` so its PRs pass `commitlint`.

## Pins applied

| Action | SHA | Version |
|---|---|---|
| actions/checkout | 34e1148… | v4.3.1 |
| actions/create-github-app-token | d72941d… | v1.12.0 |
| actions/setup-python | a26af69… | v5.6.0 |
| astral-sh/ruff-action | 4919ec5… | v3.6.1 |
| astral-sh/setup-uv | 38f3f10… | v4.2.0 |
| googleapis/release-please-action | 5c625bf… | v4.4.1 |
| wagoid/commitlint-github-action | b948419… | v6.2.1 |

Companion PRs open the same change on mlx-forge and smeltr. Version unification of `setup-uv` (v3/v4/v6 across repos) is intentionally left to follow-up Dependabot PRs so each bump is tested individually.