### PR TITLE
fix: apply streaming LoRA deltas under the correct block prefix (#52)

### DIFF
--- a/packages/ltx-core-mlx/src/ltx_core_mlx/loader/__init__.py
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/loader/__init__.py
@@ -7,6 +7,7 @@ from ltx_core_mlx.loader.primitives import (
     StateDict,
 )
 from ltx_core_mlx.loader.sd_ops import (
+    LTXV_LORA_BLOCK_PREFIX,
     LTXV_LORA_COMFY_RENAMING_MAP,
     ContentMatching,
     ContentReplacement,
@@ -20,6 +21,7 @@ from ltx_core_mlx.loader.sft_loader import (
 )
 
 __all__ = [
+    "LTXV_LORA_BLOCK_PREFIX",
     "LTXV_LORA_COMFY_RENAMING_MAP",
     "ContentMatching",
     "ContentReplacement",

--- a/packages/ltx-core-mlx/src/ltx_core_mlx/loader/block_streaming.py
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/loader/block_streaming.py
@@ -51,10 +51,14 @@ class BlockLoraSource:
 
     Args:
         lora_path: Path to LoRA safetensors.
-        block_prefix: Same prefix as the streamer (e.g.
-            ``"transformer.transformer_blocks."``). LoRA keys after
-            optional ``sd_ops`` remapping must start with this prefix
-            and be of the form ``f"{block_prefix}{idx}.{param}.lora_A.weight"``.
+        block_prefix: Prefix the LoRA keys carry **after** optional
+            ``sd_ops`` remapping — keys must start with this and be of the
+            form ``f"{block_prefix}{idx}.{param}.lora_A.weight"``. NOTE this
+            is NOT necessarily the streamer's model-weight prefix:
+            ``LTXV_LORA_COMFY_RENAMING_MAP`` produces ``transformer_blocks.``
+            (no ``transformer.``), so callers using that map must pass
+            ``LTXV_LORA_BLOCK_PREFIX``, not the ``transformer.``-prefixed
+            ``BlockStreamer`` prefix. Mixing them silently drops every delta (#52).
         strength: LoRA fusion strength (default 1.0).
         sd_ops: Optional :class:`SDOps` to remap raw safetensors keys
             (e.g. ComfyUI/diffusers → MLX naming via

--- a/packages/ltx-core-mlx/src/ltx_core_mlx/loader/sd_ops.py
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/loader/sd_ops.py
@@ -146,6 +146,18 @@ LTXV_LORA_COMFY_RENAMING_MAP = (
     .with_replacement("audio_ff.net.2.", "audio_ff.proj_out.")
 )
 
+# Block-key prefix that ``LTXV_LORA_COMFY_RENAMING_MAP`` produces.
+#
+# The map strips ``diffusion_model.`` but never adds ``transformer.``, so a
+# renamed key is ``transformer_blocks.N.<param>.lora_{A,B}.weight``. The
+# streaming LoRA path (``BlockLoraSource``) keeps a delta only if its renamed
+# key starts with the ``block_prefix`` it is given — so every streaming call
+# site MUST pass this constant, not the ``transformer.``-prefixed model-weight
+# prefix used by ``BlockStreamer`` (whose keys come from ``transformer.safetensors``
+# and genuinely carry the ``transformer.`` prefix). Mixing the two silently
+# drops every delta, making the LoRA a no-op (#52).
+LTXV_LORA_BLOCK_PREFIX = "transformer_blocks."
+
 LTXV_LORA_COMFY_TARGET_MAP = (
     SDOps("LTXV_LORA_COMFY_TARGET_MAP")
     .with_matching()

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/_base.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/_base.py
@@ -302,7 +302,10 @@ class BasePipeline:
 
             if self.low_ram_streaming:
                 from ltx_core_mlx.loader.block_streaming import BlockLoraSource
-                from ltx_core_mlx.loader.sd_ops import LTXV_LORA_COMFY_RENAMING_MAP
+                from ltx_core_mlx.loader.sd_ops import (
+                    LTXV_LORA_BLOCK_PREFIX,
+                    LTXV_LORA_COMFY_RENAMING_MAP,
+                )
                 from ltx_pipelines_mlx.utils._orchestration import load_transformer as _load_impl
                 from ltx_pipelines_mlx.utils._orchestration import resolve_lora_path
 
@@ -313,7 +316,7 @@ class BasePipeline:
                     sources.append(
                         BlockLoraSource(
                             resolved,
-                            block_prefix="transformer.transformer_blocks.",
+                            block_prefix=LTXV_LORA_BLOCK_PREFIX,
                             strength=strength,
                             sd_ops=LTXV_LORA_COMFY_RENAMING_MAP,
                         )

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ic_lora.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ic_lora.py
@@ -20,6 +20,7 @@ import mlx.core as mx
 
 from ltx_core_mlx.components.patchifiers import compute_video_latent_shape
 from ltx_core_mlx.loader import (
+    LTXV_LORA_BLOCK_PREFIX,
     LTXV_LORA_COMFY_RENAMING_MAP,
     LoraStateDictWithStrength,
     SafetensorsStateDictLoader,
@@ -156,7 +157,7 @@ class ICLoraPipeline(BasePipeline):
                 sources.append(
                     BlockLoraSource(
                         lora_path,
-                        block_prefix="transformer.transformer_blocks.",
+                        block_prefix=LTXV_LORA_BLOCK_PREFIX,
                         strength=strength,
                         sd_ops=LTXV_LORA_COMFY_RENAMING_MAP,
                     )

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ti2vid_two_stages.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ti2vid_two_stages.py
@@ -186,7 +186,10 @@ class TI2VidTwoStagesPipeline(BasePipeline):
           Slower per bind but supports arbitrary LoRA strength.
         """
         from ltx_core_mlx.loader.block_streaming import BlockLoraSource, BlockStreamer
-        from ltx_core_mlx.loader.sd_ops import LTXV_LORA_COMFY_RENAMING_MAP
+        from ltx_core_mlx.loader.sd_ops import (
+            LTXV_LORA_BLOCK_PREFIX,
+            LTXV_LORA_COMFY_RENAMING_MAP,
+        )
 
         if abs(self._distilled_lora_strength - 1.0) <= 1e-6:
             distilled_path = self._resolve_safetensors(self.model_dir, "transformer-distilled")
@@ -214,7 +217,7 @@ class TI2VidTwoStagesPipeline(BasePipeline):
             )
         lora_source = BlockLoraSource(
             lora_path,
-            block_prefix="transformer.transformer_blocks.",
+            block_prefix=LTXV_LORA_BLOCK_PREFIX,
             strength=self._distilled_lora_strength,
             sd_ops=LTXV_LORA_COMFY_RENAMING_MAP,
         )

--- a/tests/test_block_streaming.py
+++ b/tests/test_block_streaming.py
@@ -307,3 +307,48 @@ class TestBlockLoraSource:
             assert mx.array_equal(shared.attn1.to_q.weight, ref_q1).item()
             streamer.close()
             lora.close()
+
+    def test_comfy_renamed_lora_matches_pipeline_prefix(self):
+        """Regression for #52: a ComfyUI/diffusers-named LoRA remapped via
+        ``LTXV_LORA_COMFY_RENAMING_MAP`` must match blocks under the prefix
+        the pipelines hand to ``BlockLoraSource``.
+
+        The map strips ``diffusion_model.`` but never adds ``transformer.``,
+        so the streaming call sites must use ``LTXV_LORA_BLOCK_PREFIX``
+        (``"transformer_blocks."``). Passing ``"transformer.transformer_blocks."``
+        silently drops every delta — output is byte-identical to no-LoRA.
+        """
+        from ltx_core_mlx.loader.block_streaming import BlockLoraSource
+        from ltx_core_mlx.loader.sd_ops import (
+            LTXV_LORA_BLOCK_PREFIX,
+            LTXV_LORA_COMFY_RENAMING_MAP,
+        )
+
+        cfg = _tiny_config(num_layers=2)
+        ref_model = LTXModel(cfg)
+        mx.eval(ref_model.parameters())
+
+        with tempfile.TemporaryDirectory() as td:
+            lora_path = Path(td) / "comfy_lora.safetensors"
+            # ComfyUI/diffusers naming, as a trainer- or Lightricks-produced
+            # LoRA actually ships it on disk.
+            self._build_synthetic_lora(ref_model, lora_path, prefix="diffusion_model.transformer_blocks.")
+
+            # The map output namespace must equal the prefix constant the
+            # pipelines pass. This is the single source of truth the three
+            # call sites (_base, ic_lora, ti2vid_two_stages) reference.
+            renamed = LTXV_LORA_COMFY_RENAMING_MAP.apply_to_key(
+                "diffusion_model.transformer_blocks.0.attn1.to_q.lora_A.weight"
+            )
+            assert renamed.startswith(LTXV_LORA_BLOCK_PREFIX)
+
+            lora = BlockLoraSource(
+                lora_path,
+                block_prefix=LTXV_LORA_BLOCK_PREFIX,
+                strength=1.0,
+                sd_ops=LTXV_LORA_COMFY_RENAMING_MAP,
+            )
+            assert lora.has_block(0), (
+                "ComfyUI-renamed LoRA produced zero matched deltas — the streaming LoRA path is silently a no-op (#52)."
+            )
+            lora.close()

--- a/tests/test_pending_loras_dispatch.py
+++ b/tests/test_pending_loras_dispatch.py
@@ -17,7 +17,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from ltx_core_mlx.loader.sd_ops import LTXV_LORA_COMFY_RENAMING_MAP
+from ltx_core_mlx.loader.sd_ops import LTXV_LORA_BLOCK_PREFIX, LTXV_LORA_COMFY_RENAMING_MAP
 from ltx_pipelines_mlx._base import BasePipeline
 
 
@@ -109,7 +109,7 @@ def test_pending_loras_with_streaming_attaches_lora_sources(pipeline_stub):
     orch_load.assert_called_once_with(Path("/fake/transformer.safetensors"), low_ram_streaming=True)
     BlockLoraSource_cls.assert_called_once_with(
         "/fake/lora.safetensors",
-        block_prefix="transformer.transformer_blocks.",
+        block_prefix=LTXV_LORA_BLOCK_PREFIX,
         strength=1.0,
         sd_ops=LTXV_LORA_COMFY_RENAMING_MAP,
     )
@@ -154,7 +154,7 @@ def test_pending_loras_with_streaming_multi_lora(pipeline_stub, loras):
     for (path, strength), _mock_source in zip(loras, mock_sources):
         BlockLoraSource_cls.assert_any_call(
             path,
-            block_prefix="transformer.transformer_blocks.",
+            block_prefix=LTXV_LORA_BLOCK_PREFIX,
             strength=strength,
             sd_ops=LTXV_LORA_COMFY_RENAMING_MAP,
         )


### PR DESCRIPTION
Closes #52.

## Problem

In `low_ram_streaming` mode, **every LoRA was silently dropped** — generation output was byte-identical to no-LoRA, while the non-streaming path fused the same LoRA correctly.

The three `BlockLoraSource` call sites passed `block_prefix="transformer.transformer_blocks."`, but `LTXV_LORA_COMFY_RENAMING_MAP` only strips `diffusion_model.` and never adds `transformer.`. So a renamed key is `transformer_blocks.N.<param>.lora_{A,B}.weight` and **no delta ever matched the prefix** → all deltas skipped (`block_streaming.py`: `if not model_key.startswith(block_prefix): continue`).

Direct repro:

```
OLD prefix  has_block(0): False   <- the silent no-op
NEW prefix  has_block(0): True    <- fixed
```

## Fix (single source of truth)

Rather than three magic strings that can drift, introduce `LTXV_LORA_BLOCK_PREFIX = "transformer_blocks."` next to the renaming map — it documents and couples *the namespace the map produces* in one place. All three streaming sites route through it:

- `_base.py` — community `--lora` on `generate` modes (`_pending_loras`)
- `ti2vid_two_stages.py` — distilled-LoRA stage-2 fusion at custom strength
- `ic_lora.py` — IC-LoRA control LoRAs

The `BlockStreamer` model-weight prefix (genuinely `transformer.`-prefixed, from `transformer.safetensors`) is **left untouched**.

## Coverage — all LoRA-bearing pipelines

There are only **3 distinct streaming LoRA paths**; every pipeline inherits one of them:

| Funnel | Site | Inherited by |
|---|---|---|
| `_pending_loras` | `_base.py` | one-stage, two-stage, hq, distilled |
| `_swap_to_distilled_streamer` | `ti2vid_two_stages.py` | two-stages-hq, keyframe, a2v, distilled, one-stage |
| `_fuse_loras` | `ic_lora.py` | ic-lora, hdr-ic-lora, lipdub |

`retake`/`extend` don't expose LoRA. Non-streaming paths were already correct.

## Tests

- New regression test (`test_comfy_renamed_lora_matches_pipeline_prefix`): runs a ComfyUI-named LoRA through the renaming map + prefix constant, asserts `has_block(0)` — False under the old literal, True under the constant. This is the silent-no-op class that bit us in #16/#19, so it gets a contract test rather than just the one-char change.
- Fixed two existing dispatch tests that had **codified the buggy prefix**.
- Corrected the misleading `BlockLoraSource` docstring example.
- 32/32 LoRA + streaming tests pass; ruff clean.

## Validation note

No real `--low-ram --lora` generate was run in this environment (no weights/GPU). A Δ-pixel end-to-end check on one funnel (e.g. `generate --lora … --low-ram`) is worth running before merge — the three funnels now share the same constant, so one suffices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)