### PR TITLE
fix: do not truncate muxed video to shortest stream in VAE decode

### DIFF
--- a/packages/ltx-core-mlx/src/ltx_core_mlx/model/video_vae/video_vae.py
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/model/video_vae/video_vae.py
@@ -478,7 +478,12 @@ class VideoDecoder(nn.Module):
             "-",
         ]
         if audio_path:
-            cmd.extend(["-i", audio_path, "-c:a", "aac", "-shortest"])
+            # Do not use -shortest: the reference muxes both streams in full
+            # (ltx_pipelines.utils.media_io writes all video chunks + the entire
+            # audio waveform, no truncation). Reconstructed audio can be slightly
+            # shorter than the video, and -shortest would truncate tail frames on
+            # extend/retake.
+            cmd.extend(["-i", audio_path, "-c:a", "aac"])
         cmd.extend(["-c:v", "libx264", "-pix_fmt", "yuv420p", "-crf", "18", output_path])
 
         proc = subprocess.Popen(cmd, stdin=subprocess.PIPE, stderr=subprocess.PIPE)


### PR DESCRIPTION
Extracts the **iso-reference** half of #41 and drops the rest.

## What this does
Removes the `-shortest` ffmpeg flag from the audio mux in
`VideoDecoder.decode_and_stream`.

## Why it's correct (reference-checked)
The upstream reference (`ltx_pipelines/utils/media_io.py`) muxes **both streams
in full** — `write_video` encodes every video chunk (`_encode_chunks_threaded`)
and `_write_audio` writes the entire resampled waveform, with **no** truncation
to the shorter stream and no `-shortest` equivalent. Our `-shortest` therefore
*deviated* from upstream and truncated tail frames when the reconstructed audio
is slightly shorter than the video (visible on extend/retake). This realigns the
MLX port with the reference.

## What is intentionally NOT included
The fp32 VAE decode from #41 is **omitted**. Verified against the reference:
`ltx_core/model/video_vae/video_vae.py::forward` runs the decode in the
**weights dtype (bf16)** (`sample.to(weights_dtype)`), with no `autocast(float32)`
or `.float()` — the pipeline even labels it "bfloat16 VAE". The fp32 autocast in
the reference is confined to the **audio** vocoder, not the video VAE. Forcing
fp32 on the video decoder would be a deviation from upstream (and would risk
masking a real port bug rather than fixing one), so it is left out.

Supersedes the mux portion of #41. Credit: Jan Grohn (@JanGrohn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)