### PR TITLE
fix: support quantized transformers at any group_size (not just 64)

### DIFF
--- a/packages/ltx-core-mlx/src/ltx_core_mlx/loader/fuse_loras.py
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/loader/fuse_loras.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import mlx.core as mx
 
 from ltx_core_mlx.loader.primitives import LoraStateDictWithStrength, StateDict
+from ltx_core_mlx.utils.weights import derive_quant_params
 
 
 def apply_loras(
@@ -185,24 +186,15 @@ def _fuse_delta_with_quantized(
     scales = model_sd.sd[scales_key] if scales_key else None
     biases = model_sd.sd.get(biases_key) if biases_key else None
 
-    # Infer quantization parameters BEFORE dequantizing.
-    # MLX packs N-bit values into 32-bit ints: pack_factor = 32 / bits.
-    # For a weight (O, packed) and scales (O, num_groups):
-    #   real_features = num_groups * group_size
-    #   packed_features = real_features / pack_factor
-    # So: pack_factor = real_features / packed_features
-    #     bits = 32 / pack_factor
+    # Infer quantization parameters BEFORE dequantizing. The LoRA delta carries
+    # the true (out, in) weight shape, so the real in_features disambiguates
+    # (bits, group_size) for any group size (32/64/128) and bit width (4/8) —
+    # see derive_quant_params, the single home shared with load-time quantization.
     in_features_packed = weight.shape[-1]
     if scales is not None and scales.ndim > 1:
         num_groups = scales.shape[1]
-        # The LoRA delta carries the true (out, in) weight shape, so derive the
-        # real in_features from it rather than assuming a group size. This keeps
-        # fusion correct for any group_size (32/64/128) and bit width (4/8).
         in_features_real = deltas.shape[-1]
-        # packed cols hold in_features_real * bits / 32 values → solve for bits.
-        bits = max(2, min(8, round(32 * in_features_packed / in_features_real)))
-        # in_features_real is spread evenly across num_groups groups.
-        group_size = in_features_real // num_groups
+        bits, group_size = derive_quant_params(in_features_real, in_features_packed, num_groups)
     else:
         group_size = 64
         bits = 8

--- a/packages/ltx-core-mlx/src/ltx_core_mlx/loader/fuse_loras.py
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/loader/fuse_loras.py
@@ -195,11 +195,14 @@ def _fuse_delta_with_quantized(
     in_features_packed = weight.shape[-1]
     if scales is not None and scales.ndim > 1:
         num_groups = scales.shape[1]
-        # Try group_size=64 (default), compute real features, check consistency
-        group_size = 64
-        in_features_real = num_groups * group_size
-        pack_factor = in_features_real / in_features_packed if in_features_packed > 0 else 4
-        bits = max(2, min(8, round(32 / pack_factor)))
+        # The LoRA delta carries the true (out, in) weight shape, so derive the
+        # real in_features from it rather than assuming a group size. This keeps
+        # fusion correct for any group_size (32/64/128) and bit width (4/8).
+        in_features_real = deltas.shape[-1]
+        # packed cols hold in_features_real * bits / 32 values → solve for bits.
+        bits = max(2, min(8, round(32 * in_features_packed / in_features_real)))
+        # in_features_real is spread evenly across num_groups groups.
+        group_size = in_features_real // num_groups
     else:
         group_size = 64
         bits = 8

--- a/packages/ltx-core-mlx/src/ltx_core_mlx/utils/weights.py
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/utils/weights.py
@@ -67,6 +67,50 @@ def _detect_quantization_bits(
     return 8  # default fallback
 
 
+def derive_quant_params(
+    in_features: int,
+    packed_cols: int,
+    scales_cols: int,
+) -> tuple[int, int]:
+    """Derive ``(bits, group_size)`` from a quantized layer's true in_features.
+
+    Given the layer's real ``in_features`` (from the float weight or the LoRA
+    delta, both of which carry the unpacked shape) and the saved packed weight /
+    scales column counts:
+
+        packed_cols = in_features * bits / 32   -> bits = 32 * packed_cols / in_features
+        scales_cols = in_features / group_size  -> group_size = in_features / scales_cols
+
+    The result is validated for *exact* consistency: a stale or mis-shaped tensor
+    whose ratio merely rounds to a plausible ``bits`` is rejected here instead of
+    silently misinterpreting the weights downstream. Single home for the
+    derivation shared by load-time quantization and LoRA fusion.
+
+    Raises:
+        ValueError: if the three counts are not exactly consistent with a valid
+            MLX (bits, group_size) split.
+    """
+    if in_features <= 0 or packed_cols <= 0 or scales_cols <= 0:
+        raise ValueError(
+            "quant param derivation needs positive shapes, got "
+            f"in_features={in_features}, packed_cols={packed_cols}, scales_cols={scales_cols}"
+        )
+    bits = round(32 * packed_cols / in_features)
+    if not 2 <= bits <= 8 or packed_cols * 32 != in_features * bits:
+        raise ValueError(
+            f"packed weight cols ({packed_cols}) are not an exact bit-packing of "
+            f"in_features={in_features}: 32*{packed_cols} != {in_features}*bits for any "
+            f"bits in [2, 8] (nearest bits={bits})"
+        )
+    if in_features % scales_cols != 0:
+        raise ValueError(
+            f"in_features={in_features} is not divisible by scales cols ({scales_cols}); "
+            "cannot derive a uniform group_size"
+        )
+    group_size = in_features // scales_cols
+    return bits, group_size
+
+
 def _derive_quant_params(
     model: nn.Module,
     weights: dict[str, mx.array],
@@ -75,13 +119,11 @@ def _derive_quant_params(
     """Derive (bits, group_size) from a representative quantized layer.
 
     Cross-references the saved packed weight + scales against the model's float
-    weight, whose last dim is the true ``in_features``. Given those three:
+    weight, whose last dim is the true ``in_features``, via
+    :func:`derive_quant_params`.
 
-        packed_cols = in_features * bits / 32   -> bits = 32 * packed_cols / in_features
-        scales_cols = in_features / group_size  -> group_size = in_features / scales_cols
-
-    Returns None if no quantized layer can be matched to a model weight (falls
-    back to shape-only detection).
+    Returns None if no quantized layer can be matched to a *float* model weight
+    (falls back to shape-only detection).
     """
     from mlx.utils import tree_flatten
 
@@ -89,15 +131,18 @@ def _derive_quant_params(
     for layer in quantized_layers:
         wkey = f"{layer}.weight"
         skey = f"{layer}.scales"
-        if wkey in weights and skey in weights and wkey in model_params:
-            in_features = int(model_params[wkey].shape[-1])
-            packed_cols = int(weights[wkey].shape[-1])
-            scales_cols = int(weights[skey].shape[-1])
-            if in_features == 0 or scales_cols == 0:
-                continue
-            bits = max(2, min(8, round(32 * packed_cols / in_features)))
-            group_size = in_features // scales_cols
-            return bits, group_size
+        if wkey not in weights or skey not in weights or wkey not in model_params:
+            continue
+        # Skip layers the model already stores quantized: then ``.weight``'s last
+        # dim is the packed column count, not the true in_features, and the
+        # derivation would produce garbage. (e.g. the ic_lora re-quantization
+        # path, where the dit is quantized before fusion runs.)
+        if skey in model_params:
+            continue
+        in_features = int(model_params[wkey].shape[-1])
+        packed_cols = int(weights[wkey].shape[-1])
+        scales_cols = int(weights[skey].shape[-1])
+        return derive_quant_params(in_features, packed_cols, scales_cols)
     return None
 
 
@@ -134,12 +179,17 @@ def apply_quantization(
     # down (group_size * bits), not the split — so a g32/int4 model is
     # indistinguishable from g64/int2 without external truth. The model's float
     # weights still carry the real (out, in) shape, which disambiguates.
-    if bits is None:
-        derived = _derive_quant_params(model, weights, quantized_layers)
-        if derived is not None:
-            bits, group_size = derived
-        else:
-            bits = _detect_quantization_bits(weights, group_size)
+    #
+    # group_size is derived independently of whether an explicit ``bits`` was
+    # passed: otherwise ``bits=4`` on a g32 checkpoint would leave the default
+    # group_size=64 and fail load_weights with a shape mismatch.
+    derived = _derive_quant_params(model, weights, quantized_layers)
+    if derived is not None:
+        derived_bits, group_size = derived
+        if bits is None:
+            bits = derived_bits
+    elif bits is None:
+        bits = _detect_quantization_bits(weights, group_size)
 
     # Build class predicate: only quantize layers that have scales in the weights
     def _should_quantize(path: str, _module: nn.Module) -> bool:

--- a/packages/ltx-core-mlx/src/ltx_core_mlx/utils/weights.py
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/utils/weights.py
@@ -67,6 +67,40 @@ def _detect_quantization_bits(
     return 8  # default fallback
 
 
+def _derive_quant_params(
+    model: nn.Module,
+    weights: dict[str, mx.array],
+    quantized_layers: set[str],
+) -> tuple[int, int] | None:
+    """Derive (bits, group_size) from a representative quantized layer.
+
+    Cross-references the saved packed weight + scales against the model's float
+    weight, whose last dim is the true ``in_features``. Given those three:
+
+        packed_cols = in_features * bits / 32   -> bits = 32 * packed_cols / in_features
+        scales_cols = in_features / group_size  -> group_size = in_features / scales_cols
+
+    Returns None if no quantized layer can be matched to a model weight (falls
+    back to shape-only detection).
+    """
+    from mlx.utils import tree_flatten
+
+    model_params = dict(tree_flatten(model.parameters()))
+    for layer in quantized_layers:
+        wkey = f"{layer}.weight"
+        skey = f"{layer}.scales"
+        if wkey in weights and skey in weights and wkey in model_params:
+            in_features = int(model_params[wkey].shape[-1])
+            packed_cols = int(weights[wkey].shape[-1])
+            scales_cols = int(weights[skey].shape[-1])
+            if in_features == 0 or scales_cols == 0:
+                continue
+            bits = max(2, min(8, round(32 * packed_cols / in_features)))
+            group_size = in_features // scales_cols
+            return bits, group_size
+    return None
+
+
 def apply_quantization(
     model: nn.Module,
     weights: dict[str, mx.array],
@@ -95,8 +129,17 @@ def apply_quantization(
     if not quantized_layers:
         return
 
+    # Derive bits AND group_size from the model's true in_features. The saved
+    # tensors alone are ambiguous — packed weight cols and scales cols only pin
+    # down (group_size * bits), not the split — so a g32/int4 model is
+    # indistinguishable from g64/int2 without external truth. The model's float
+    # weights still carry the real (out, in) shape, which disambiguates.
     if bits is None:
-        bits = _detect_quantization_bits(weights, group_size)
+        derived = _derive_quant_params(model, weights, quantized_layers)
+        if derived is not None:
+            bits, group_size = derived
+        else:
+            bits = _detect_quantization_bits(weights, group_size)
 
     # Build class predicate: only quantize layers that have scales in the weights
     def _should_quantize(path: str, _module: nn.Module) -> bool:

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -230,7 +230,7 @@ class TestQuantizedLoraFusion:
     "[broadcast_shapes] Shapes (O,2*I) and (O,I) cannot be broadcast".
     """
 
-    def _quantized_model_sd(self, weight, bits, group_size):
+    def _quantized_model_sd(self, weight: mx.array, bits: int, group_size: int) -> StateDict:
         q, scales, biases = mx.quantize(weight, bits=bits, group_size=group_size)
         return StateDict(
             sd={"layer.weight": q, "layer.scales": scales, "layer.biases": biases},
@@ -238,7 +238,7 @@ class TestQuantizedLoraFusion:
             dtype=set(),
         )
 
-    def _lora(self, a, b):
+    def _lora(self, a: mx.array, b: mx.array) -> StateDict:
         return StateDict(
             sd={"layer.lora_A.weight": a, "layer.lora_B.weight": b},
             size=0,
@@ -246,7 +246,7 @@ class TestQuantizedLoraFusion:
         )
 
     @pytest.mark.parametrize(("bits", "group_size"), [(4, 32), (8, 64), (4, 64), (4, 128)])
-    def test_shapes_preserved(self, bits, group_size):
+    def test_shapes_preserved(self, bits: int, group_size: int) -> None:
         # in_features=128 (divisible by every group size under test), out=64, rank=4
         mx.random.seed(0)
         weight = mx.random.normal((64, 128))
@@ -262,7 +262,7 @@ class TestQuantizedLoraFusion:
         assert result.sd["layer.scales"].shape == orig["layer.scales"].shape
         assert result.sd["layer.biases"].shape == orig["layer.biases"].shape
 
-    def test_reconstructs_delta_g32(self):
+    def test_reconstructs_delta_g32(self) -> None:
         """Fusing into an int8/g32 weight recovers dequant(orig)+delta.
 
         Uses int8 so the quantization grid is fine enough to assert the fusion

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 
 import mlx.core as mx
+import pytest
 
 from ltx_core_mlx.loader.fuse_loras import _fuse_delta_with_float, _prepare_deltas, apply_loras
 from ltx_core_mlx.loader.primitives import LoraStateDictWithStrength, StateDict
@@ -218,6 +219,81 @@ class TestApplyLoras:
         # scales and biases should not appear as standalone entries
         # (they're handled with their weight key)
         assert "layer.weight" in result.sd
+
+
+class TestQuantizedLoraFusion:
+    """Fusing a LoRA delta into a *quantized* weight (dequant -> add -> requant).
+
+    Regression coverage for the group_size!=64 bug in
+    _fuse_delta_with_quantized: it assumed group_size=64, so fusing into an
+    int4/g32 weight dequantized to the wrong in_features and raised
+    "[broadcast_shapes] Shapes (O,2*I) and (O,I) cannot be broadcast".
+    """
+
+    def _quantized_model_sd(self, weight, bits, group_size):
+        q, scales, biases = mx.quantize(weight, bits=bits, group_size=group_size)
+        return StateDict(
+            sd={"layer.weight": q, "layer.scales": scales, "layer.biases": biases},
+            size=0,
+            dtype=set(),
+        )
+
+    def _lora(self, a, b):
+        return StateDict(
+            sd={"layer.lora_A.weight": a, "layer.lora_B.weight": b},
+            size=0,
+            dtype=set(),
+        )
+
+    @pytest.mark.parametrize(("bits", "group_size"), [(4, 32), (8, 64), (4, 64), (4, 128)])
+    def test_shapes_preserved(self, bits, group_size):
+        # in_features=128 (divisible by every group size under test), out=64, rank=4
+        mx.random.seed(0)
+        weight = mx.random.normal((64, 128))
+        model_sd = self._quantized_model_sd(weight, bits, group_size)
+        orig = dict(model_sd.sd)
+
+        a = mx.random.normal((4, 128)) * 0.01
+        b = mx.random.normal((64, 4)) * 0.01
+        result = apply_loras(model_sd, [LoraStateDictWithStrength(self._lora(a, b), 1.0)])
+
+        # The requantized outputs keep the original packed/scale shapes.
+        assert result.sd["layer.weight"].shape == orig["layer.weight"].shape
+        assert result.sd["layer.scales"].shape == orig["layer.scales"].shape
+        assert result.sd["layer.biases"].shape == orig["layer.biases"].shape
+
+    def test_reconstructs_delta_g32(self):
+        """Fusing into an int8/g32 weight recovers dequant(orig)+delta.
+
+        Uses int8 so the quantization grid is fine enough to assert the fusion
+        math (correct group_size/bits + add) rather than just shapes. With the
+        old g64 assumption this dequantized to the wrong in_features and raised.
+        """
+        mx.random.seed(1)
+        weight = mx.random.normal((64, 128))
+        model_sd = self._quantized_model_sd(weight, bits=8, group_size=32)
+        orig = mx.dequantize(
+            model_sd.sd["layer.weight"],
+            scales=model_sd.sd["layer.scales"],
+            biases=model_sd.sd["layer.biases"],
+            group_size=32,
+            bits=8,
+        )
+
+        a = mx.random.normal((4, 128)) * 0.05
+        b = mx.random.normal((64, 4)) * 0.05
+        delta = b @ a
+        result = apply_loras(model_sd, [LoraStateDictWithStrength(self._lora(a, b), 1.0)])
+
+        fused = mx.dequantize(
+            result.sd["layer.weight"],
+            scales=result.sd["layer.scales"],
+            biases=result.sd["layer.biases"],
+            group_size=32,
+            bits=8,
+        )
+        # int8 requant error is well within 0.05.
+        assert mx.allclose(fused, orig + delta, atol=0.05).item()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_quantization_params.py
+++ b/tests/test_quantization_params.py
@@ -16,7 +16,11 @@ import mlx.core as mx
 import mlx.nn as nn
 import pytest
 
-from ltx_core_mlx.utils.weights import _derive_quant_params, apply_quantization
+from ltx_core_mlx.utils.weights import (
+    _derive_quant_params,
+    apply_quantization,
+    derive_quant_params,
+)
 
 
 class TinyModel(nn.Module):
@@ -50,6 +54,33 @@ _PARAMS = [
 ]
 
 
+class TestDerivePureFunction:
+    """The shared, model-free ``derive_quant_params`` helper."""
+
+    @pytest.mark.parametrize(("bits", "group_size"), _PARAMS)
+    def test_recovers_exact_params(self, bits: int, group_size: int) -> None:
+        in_features = 128
+        packed_cols = in_features * bits // 32
+        scales_cols = in_features // group_size
+        assert derive_quant_params(in_features, packed_cols, scales_cols) == (bits, group_size)
+
+    def test_rejects_inexact_bit_packing(self) -> None:
+        # packed_cols that rounds toward bits=4 but is not an exact 32-bit packing
+        # of in_features would previously be coerced by the min/max clamp.
+        with pytest.raises(ValueError, match="exact bit-packing"):
+            derive_quant_params(in_features=128, packed_cols=17, scales_cols=4)
+
+    def test_rejects_indivisible_group_size(self) -> None:
+        # int4/g32 of in_features=128 -> packed_cols=16, but scales_cols=5 does not
+        # divide 128 evenly, so no uniform group_size exists.
+        with pytest.raises(ValueError, match="not divisible"):
+            derive_quant_params(in_features=128, packed_cols=16, scales_cols=5)
+
+    def test_rejects_nonpositive_shapes(self) -> None:
+        with pytest.raises(ValueError, match="positive shapes"):
+            derive_quant_params(in_features=0, packed_cols=16, scales_cols=4)
+
+
 class TestDeriveQuantParams:
     @pytest.mark.parametrize(("bits", "group_size"), _PARAMS)
     def test_recovers_exact_params(self, bits: int, group_size: int) -> None:
@@ -65,6 +96,21 @@ class TestDeriveQuantParams:
         # scales present but no corresponding model weight key
         weights = {"ghost.scales": mx.ones((4, 2))}
         assert _derive_quant_params(model, weights, {"ghost"}) is None
+
+    def test_skips_already_quantized_model_layer(self) -> None:
+        """A model layer that is already QuantizedLinear must be skipped.
+
+        Its ``.weight`` last dim is the packed column count, not in_features, so
+        deriving from it would yield garbage. With only such a layer available,
+        derivation finds no float reference and returns None.
+        """
+        model = TinyModel()
+        # Quantize the model in place so model.a is a QuantizedLinear.
+        weights = _quantize_model(TinyModel(), bits=4, group_size=32)
+        apply_quantization(model, weights)
+        assert isinstance(model.a, nn.QuantizedLinear)
+
+        assert _derive_quant_params(model, weights, {"a", "b"}) is None
 
 
 class TestApplyQuantization:

--- a/tests/test_quantization_params.py
+++ b/tests/test_quantization_params.py
@@ -1,0 +1,98 @@
+"""Unit tests for quantization parameter derivation and application.
+
+Self-contained (no model weights on disk): builds tiny models, quantizes them
+at various (bits, group_size) combinations, and verifies the loader rebuilds
+matching QuantizedLinear modules.
+
+Regression coverage for the group_size!=64 bug: the loader previously assumed
+group_size=64, which mis-derived bits for any other group size (e.g. an int4/
+g32 transformer was read as int2/g64) and failed at load_weights with a shape
+mismatch. See ltx_core_mlx.utils.weights._derive_quant_params.
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+import mlx.nn as nn
+import pytest
+
+from ltx_core_mlx.utils.weights import _derive_quant_params, apply_quantization
+
+
+class TinyModel(nn.Module):
+    """Two Linear layers with different in_features to exercise per-shape math."""
+
+    # in_features are divisible by every group size under test (32/64/128).
+    def __init__(self, in1: int = 128, out1: int = 64, in2: int = 256, out2: int = 128):
+        super().__init__()
+        self.a = nn.Linear(in1, out1, bias=False)
+        self.b = nn.Linear(in2, out2, bias=False)
+
+
+def _quantize_model(model: TinyModel, bits: int, group_size: int) -> dict[str, mx.array]:
+    """Produce a weights dict (packed weight + scales + biases) for each Linear."""
+    weights: dict[str, mx.array] = {}
+    for name, lin in (("a", model.a), ("b", model.b)):
+        q, scales, biases = mx.quantize(lin.weight, bits=bits, group_size=group_size)
+        weights[f"{name}.weight"] = q
+        weights[f"{name}.scales"] = scales
+        weights[f"{name}.biases"] = biases
+    return weights
+
+
+# group sizes and bit widths that must all round-trip, not just the old g64 default
+_PARAMS = [
+    pytest.param(4, 32, id="int4-g32"),
+    pytest.param(8, 64, id="int8-g64"),
+    pytest.param(4, 64, id="int4-g64"),
+    pytest.param(8, 32, id="int8-g32"),
+    pytest.param(4, 128, id="int4-g128"),
+]
+
+
+class TestDeriveQuantParams:
+    @pytest.mark.parametrize(("bits", "group_size"), _PARAMS)
+    def test_recovers_exact_params(self, bits: int, group_size: int) -> None:
+        source = TinyModel()
+        weights = _quantize_model(source, bits=bits, group_size=group_size)
+        # Fresh (float) model still carries true in_features, which disambiguates.
+        model = TinyModel()
+        derived = _derive_quant_params(model, weights, {"a", "b"})
+        assert derived == (bits, group_size)
+
+    def test_returns_none_when_no_layer_matches(self) -> None:
+        model = TinyModel()
+        # scales present but no corresponding model weight key
+        weights = {"ghost.scales": mx.ones((4, 2))}
+        assert _derive_quant_params(model, weights, {"ghost"}) is None
+
+
+class TestApplyQuantization:
+    @pytest.mark.parametrize(("bits", "group_size"), _PARAMS)
+    def test_load_weights_strict_roundtrip(self, bits: int, group_size: int) -> None:
+        """apply_quantization must build modules that strictly load the weights.
+
+        With the old hardcoded g64 assumption this raised a shape mismatch for
+        every non-g64 model (the reported int4/g32 failure).
+        """
+        source = TinyModel()
+        weights = _quantize_model(source, bits=bits, group_size=group_size)
+
+        model = TinyModel()
+        apply_quantization(model, weights)
+        # Would raise ValueError("Expected shape ... but received ...") on the bug.
+        model.load_weights(list(weights.items()), strict=True)
+
+        assert isinstance(model.a, nn.QuantizedLinear)
+        assert model.a.bits == bits
+        assert model.a.group_size == group_size
+
+    def test_no_scales_is_noop(self) -> None:
+        model = TinyModel()
+        float_weights = {
+            "a.weight": model.a.weight,
+            "b.weight": model.b.weight,
+        }
+        apply_quantization(model, float_weights)
+        assert isinstance(model.a, nn.Linear)
+        assert not isinstance(model.a, nn.QuantizedLinear)


### PR DESCRIPTION
## Summary

The runtime assumed a quantization **group size of 64** in two places, so any quantized transformer using a different group size (e.g. an **int4 / group_size 32** build) failed to load or fuse LoRAs. Both spots now derive the true `(bits, group_size)` from shapes that carry it, so any group size (32 / 64 / 128) and bit width (int4 / int8) work.

## Why the tensors alone weren't enough

For a quantized `Linear`, the saved tensors give:

- `packed_cols = in_features * bits / 32`
- `scales_cols = in_features / group_size`

That only pins down `group_size * bits`, not the split — an int4/g32 layer is indistinguishable from int2/g64 without knowing `in_features`. The fix recovers `in_features` from a shape that *does* carry it:

- **`fuse_loras._fuse_delta_with_quantized`** — the LoRA delta has the true `(out, in)` shape. Previously it assumed g64, dequantized to the wrong `in_features`, and raised `[broadcast_shapes] Shapes (O, 2*I) and (O, I) cannot be broadcast` when adding the delta.
- **`weights.apply_quantization`** — the model's float `Linear` weight still has its real `(out, in)` shape at quantize time. Previously `_detect_quantization_bits` assumed g64 and mis-derived bits (int4/g32 → int2/g64), so the rebuilt `QuantizedLinear` had the wrong packed shape and `load_weights` failed with `Expected shape ... but received shape ...`.

Fixing `apply_quantization` covers all five call sites centrally, including `--low-ram` block streaming (which reuses `apply_loras`).

## Behavior change

None for existing group_size=64 models — the derivation returns exactly `(bits, 64)` for them (covered by tests). It only *adds* support for other group sizes.

## Testing

Self-contained regression tests (no on-disk model required, so they run in CI — unlike the existing `@skip_no_weights` integration tests):

- `tests/test_quantization_params.py` — `_derive_quant_params` recovery + strict `load_weights` roundtrip across **int4/int8 × g32/g64/g128**.
- `tests/test_loader.py::TestQuantizedLoraFusion` — quantized LoRA fusion shape preservation + numeric reconstruction across group sizes.

Verified these tests **fail on the pre-fix code with the exact production errors** (`[broadcast_shapes]` and the `load_weights` shape mismatch) while the g64 cases stay green, then pass once the fixes are applied. Full suite: **545 passed, 22 skipped**.

## Motivation

Surfaced converting a distilled LTX-2.3 transformer to **int4 / group_size 32** (int4 benefits from the smaller group size) for a quality-vs-int8 comparison. Nothing published used a non-64 group size, so the assumption had gone unnoticed and untested.
