### PR TITLE
style: fix ruff format on combined_image_conditionings calls

### DIFF
--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/a2vid_two_stage.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/a2vid_two_stage.py
@@ -210,7 +210,7 @@ class A2VidPipelineTwoStage(TI2VidTwoStagesPipeline):
                     enc_w=enc_w_half,
                     spatial_dims=(F, H_half, W_half),
                     video_encoder=encoder,
-                    frame_rate=frame_rate
+                    frame_rate=frame_rate,
                 )
                 mx.synchronize()
                 return conds
@@ -290,7 +290,7 @@ class A2VidPipelineTwoStage(TI2VidTwoStagesPipeline):
                     enc_w=enc_w_full,
                     spatial_dims=(F, H_full, W_full),
                     video_encoder=encoder,
-                    frame_rate=frame_rate
+                    frame_rate=frame_rate,
                 )
             return v_up_renorm, conds
 

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/lipdub.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/lipdub.py
@@ -195,7 +195,7 @@ class LipDubPipeline(ICLoraPipeline):
                     enc_w=W_half * 32,
                     spatial_dims=(F, H_half, W_half),
                     video_encoder=self.vae_encoder,
-                    frame_rate=frame_rate
+                    frame_rate=frame_rate,
                 )
             )
         append_ic_lora_reference_video_conditionings(
@@ -279,7 +279,7 @@ class LipDubPipeline(ICLoraPipeline):
                     enc_w=enc_w_full,
                     spatial_dims=(F, H_full, W_full),
                     video_encoder=self.vae_encoder,
-                    frame_rate=frame_rate
+                    frame_rate=frame_rate,
                 )
             )
         append_ic_lora_reference_video_conditionings(


### PR DESCRIPTION
Fixes the red `lint / format (ruff format)` CI on `main` introduced by #56.

#56 added `frame_rate=frame_rate` to four `combined_image_conditionings`
call sites without a magic trailing comma, so `ruff format --check` flagged
`a2vid_two_stage.py` and `lipdub.py`. This adds the four trailing commas.

`ruff format --check packages/ tests/` and `ruff check` both pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)