### PR TITLE
ci: allow Dependabot grouped-PR bodies past commitlint

### DIFF
--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,0 +1,10 @@
+export default {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    // Dependabot's grouped PRs put long markdown tables + URLs in the commit
+    // body and footer; don't reject those on line length. Subject/header rules
+    // still apply.
+    'body-max-line-length': [0],
+    'footer-max-line-length': [0],
+  },
+};


### PR DESCRIPTION
Dependabot's grouped `github-actions` PRs put a long markdown table + release-note URLs in the **commit body**, which trips config-conventional's `body-max-line-length: 100` (and would trip `footer-max-line-length`). The subject (`ci: bump …`) is valid — only the auto-generated body fails.

This adds `commitlint.config.mjs` extending config-conventional with those two length rules disabled. Subject/header rules unchanged.

Unblocks #49 (and every future Dependabot PR). Companion fixes on mlx-forge (#24) and smeltr (#76), which hit the identical failure.