### PR TITLE
Add missing parameter to combined_image_conditionings.

### DIFF
--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/a2vid_two_stage.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/a2vid_two_stage.py
@@ -210,6 +210,7 @@ class A2VidPipelineTwoStage(TI2VidTwoStagesPipeline):
                     enc_w=enc_w_half,
                     spatial_dims=(F, H_half, W_half),
                     video_encoder=encoder,
+                    frame_rate=frame_rate
                 )
                 mx.synchronize()
                 return conds
@@ -289,6 +290,7 @@ class A2VidPipelineTwoStage(TI2VidTwoStagesPipeline):
                     enc_w=enc_w_full,
                     spatial_dims=(F, H_full, W_full),
                     video_encoder=encoder,
+                    frame_rate=frame_rate
                 )
             return v_up_renorm, conds
 

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/lipdub.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/lipdub.py
@@ -195,6 +195,7 @@ class LipDubPipeline(ICLoraPipeline):
                     enc_w=W_half * 32,
                     spatial_dims=(F, H_half, W_half),
                     video_encoder=self.vae_encoder,
+                    frame_rate=frame_rate
                 )
             )
         append_ic_lora_reference_video_conditionings(
@@ -278,6 +279,7 @@ class LipDubPipeline(ICLoraPipeline):
                     enc_w=enc_w_full,
                     spatial_dims=(F, H_full, W_full),
                     video_encoder=self.vae_encoder,
+                    frame_rate=frame_rate
                 )
             )
         append_ic_lora_reference_video_conditionings(


### PR DESCRIPTION
This should fix some of the pipelines like a2v which currently break when passing an image.