### PR TITLE
feat: Prompt Relay temporal prompt gating

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Pure MLX port of [LTX-2](https://github.com/Lightricks/LTX-2) for Apple Silicon.
 - **LipDub** *(experimental)* — lip-dub a reference video by re-syncing visuals to the source audio
 - **Two-stage generation** — half-res → neural upscale → refine
 - **HQ generation** — res_2s second-order sampler + CFG/STG guidance
+- **Prompt Relay** — sequence local prompts over time within one generation (`--segment "text" [LEN]`); a training-free Gaussian penalty gates each prompt's tokens to a slice of the timeline via the video→text cross-attention. Works across all generate modes; on CFG modes the mask applies to the conditional pass only.
 - **Prompt enhancement** — Gemma 3 12B rewrites short prompts into detailed descriptions
 - **Training** — LoRA fine-tuning with flow matching (T2V and V2V strategies)
 - **Block streaming (`--low-ram`)** — stream transformer blocks from disk so q8 fits 16 GB Macs and bf16 fits 32 GB Macs (covers generate / `--two-stage` / `--two-stages-hq` / a2v / keyframe / ic-lora; bind-time LoRA fusion supports custom distilled-lora-strength)

--- a/packages/ltx-core-mlx/src/ltx_core_mlx/conditioning/prompt_relay.py
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/conditioning/prompt_relay.py
@@ -64,6 +64,7 @@ def map_token_ranges(
     tokenizer,
     global_prompt: str,
     local_prompts: list[str],
+    max_length: int | None = None,
 ) -> tuple[str, list[tuple[int, int]]]:
     """Build the combined prompt and each local prompt's ``[start, end)`` token range.
 
@@ -75,6 +76,10 @@ def map_token_ranges(
         tokenizer: mlx-lm tokenizer (``pipe.prompt_encoder._text_encoder._tokenizer``).
         global_prompt: Prompt applied to every frame.
         local_prompts: Ordered per-segment prompts, gated to their time windows.
+        max_length: Encoder sequence limit (``LTX2_GEMMA_MAX_LENGTH``). When set,
+            a combined prompt exceeding it is rejected: the encoder left-truncates
+            (keeps the last ``max_length`` tokens), which shifts every column and
+            makes the ranges point at the wrong tokens — unrecoverable, so fail fast.
 
     Returns:
         ``(combined_prompt, token_ranges)`` where ``combined_prompt`` is what the
@@ -106,6 +111,13 @@ def map_token_ranges(
         token_ranges.append((prev_len, cur_len))
         prev_len = cur_len
 
+    if max_length is not None and len(tokenizer.encode(combined_prompt)) > max_length:
+        raise ValueError(
+            f"Prompt Relay combined prompt exceeds the encoder max length "
+            f"({max_length}); the encoder left-truncates, which would misalign "
+            "every segment's token range. Shorten the prompts/segments or raise "
+            "LTX2_GEMMA_MAX_LENGTH."
+        )
     return combined_prompt, token_ranges
 
 
@@ -159,7 +171,9 @@ def _build_segments(
         if length <= 0:
             frame_cursor += length
             continue
-        midpoint = (2 * frame_cursor + length) / 2.0
+        # Floor-divide to match the reference (WhatDreamsCost build_segments):
+        # an odd-length segment keeps one fully-free anchor frame at its center.
+        midpoint = float((2 * frame_cursor + length) // 2)
         window = max(length // 2 - 2, 0)
         segments.append(
             _Segment(
@@ -207,7 +221,27 @@ def build_relay_mask(
         where a text range is penalised for a video frame outside its window.
     """
     # Reference uses a constant sigma = 1/ln(1/epsilon) regardless of segment length.
-    sigma = 1.0 / math.log(1.0 / epsilon) if 0.0 < epsilon < 1.0 else 0.1448
+    # Reject out-of-range epsilon rather than silently substituting a default: e.g.
+    # epsilon=1.0 means "no falloff" (sigma -> inf) but a fallback would produce the
+    # opposite (sharp default gating).
+    if not 0.0 < epsilon < 1.0:
+        raise ValueError(f"Prompt Relay epsilon must be in (0, 1), got {epsilon}")
+    sigma = 1.0 / math.log(1.0 / epsilon)
+    # A zero-length beat has no temporal window; leaving its columns at cost 0 would
+    # let it attend to *every* frame — the inverse of gating. Fail fast instead.
+    if any(length <= 0 for length in segment_lengths):
+        raise ValueError(
+            f"Prompt Relay segment lengths {segment_lengths} contain a zero-length "
+            "beat: that segment would attend to every frame instead of being gated. "
+            "Give it an explicit length or drop a segment."
+        )
+    # numpy silently clips out-of-bounds column slices, which would ungate a segment
+    # without warning. Reject ranges past the text axis.
+    if any(end > num_text_tokens for _, end in token_ranges):
+        raise ValueError(
+            f"Prompt Relay token ranges {token_ranges} exceed the text axis "
+            f"(num_text_tokens={num_text_tokens})"
+        )
     segments = _build_segments(token_ranges, segment_lengths, strength)
     cost = np.zeros((num_video_tokens, num_text_tokens), dtype=np.float32)
 

--- a/packages/ltx-core-mlx/src/ltx_core_mlx/conditioning/prompt_relay.py
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/conditioning/prompt_relay.py
@@ -1,0 +1,236 @@
+"""Prompt Relay: temporal cross-attention biasing for LTX-2.
+
+A training-free technique (https://gordonchen19.github.io/Prompt-Relay/) that lets
+a single generation follow a *sequence* of local prompts over time. A global prompt
+is concatenated with N space-separated local prompts; each local prompt's text-token
+range is softly gated — via an additive Gaussian penalty on the video↔text
+cross-attention (``attn2``) — so it only influences the video frames inside its own
+temporal window. Global-prompt tokens (and the connector's register/padding tokens)
+receive zero penalty and attend freely across all frames.
+
+Ported from Kijai/WhatDreamsCost's ComfyUI ``prompt_relay.py``. This module only
+covers the **video** integer-frame path (audio's scaled non-integer-frame path is a
+follow-on). The output is an additive bias of shape ``(1, 1, Nv, Nk)`` suitable for
+``mx.fast.scaled_dot_product_attention(..., mask=...)``.
+
+Token→position note: the Gemma feature connector front-packs valid tokens to the
+front of the ``Nk``-length sequence (see ``text_encoders/gemma`` embeddings
+connector), so text token *i* (in encode order) lives at sequence position *i*.
+Ranges here are therefore computed by incremental tokenization of the combined
+prompt and used directly as column indices into the ``Nk`` axis.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+import mlx.core as mx
+import numpy as np
+
+
+@dataclass
+class PromptRelayInput:
+    """User-facing Prompt Relay request carried through the pipeline.
+
+    Attributes:
+        local_prompts: Ordered per-segment prompts (concatenated after the global
+            ``--prompt`` to form the combined prompt that is actually encoded).
+        segment_lengths: Optional per-segment length in *latent* frames. ``None``
+            auto-distributes evenly across the timeline. Length, if given, must
+            match ``local_prompts``.
+        epsilon: Plateau→penalty falloff (smaller = sharper temporal gating).
+        strength: Global multiplier on the penalty magnitude.
+    """
+
+    local_prompts: list[str]
+    segment_lengths: list[int | None] | None = None
+    epsilon: float = 1e-3
+    strength: float = 1.0
+
+
+@dataclass
+class _Segment:
+    """Per-local-prompt metadata for the temporal penalty."""
+
+    tok_start: int
+    tok_end: int
+    midpoint: float  # in latent-frame units
+    window: float  # half-width of the zero-penalty plateau, in latent frames
+    strength: float
+
+
+def map_token_ranges(
+    tokenizer,
+    global_prompt: str,
+    local_prompts: list[str],
+) -> tuple[str, list[tuple[int, int]]]:
+    """Build the combined prompt and each local prompt's ``[start, end)`` token range.
+
+    Uses incremental tokenization (measuring cumulative prefixes) to sidestep
+    SentencePiece context-dependency, mirroring the reference implementation.
+    The tokenizer is an mlx-lm tokenizer whose ``.encode()`` returns a token-id list.
+
+    Args:
+        tokenizer: mlx-lm tokenizer (``pipe.prompt_encoder._text_encoder._tokenizer``).
+        global_prompt: Prompt applied to every frame.
+        local_prompts: Ordered per-segment prompts, gated to their time windows.
+
+    Returns:
+        ``(combined_prompt, token_ranges)`` where ``combined_prompt`` is what the
+        pipeline must actually encode, and ``token_ranges[i]`` is the half-open
+        column range of ``local_prompts[i]`` in the front-packed text axis.
+    """
+    prefixed_locals = [" " + lp for lp in local_prompts]
+    combined_prompt = global_prompt + "".join(prefixed_locals)
+
+    # Detect whether encode() appends an EOS so we can strip its phantom offset
+    # from cumulative counts (else every local range would shift by +1).
+    eos_adj = 0
+    probe = tokenizer.encode("test")
+    eos_id = getattr(tokenizer, "eos_token_id", None)
+    if probe and ((eos_id is not None and probe[-1] == eos_id) or probe[-1] == 1):
+        eos_adj = 1
+
+    def enc_len(text: str) -> int:
+        return len(tokenizer.encode(text.strip())) - eos_adj
+
+    prev_len = enc_len(global_prompt)
+    token_ranges: list[tuple[int, int]] = []
+    built = global_prompt
+    for plp in prefixed_locals:
+        built += plp
+        cur_len = enc_len(built)
+        if cur_len <= prev_len:
+            raise ValueError(f"Local prompt produced no tokens: '{plp.strip()}'")
+        token_ranges.append((prev_len, cur_len))
+        prev_len = cur_len
+
+    return combined_prompt, token_ranges
+
+
+def distribute_segment_lengths(
+    num_segments: int,
+    latent_frames: int,
+    specified_lengths: list[int | None] | None = None,
+) -> list[int]:
+    """Validate or auto-distribute per-segment lengths (in latent frames).
+
+    ``specified_lengths`` may be ``None`` (all beats auto → even ceil split) or a list
+    matching ``num_segments`` where each entry is either a pinned length or ``None``
+    (auto). Pinned beats keep their length; the leftover timeline is spread evenly across
+    the ``None`` beats. Lengths are then clamped so the running sum never exceeds
+    ``latent_frames``.
+    """
+    if specified_lengths is None:
+        step = -(-latent_frames // num_segments)  # ceil division
+        lengths = [step] * num_segments
+    else:
+        if len(specified_lengths) != num_segments:
+            raise ValueError(
+                f"segment length count ({len(specified_lengths)}) must match number of local prompts ({num_segments})"
+            )
+        auto_idx = [i for i, length in enumerate(specified_lengths) if length is None]
+        if auto_idx:
+            pinned_total = sum(length for length in specified_lengths if length is not None)
+            remaining = max(latent_frames - pinned_total, 0)
+            per_auto = -(-remaining // len(auto_idx)) if remaining > 0 else 0  # ceil split
+            lengths = [per_auto if length is None else length for length in specified_lengths]
+        else:
+            lengths = [int(length) for length in specified_lengths]
+
+    effective: list[int] = []
+    cursor = 0
+    for length in lengths:
+        end = min(cursor + length, latent_frames)
+        effective.append(max(end - cursor, 0))
+        cursor = end
+    return effective
+
+
+def _build_segments(
+    token_ranges: list[tuple[int, int]],
+    segment_lengths: list[int],
+    strength: float,
+) -> list[_Segment]:
+    segments: list[_Segment] = []
+    frame_cursor = 0
+    for (tok_start, tok_end), length in zip(token_ranges, segment_lengths):
+        if length <= 0:
+            frame_cursor += length
+            continue
+        midpoint = (2 * frame_cursor + length) / 2.0
+        window = max(length // 2 - 2, 0)
+        segments.append(
+            _Segment(
+                tok_start=tok_start,
+                tok_end=tok_end,
+                midpoint=midpoint,
+                window=float(window),
+                strength=strength,
+            )
+        )
+        frame_cursor += length
+    return segments
+
+
+def build_relay_mask(
+    token_ranges: list[tuple[int, int]],
+    segment_lengths: list[int],
+    num_video_tokens: int,
+    tokens_per_frame: int,
+    latent_frames: int,
+    num_text_tokens: int,
+    epsilon: float = 1e-3,
+    strength: float = 1.0,
+    dtype: mx.Dtype = mx.bfloat16,
+) -> mx.array:
+    """Build the additive Prompt Relay cross-attention bias.
+
+    Args:
+        token_ranges: Per-segment ``[start, end)`` column ranges (from
+            :func:`map_token_ranges`).
+        segment_lengths: Per-segment length in latent frames (from
+            :func:`distribute_segment_lengths`).
+        num_video_tokens: Actual video token count ``Nv`` at attention time. May
+            exceed ``latent_frames * tokens_per_frame`` when keyframe conditioning
+            appends tokens — those trailing rows receive zero penalty.
+        tokens_per_frame: Video tokens per latent frame (``H*W`` of the latent grid).
+        latent_frames: Number of latent frames ``F``.
+        num_text_tokens: Text sequence length ``Nk`` (e.g. ``LTX2_GEMMA_MAX_LENGTH``).
+        epsilon: Controls plateau→penalty falloff (smaller = sharper gating).
+        strength: Global multiplier on the penalty magnitude.
+        dtype: Output dtype (model runs bf16).
+
+    Returns:
+        Additive bias ``(1, 1, Nv, Nk)`` — ``0`` where attention is free, negative
+        where a text range is penalised for a video frame outside its window.
+    """
+    # Reference uses a constant sigma = 1/ln(1/epsilon) regardless of segment length.
+    sigma = 1.0 / math.log(1.0 / epsilon) if 0.0 < epsilon < 1.0 else 0.1448
+    segments = _build_segments(token_ranges, segment_lengths, strength)
+    cost = np.zeros((num_video_tokens, num_text_tokens), dtype=np.float32)
+
+    rows = np.arange(num_video_tokens)
+    query_frames = (rows // tokens_per_frame).astype(np.float32)
+    # Only the first F*tokens_per_frame rows map to real frames; appended keyframe
+    # tokens (if any) sit beyond that and must attend freely.
+    real = rows < latent_frames * tokens_per_frame
+
+    inv_two_sigma_sq = 1.0 / (2.0 * sigma * sigma)
+    for seg in segments:
+        d = np.abs(query_frames - seg.midpoint)
+        penalty = seg.strength * np.square(np.maximum(d - seg.window, 0.0)) * inv_two_sigma_sq
+        penalty = np.where(real, penalty, 0.0).astype(np.float32)
+        cost[:, seg.tok_start : seg.tok_end] = penalty[:, None]
+
+    mask = -cost  # additive negative bias
+    return mx.array(mask, dtype=dtype)[None, None, :, :]
+
+
+__all__ = [
+    "PromptRelayInput",
+    "build_relay_mask",
+    "distribute_segment_lengths",
+    "map_token_ranges",
+]

--- a/packages/ltx-core-mlx/src/ltx_core_mlx/conditioning/prompt_relay.py
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/conditioning/prompt_relay.py
@@ -239,8 +239,7 @@ def build_relay_mask(
     # without warning. Reject ranges past the text axis.
     if any(end > num_text_tokens for _, end in token_ranges):
         raise ValueError(
-            f"Prompt Relay token ranges {token_ranges} exceed the text axis "
-            f"(num_text_tokens={num_text_tokens})"
+            f"Prompt Relay token ranges {token_ranges} exceed the text axis (num_text_tokens={num_text_tokens})"
         )
     segments = _build_segments(token_ranges, segment_lengths, strength)
     cost = np.zeros((num_video_tokens, num_text_tokens), dtype=np.float32)

--- a/packages/ltx-core-mlx/src/ltx_core_mlx/model/transformer/model.py
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/model/transformer/model.py
@@ -324,6 +324,7 @@ class LTXModel(nn.Module):
         audio_positions: mx.array | None = None,
         video_attention_mask: mx.array | None = None,
         audio_attention_mask: mx.array | None = None,
+        video_cross_attention_mask: mx.array | None = None,
         video_timesteps: mx.array | None = None,
         audio_timesteps: mx.array | None = None,
         perturbations: BatchedPerturbationConfig | None = None,
@@ -343,6 +344,9 @@ class LTXModel(nn.Module):
             audio_positions: (B, Na, num_axes) -- positions for RoPE.
             video_attention_mask: Optional mask for video attention.
             audio_attention_mask: Optional mask for audio attention.
+            video_cross_attention_mask: Optional additive bias for the video→text
+                cross-attention (Prompt Relay temporal prompt gating). Same array
+                is broadcast to every block.
             video_timesteps: Optional (B, Nv) per-token timesteps for video.
                 When provided, AdaLN parameters are computed per-token instead
                 of per-batch, enabling preserved tokens (mask=0) to receive
@@ -509,6 +513,7 @@ class LTXModel(nn.Module):
                             audio_cross_rope_freqs=audio_cross_rope_freqs,
                             video_attention_mask=video_attention_mask,
                             audio_attention_mask=audio_attention_mask,
+                            video_cross_attention_mask=video_cross_attention_mask,
                             perturbations=perturbations,
                             block_idx=_bidx,
                         )
@@ -537,6 +542,7 @@ class LTXModel(nn.Module):
                     audio_cross_rope_freqs=audio_cross_rope_freqs,
                     video_attention_mask=video_attention_mask,
                     audio_attention_mask=audio_attention_mask,
+                    video_cross_attention_mask=video_cross_attention_mask,
                     perturbations=perturbations,
                     block_idx=block_idx,
                 )

--- a/packages/ltx-core-mlx/src/ltx_core_mlx/model/transformer/transformer.py
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/model/transformer/transformer.py
@@ -224,6 +224,7 @@ class BasicAVTransformerBlock(nn.Module):
         audio_cross_rope_freqs: mx.array | None = None,
         video_attention_mask: mx.array | None = None,
         audio_attention_mask: mx.array | None = None,
+        video_cross_attention_mask: mx.array | None = None,
         perturbations: BatchedPerturbationConfig | None = None,
         block_idx: int = 0,
     ) -> tuple[mx.array, mx.array]:
@@ -246,6 +247,8 @@ class BasicAVTransformerBlock(nn.Module):
             audio_rope_freqs: RoPE frequencies for audio.
             video_attention_mask: Attention mask for video self-attention.
             audio_attention_mask: Attention mask for audio self-attention.
+            video_cross_attention_mask: Optional additive bias (broadcastable to
+                (B, 1, Nv, Nt)) for the video→text cross-attention (Prompt Relay).
             perturbations: Optional perturbation config for STG guidance.
                 When provided, generates masks that zero out attention outputs
                 for perturbed samples in the batch.
@@ -323,7 +326,15 @@ class BasicAVTransformerBlock(nn.Module):
             video_normed = self._rms_norm(video_hidden) * (1.0 + v_scale_ca) + v_shift_ca
             vp_shift, vp_scale = self._unpack_adaln(video_prompt_adaln_params, self.prompt_scale_shift_table, 2, vdim)
             text_scaled = video_text_embeds * (1.0 + vp_scale) + vp_shift
-            video_hidden = video_hidden + self.attn2(video_normed, encoder_hidden_states=text_scaled) * v_gate_ca
+            video_hidden = (
+                video_hidden
+                + self.attn2(
+                    video_normed,
+                    encoder_hidden_states=text_scaled,
+                    attention_mask=video_cross_attention_mask,
+                )
+                * v_gate_ca
+            )
 
         # --- 4. Audio text cross-attention ---
         if audio_text_embeds is not None:

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/_base.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/_base.py
@@ -10,7 +10,9 @@ Lightricks/LTX-2 design where each pipeline file owns its API.
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import mlx.core as mx
 
@@ -26,6 +28,11 @@ from ltx_core_mlx.utils.memory import aggressive_cleanup
 from ltx_core_mlx.utils.weights import apply_quantization, load_split_safetensors
 from ltx_pipelines_mlx.utils.constants import DEFAULT_NEGATIVE_PROMPT
 from ltx_pipelines_mlx.utils.progress import phase
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from ltx_core_mlx.conditioning.prompt_relay import PromptRelayInput
 
 
 class BasePipeline:
@@ -429,12 +436,14 @@ class BasePipeline:
     # Prompt Relay (temporal cross-attention prompt gating)
     # ------------------------------------------------------------------
 
-    def _prompt_relay_setup(self, prompt: str, prompt_relay):
+    def _prompt_relay_setup(
+        self, prompt: str, prompt_relay: PromptRelayInput | None
+    ) -> tuple[str, list[tuple[int, int]] | None]:
         """Resolve the prompt actually encoded + per-segment token ranges.
 
         With Prompt Relay active, the encoded (positive) prompt is the global
         prompt followed by the space-joined local prompts; the returned token
-        ranges index those locals for :meth:`_prompt_relay_mask`. Returns
+        ranges index those locals for :meth:`_prompt_relay_mask_builder`. Returns
         ``(prompt, None)`` when Prompt Relay is off.
         """
         if prompt_relay is None:
@@ -448,44 +457,51 @@ class BasePipeline:
 
         self._load_text_encoder()
         tokenizer = self.text_encoder._tokenizer
-        return map_token_ranges(tokenizer, prompt, prompt_relay.local_prompts)
+        max_length = int(os.environ.get("LTX2_GEMMA_MAX_LENGTH", "1024"))
+        return map_token_ranges(
+            tokenizer, prompt, prompt_relay.local_prompts, max_length=max_length
+        )
 
     @staticmethod
-    def _prompt_relay_mask(
-        prompt_relay,
-        token_ranges,
-        latent_f: int,
-        latent_h: int,
-        latent_w: int,
-        num_video_tokens: int,
+    def _prompt_relay_mask_builder(
+        prompt_relay: PromptRelayInput | None,
+        token_ranges: list[tuple[int, int]] | None,
         num_text_tokens: int,
-    ):
-        """Build the additive video->text cross-attention bias for one stage.
+    ) -> Callable[[int, int, int, int], mx.array | None]:
+        """Return a per-stage builder for the additive video->text cross-attn bias.
 
-        Rebuilt per stage because tokens-per-frame (``latent_h * latent_w``)
-        differs between half- and full-resolution stages. Returns ``None`` when
-        Prompt Relay is off (``token_ranges is None``).
+        The returned closure takes only the stage-varying dims
+        ``(latent_f, latent_h, latent_w, num_video_tokens)`` — a single call site
+        can't silently mis-order the fixed args — and rebuilds the mask each stage
+        because tokens-per-frame (``latent_h * latent_w``) differs between half- and
+        full-resolution stages. The closure returns ``None`` when Prompt Relay is
+        off (``token_ranges is None``).
         """
         if token_ranges is None:
-            return None
+            return lambda latent_f, latent_h, latent_w, num_video_tokens: None
         from ltx_core_mlx.conditioning.prompt_relay import (
             build_relay_mask,
             distribute_segment_lengths,
         )
 
-        seg_lengths = distribute_segment_lengths(
-            len(prompt_relay.local_prompts), latent_f, prompt_relay.segment_lengths
-        )
-        return build_relay_mask(
-            token_ranges=token_ranges,
-            segment_lengths=seg_lengths,
-            num_video_tokens=num_video_tokens,
-            tokens_per_frame=latent_h * latent_w,
-            latent_frames=latent_f,
-            num_text_tokens=num_text_tokens,
-            epsilon=prompt_relay.epsilon,
-            strength=prompt_relay.strength,
-        )
+        def _build(
+            latent_f: int, latent_h: int, latent_w: int, num_video_tokens: int
+        ) -> mx.array:
+            seg_lengths = distribute_segment_lengths(
+                len(prompt_relay.local_prompts), latent_f, prompt_relay.segment_lengths
+            )
+            return build_relay_mask(
+                token_ranges=token_ranges,
+                segment_lengths=seg_lengths,
+                num_video_tokens=num_video_tokens,
+                tokens_per_frame=latent_h * latent_w,
+                latent_frames=latent_f,
+                num_text_tokens=num_text_tokens,
+                epsilon=prompt_relay.epsilon,
+                strength=prompt_relay.strength,
+            )
+
+        return _build
 
     @staticmethod
     def _pre_denoise_flush(video_state: LatentState, audio_state: LatentState) -> None:

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/_base.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/_base.py
@@ -458,9 +458,7 @@ class BasePipeline:
         self._load_text_encoder()
         tokenizer = self.text_encoder._tokenizer
         max_length = int(os.environ.get("LTX2_GEMMA_MAX_LENGTH", "1024"))
-        return map_token_ranges(
-            tokenizer, prompt, prompt_relay.local_prompts, max_length=max_length
-        )
+        return map_token_ranges(tokenizer, prompt, prompt_relay.local_prompts, max_length=max_length)
 
     @staticmethod
     def _prompt_relay_mask_builder(
@@ -484,9 +482,7 @@ class BasePipeline:
             distribute_segment_lengths,
         )
 
-        def _build(
-            latent_f: int, latent_h: int, latent_w: int, num_video_tokens: int
-        ) -> mx.array:
+        def _build(latent_f: int, latent_h: int, latent_w: int, num_video_tokens: int) -> mx.array:
             seg_lengths = distribute_segment_lengths(
                 len(prompt_relay.local_prompts), latent_f, prompt_relay.segment_lengths
             )

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/_base.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/_base.py
@@ -425,6 +425,68 @@ class BasePipeline:
         """
         return self.prompt_encoder.encode(prompt)
 
+    # ------------------------------------------------------------------
+    # Prompt Relay (temporal cross-attention prompt gating)
+    # ------------------------------------------------------------------
+
+    def _prompt_relay_setup(self, prompt: str, prompt_relay):
+        """Resolve the prompt actually encoded + per-segment token ranges.
+
+        With Prompt Relay active, the encoded (positive) prompt is the global
+        prompt followed by the space-joined local prompts; the returned token
+        ranges index those locals for :meth:`_prompt_relay_mask`. Returns
+        ``(prompt, None)`` when Prompt Relay is off.
+        """
+        if prompt_relay is None:
+            return prompt, None
+        if getattr(self, "_tile_count", None) is not None:
+            raise ValueError(
+                "Prompt Relay is not compatible with modality tiling "
+                "(--tile-frames / --tile-spatial). Run without tiling."
+            )
+        from ltx_core_mlx.conditioning.prompt_relay import map_token_ranges
+
+        self._load_text_encoder()
+        tokenizer = self.text_encoder._tokenizer
+        return map_token_ranges(tokenizer, prompt, prompt_relay.local_prompts)
+
+    @staticmethod
+    def _prompt_relay_mask(
+        prompt_relay,
+        token_ranges,
+        latent_f: int,
+        latent_h: int,
+        latent_w: int,
+        num_video_tokens: int,
+        num_text_tokens: int,
+    ):
+        """Build the additive video->text cross-attention bias for one stage.
+
+        Rebuilt per stage because tokens-per-frame (``latent_h * latent_w``)
+        differs between half- and full-resolution stages. Returns ``None`` when
+        Prompt Relay is off (``token_ranges is None``).
+        """
+        if token_ranges is None:
+            return None
+        from ltx_core_mlx.conditioning.prompt_relay import (
+            build_relay_mask,
+            distribute_segment_lengths,
+        )
+
+        seg_lengths = distribute_segment_lengths(
+            len(prompt_relay.local_prompts), latent_f, prompt_relay.segment_lengths
+        )
+        return build_relay_mask(
+            token_ranges=token_ranges,
+            segment_lengths=seg_lengths,
+            num_video_tokens=num_video_tokens,
+            tokens_per_frame=latent_h * latent_w,
+            latent_frames=latent_f,
+            num_text_tokens=num_text_tokens,
+            epsilon=prompt_relay.epsilon,
+            strength=prompt_relay.strength,
+        )
+
     @staticmethod
     def _pre_denoise_flush(video_state: LatentState, audio_state: LatentState) -> None:
         """Force-materialise noised states before starting the denoise loop.

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/cli.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/cli.py
@@ -167,6 +167,36 @@ examples:
             "Mirrors upstream LTX_2_3 --image."
         ),
     )
+    from ltx_pipelines_mlx.utils.args import SegmentAction as _SegmentAction
+
+    gen.add_argument(
+        "--segment",
+        action=_SegmentAction,
+        nargs="+",
+        dest="segments",
+        default=None,
+        metavar="ARG",
+        help=(
+            "Prompt Relay segment: a local prompt gated to a slice of the timeline. "
+            "Form: TEXT [LEN_FRAMES] (LEN_FRAMES in latent frames; omit to auto-distribute "
+            "evenly). Repeatable, in timeline order — e.g. --segment 'a red car' "
+            "--segment 'a blue sky'. The global --prompt applies to all frames. "
+            "Works on all generate modes (video cross-attention); on CFG modes the mask "
+            "applies to the conditional pass only. Not compatible with modality tiling."
+        ),
+    )
+    gen.add_argument(
+        "--relay-epsilon",
+        type=float,
+        default=1e-3,
+        help="Prompt Relay falloff (smaller = sharper temporal gating). Default: 1e-3.",
+    )
+    gen.add_argument(
+        "--relay-strength",
+        type=float,
+        default=1.0,
+        help="Prompt Relay penalty multiplier (higher = stricter segment isolation). Default: 1.0.",
+    )
     gen.add_argument("--steps", type=int, default=None, help="Denoising steps for one-stage (default: 8)")
     gen.add_argument(
         "--two-stage",
@@ -571,6 +601,20 @@ def _cmd_generate(args: argparse.Namespace) -> None:
 
     lora_paths = [(path, float(strength)) for path, strength in args.lora] if args.lora else []
 
+    # Prompt Relay (temporal prompt gating) — applies to every generate mode. Pass the
+    # (possibly mixed) list when any beat is pinned; None entries auto-fill downstream.
+    relay = None
+    if getattr(args, "segments", None):
+        from ltx_core_mlx.conditioning.prompt_relay import PromptRelayInput
+
+        specified = [s.length for s in args.segments]
+        relay = PromptRelayInput(
+            local_prompts=[s.text for s in args.segments],
+            segment_lengths=specified if any(length is not None for length in specified) else None,
+            epsilon=args.relay_epsilon,
+            strength=args.relay_strength,
+        )
+
     if args.enable_teacache and not (args.two_stages_hq or args.two_stage):
         raise SystemExit(
             "--enable-teacache requires --two-stage (or --two-stages-hq, but HQ is not yet "
@@ -618,6 +662,8 @@ def _cmd_generate(args: argparse.Namespace) -> None:
             kwargs["cfg_scale"] = args.cfg_scale
         if args.stg_scale is not None:
             kwargs["stg_scale"] = args.stg_scale
+        if relay is not None:
+            kwargs["prompt_relay"] = relay
         pipe.generate_and_save(**kwargs)
 
     elif args.distilled:
@@ -651,6 +697,8 @@ def _cmd_generate(args: argparse.Namespace) -> None:
             kwargs["stage1_steps"] = args.stage1_steps
         if args.stage2_steps is not None:
             kwargs["stage2_steps"] = args.stage2_steps
+        if relay is not None:
+            kwargs["prompt_relay"] = relay
         pipe.generate_and_save(**kwargs)
 
     elif args.two_stages_hq or args.two_stage:
@@ -705,6 +753,8 @@ def _cmd_generate(args: argparse.Namespace) -> None:
             kwargs["enable_teacache"] = True
             if args.teacache_thresh is not None:
                 kwargs["teacache_thresh"] = args.teacache_thresh
+        if relay is not None:
+            kwargs["prompt_relay"] = relay
         pipe.generate_and_save(**kwargs)
 
     else:

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/distilled.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/distilled.py
@@ -153,17 +153,7 @@ class DistilledPipeline(TI2VidTwoStagesPipeline):
         # Per-stage Prompt Relay mask builder. Ranges were computed pre-encode;
         # the mask is rebuilt each stage because tokens-per-frame (H*W) differs.
         num_text_tokens = video_embeds.shape[1]
-
-        def _relay_mask(latent_f: int, latent_h: int, latent_w: int, num_video_tokens: int):
-            return self._prompt_relay_mask(
-                prompt_relay,
-                relay_token_ranges,
-                latent_f,
-                latent_h,
-                latent_w,
-                num_video_tokens,
-                num_text_tokens,
-            )
+        relay_mask = self._prompt_relay_mask_builder(prompt_relay, relay_token_ranges, num_text_tokens)
 
         # --- Load distilled DiT + VAE encoder + upsampler ---
         self.load()
@@ -242,7 +232,7 @@ class DistilledPipeline(TI2VidTwoStagesPipeline):
             video_text_embeds=video_embeds,
             audio_text_embeds=audio_embeds,
             sigmas=sigmas_1,
-            video_cross_attention_mask=_relay_mask(F, H_half, W_half, video_state.latent.shape[1]),
+            video_cross_attention_mask=relay_mask(F, H_half, W_half, video_state.latent.shape[1]),
         )
         if self.low_memory:
             aggressive_cleanup()
@@ -326,7 +316,7 @@ class DistilledPipeline(TI2VidTwoStagesPipeline):
             video_text_embeds=video_embeds,
             audio_text_embeds=audio_embeds,
             sigmas=sigmas_2,
-            video_cross_attention_mask=_relay_mask(F, H_full, W_full, video_state_2.latent.shape[1]),
+            video_cross_attention_mask=relay_mask(F, H_full, W_full, video_state_2.latent.shape[1]),
         )
         if self.low_memory:
             aggressive_cleanup()

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/distilled.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/distilled.py
@@ -117,6 +117,7 @@ class DistilledPipeline(TI2VidTwoStagesPipeline):
         stage2_steps: int | None = None,
         image: str | None = None,
         images=None,
+        prompt_relay=None,
         **_unused_kwargs,
     ) -> tuple[mx.array, mx.array]:
         """Generate video using the distilled two-stage pipeline.
@@ -137,14 +138,32 @@ class DistilledPipeline(TI2VidTwoStagesPipeline):
         Returns:
             Tuple of (video_latent, audio_latent) at full resolution.
         """
+        # --- Prompt Relay setup (temporal prompt gating on video cross-attn) ---
+        encode_prompt, relay_token_ranges = self._prompt_relay_setup(prompt, prompt_relay)
+
         # --- Text encoding (positive only — no CFG) ---
         self._load_text_encoder()
         with phase("Encoding prompt", verbose=self.verbose):
-            video_embeds, audio_embeds = self._encode_text(prompt)
+            video_embeds, audio_embeds = self._encode_text(encode_prompt)
             _materialize(video_embeds, audio_embeds)
         if self.low_memory:
             self.prompt_encoder.free()
             aggressive_cleanup()
+
+        # Per-stage Prompt Relay mask builder. Ranges were computed pre-encode;
+        # the mask is rebuilt each stage because tokens-per-frame (H*W) differs.
+        num_text_tokens = video_embeds.shape[1]
+
+        def _relay_mask(latent_f: int, latent_h: int, latent_w: int, num_video_tokens: int):
+            return self._prompt_relay_mask(
+                prompt_relay,
+                relay_token_ranges,
+                latent_f,
+                latent_h,
+                latent_w,
+                num_video_tokens,
+                num_text_tokens,
+            )
 
         # --- Load distilled DiT + VAE encoder + upsampler ---
         self.load()
@@ -223,6 +242,7 @@ class DistilledPipeline(TI2VidTwoStagesPipeline):
             video_text_embeds=video_embeds,
             audio_text_embeds=audio_embeds,
             sigmas=sigmas_1,
+            video_cross_attention_mask=_relay_mask(F, H_half, W_half, video_state.latent.shape[1]),
         )
         if self.low_memory:
             aggressive_cleanup()
@@ -306,6 +326,7 @@ class DistilledPipeline(TI2VidTwoStagesPipeline):
             video_text_embeds=video_embeds,
             audio_text_embeds=audio_embeds,
             sigmas=sigmas_2,
+            video_cross_attention_mask=_relay_mask(F, H_full, W_full, video_state_2.latent.shape[1]),
         )
         if self.low_memory:
             aggressive_cleanup()

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ti2vid_one_stage.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ti2vid_one_stage.py
@@ -145,6 +145,7 @@ class TI2VidOneStagePipeline(TI2VidTwoStagesPipeline):
         encode_prompt, relay_token_ranges = self._prompt_relay_setup(prompt, prompt_relay)
         video_embeds, audio_embeds, neg_video_embeds, neg_audio_embeds = self._encode_text_with_negative(encode_prompt)
         num_text_tokens = video_embeds.shape[1]
+        relay_mask = self._prompt_relay_mask_builder(prompt_relay, relay_token_ranges, num_text_tokens)
 
         # --- Load dev DiT + VAE encoder ---
         self.load()
@@ -250,15 +251,7 @@ class TI2VidOneStagePipeline(TI2VidTwoStagesPipeline):
             video_guider_factory=video_factory,
             audio_guider_factory=audio_factory,
             sigmas=sigmas,
-            video_cross_attention_mask=self._prompt_relay_mask(
-                prompt_relay,
-                relay_token_ranges,
-                F,
-                H,
-                W,
-                video_state.latent.shape[1],
-                num_text_tokens,
-            ),
+            video_cross_attention_mask=relay_mask(F, H, W, video_state.latent.shape[1]),
             tap=tap,
         )
         if self.low_memory:

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ti2vid_one_stage.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ti2vid_one_stage.py
@@ -114,6 +114,7 @@ class TI2VidOneStagePipeline(TI2VidTwoStagesPipeline):
         stg_scale: float = 1.0,
         image: str | None = None,
         images=None,
+        prompt_relay=None,
         video_guider_params: MultiModalGuiderParams | None = None,
         audio_guider_params: MultiModalGuiderParams | None = None,
         tap: callable | None = None,
@@ -139,8 +140,11 @@ class TI2VidOneStagePipeline(TI2VidTwoStagesPipeline):
         Returns:
             Tuple of (video_latent, audio_latent) at target resolution.
         """
-        # --- Text encoding (positive + negative for CFG) ---
-        video_embeds, audio_embeds, neg_video_embeds, neg_audio_embeds = self._encode_text_with_negative(prompt)
+        # --- Text encoding (positive + negative for CFG; Prompt Relay encodes the
+        # combined prompt on the positive side) ---
+        encode_prompt, relay_token_ranges = self._prompt_relay_setup(prompt, prompt_relay)
+        video_embeds, audio_embeds, neg_video_embeds, neg_audio_embeds = self._encode_text_with_negative(encode_prompt)
+        num_text_tokens = video_embeds.shape[1]
 
         # --- Load dev DiT + VAE encoder ---
         self.load()
@@ -246,6 +250,15 @@ class TI2VidOneStagePipeline(TI2VidTwoStagesPipeline):
             video_guider_factory=video_factory,
             audio_guider_factory=audio_factory,
             sigmas=sigmas,
+            video_cross_attention_mask=self._prompt_relay_mask(
+                prompt_relay,
+                relay_token_ranges,
+                F,
+                H,
+                W,
+                video_state.latent.shape[1],
+                num_text_tokens,
+            ),
             tap=tap,
         )
         if self.low_memory:
@@ -273,6 +286,7 @@ class TI2VidOneStagePipeline(TI2VidTwoStagesPipeline):
         stg_scale: float = 1.0,
         image: str | None = None,
         images=None,
+        prompt_relay=None,
         video_guider_params: MultiModalGuiderParams | None = None,
         audio_guider_params: MultiModalGuiderParams | None = None,
         **_unused_kwargs,
@@ -295,6 +309,7 @@ class TI2VidOneStagePipeline(TI2VidTwoStagesPipeline):
             stg_scale=stg_scale,
             image=image,
             images=images,
+            prompt_relay=prompt_relay,
             video_guider_params=video_guider_params,
             audio_guider_params=audio_guider_params,
         )

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ti2vid_two_stages.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ti2vid_two_stages.py
@@ -356,6 +356,7 @@ class TI2VidTwoStagesPipeline(BasePipeline):
         encode_prompt, relay_token_ranges = self._prompt_relay_setup(prompt, prompt_relay)
         video_embeds, audio_embeds, neg_video_embeds, neg_audio_embeds = self._encode_text_with_negative(encode_prompt)
         num_text_tokens = video_embeds.shape[1]
+        relay_mask = self._prompt_relay_mask_builder(prompt_relay, relay_token_ranges, num_text_tokens)
 
         # --- Load DiT + VAE encoder + upsampler ---
         if self.dit is None:
@@ -479,15 +480,7 @@ class TI2VidTwoStagesPipeline(BasePipeline):
             video_guider_factory=video_factory,
             audio_guider_factory=audio_factory,
             sigmas=sigmas_1,
-            video_cross_attention_mask=self._prompt_relay_mask(
-                prompt_relay,
-                relay_token_ranges,
-                F,
-                H_half,
-                W_half,
-                video_state.latent.shape[1],
-                num_text_tokens,
-            ),
+            video_cross_attention_mask=relay_mask(F, H_half, W_half, video_state.latent.shape[1]),
             teacache=teacache_controller,
             tap=tap,
         )
@@ -589,15 +582,7 @@ class TI2VidTwoStagesPipeline(BasePipeline):
             video_text_embeds=video_embeds,
             audio_text_embeds=audio_embeds,
             sigmas=sigmas_2,
-            video_cross_attention_mask=self._prompt_relay_mask(
-                prompt_relay,
-                relay_token_ranges,
-                F,
-                H_full,
-                W_full,
-                video_state_2.latent.shape[1],
-                num_text_tokens,
-            ),
+            video_cross_attention_mask=relay_mask(F, H_full, W_full, video_state_2.latent.shape[1]),
         )
         if self.low_memory:
             aggressive_cleanup()
@@ -637,7 +622,7 @@ class TI2VidTwoStagesPipeline(BasePipeline):
         overridden by this parent method's signature.
 
         ``prompt_relay`` (a ``PromptRelayInput``) is forwarded only when set;
-        it is currently honoured by the distilled ``generate_two_stage``.
+        ``generate_two_stage`` wires the mask into both of its denoise loops.
         """
         gen_kwargs: dict = dict(
             prompt=prompt,

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ti2vid_two_stages.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ti2vid_two_stages.py
@@ -316,6 +316,7 @@ class TI2VidTwoStagesPipeline(BasePipeline):
         stg_scale: float = 1.0,
         image: str | None = None,
         images=None,
+        prompt_relay=None,
         video_guider_params: MultiModalGuiderParams | None = None,
         audio_guider_params: MultiModalGuiderParams | None = None,
         enable_teacache: bool = False,
@@ -350,8 +351,11 @@ class TI2VidTwoStagesPipeline(BasePipeline):
         Returns:
             Tuple of (video_latent, audio_latent) at full resolution.
         """
-        # --- Text encoding ---
-        video_embeds, audio_embeds, neg_video_embeds, neg_audio_embeds = self._encode_text_with_negative(prompt)
+        # --- Text encoding (Prompt Relay: encode the combined prompt; the negative
+        # prompt is a fixed default, so it is unaffected by the local prompts) ---
+        encode_prompt, relay_token_ranges = self._prompt_relay_setup(prompt, prompt_relay)
+        video_embeds, audio_embeds, neg_video_embeds, neg_audio_embeds = self._encode_text_with_negative(encode_prompt)
+        num_text_tokens = video_embeds.shape[1]
 
         # --- Load DiT + VAE encoder + upsampler ---
         if self.dit is None:
@@ -475,6 +479,15 @@ class TI2VidTwoStagesPipeline(BasePipeline):
             video_guider_factory=video_factory,
             audio_guider_factory=audio_factory,
             sigmas=sigmas_1,
+            video_cross_attention_mask=self._prompt_relay_mask(
+                prompt_relay,
+                relay_token_ranges,
+                F,
+                H_half,
+                W_half,
+                video_state.latent.shape[1],
+                num_text_tokens,
+            ),
             teacache=teacache_controller,
             tap=tap,
         )
@@ -576,6 +589,15 @@ class TI2VidTwoStagesPipeline(BasePipeline):
             video_text_embeds=video_embeds,
             audio_text_embeds=audio_embeds,
             sigmas=sigmas_2,
+            video_cross_attention_mask=self._prompt_relay_mask(
+                prompt_relay,
+                relay_token_ranges,
+                F,
+                H_full,
+                W_full,
+                video_state_2.latent.shape[1],
+                num_text_tokens,
+            ),
         )
         if self.low_memory:
             aggressive_cleanup()
@@ -606,12 +628,16 @@ class TI2VidTwoStagesPipeline(BasePipeline):
         audio_guider_params: MultiModalGuiderParams | None = None,
         enable_teacache: bool = False,
         teacache_thresh: float | None = None,
+        prompt_relay=None,
     ) -> str:
         """Generate two-stage video+audio and save to file.
 
         ``stage1_steps`` defaults to ``None`` so subclasses can apply
         their own default (Euler: 30, HQ res_2s: 15) without being
         overridden by this parent method's signature.
+
+        ``prompt_relay`` (a ``PromptRelayInput``) is forwarded only when set;
+        it is currently honoured by the distilled ``generate_two_stage``.
         """
         gen_kwargs: dict = dict(
             prompt=prompt,
@@ -632,6 +658,8 @@ class TI2VidTwoStagesPipeline(BasePipeline):
         )
         if stage1_steps is not None:
             gen_kwargs["stage1_steps"] = stage1_steps
+        if prompt_relay is not None:
+            gen_kwargs["prompt_relay"] = prompt_relay
         video_latent, audio_latent = self.generate_two_stage(**gen_kwargs)
 
         # Free transformer + encoder to make room for decoders

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ti2vid_two_stages_hq.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ti2vid_two_stages_hq.py
@@ -114,6 +114,7 @@ class TI2VidTwoStagesHQPipeline(TI2VidTwoStagesPipeline):
         encode_prompt, relay_token_ranges = self._prompt_relay_setup(prompt, prompt_relay)
         video_embeds, audio_embeds, neg_video_embeds, neg_audio_embeds = self._encode_text_with_negative(encode_prompt)
         num_text_tokens = video_embeds.shape[1]
+        relay_mask = self._prompt_relay_mask_builder(prompt_relay, relay_token_ranges, num_text_tokens)
 
         # --- Load DiT + VAE encoder + upsampler ---
         if self.dit is None:
@@ -223,15 +224,7 @@ class TI2VidTwoStagesHQPipeline(TI2VidTwoStagesPipeline):
             sigmas=sigmas_1,
             video_guider_factory=video_factory,
             audio_guider_factory=audio_factory,
-            video_cross_attention_mask=self._prompt_relay_mask(
-                prompt_relay,
-                relay_token_ranges,
-                F,
-                H_half,
-                W_half,
-                video_state.latent.shape[1],
-                num_text_tokens,
-            ),
+            video_cross_attention_mask=relay_mask(F, H_half, W_half, video_state.latent.shape[1]),
             teacache=teacache_controller,
             tap=tap,
         )
@@ -322,15 +315,7 @@ class TI2VidTwoStagesHQPipeline(TI2VidTwoStagesPipeline):
             video_text_embeds=video_embeds,
             audio_text_embeds=audio_embeds,
             sigmas=sigmas_2,
-            video_cross_attention_mask=self._prompt_relay_mask(
-                prompt_relay,
-                relay_token_ranges,
-                F,
-                H_full,
-                W_full,
-                video_state_2.latent.shape[1],
-                num_text_tokens,
-            ),
+            video_cross_attention_mask=relay_mask(F, H_full, W_full, video_state_2.latent.shape[1]),
         )
         if self.low_memory:
             aggressive_cleanup()

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ti2vid_two_stages_hq.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ti2vid_two_stages_hq.py
@@ -96,6 +96,7 @@ class TI2VidTwoStagesHQPipeline(TI2VidTwoStagesPipeline):
         stg_scale: float = 0.0,
         image: str | None = None,
         images=None,
+        prompt_relay=None,
         video_guider_params: MultiModalGuiderParams | None = None,
         audio_guider_params: MultiModalGuiderParams | None = None,
         enable_teacache: bool = False,
@@ -109,8 +110,10 @@ class TI2VidTwoStagesHQPipeline(TI2VidTwoStagesPipeline):
         / ``tap`` are forwarded to ``res2s_denoise_loop`` exactly as in the
         Euler path.
         """
-        # --- Text encoding ---
-        video_embeds, audio_embeds, neg_video_embeds, neg_audio_embeds = self._encode_text_with_negative(prompt)
+        # --- Text encoding (Prompt Relay: encode the combined prompt) ---
+        encode_prompt, relay_token_ranges = self._prompt_relay_setup(prompt, prompt_relay)
+        video_embeds, audio_embeds, neg_video_embeds, neg_audio_embeds = self._encode_text_with_negative(encode_prompt)
+        num_text_tokens = video_embeds.shape[1]
 
         # --- Load DiT + VAE encoder + upsampler ---
         if self.dit is None:
@@ -220,6 +223,15 @@ class TI2VidTwoStagesHQPipeline(TI2VidTwoStagesPipeline):
             sigmas=sigmas_1,
             video_guider_factory=video_factory,
             audio_guider_factory=audio_factory,
+            video_cross_attention_mask=self._prompt_relay_mask(
+                prompt_relay,
+                relay_token_ranges,
+                F,
+                H_half,
+                W_half,
+                video_state.latent.shape[1],
+                num_text_tokens,
+            ),
             teacache=teacache_controller,
             tap=tap,
         )
@@ -310,6 +322,15 @@ class TI2VidTwoStagesHQPipeline(TI2VidTwoStagesPipeline):
             video_text_embeds=video_embeds,
             audio_text_embeds=audio_embeds,
             sigmas=sigmas_2,
+            video_cross_attention_mask=self._prompt_relay_mask(
+                prompt_relay,
+                relay_token_ranges,
+                F,
+                H_full,
+                W_full,
+                video_state_2.latent.shape[1],
+                num_text_tokens,
+            ),
         )
         if self.low_memory:
             aggressive_cleanup()

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/utils/args.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/utils/args.py
@@ -15,6 +15,17 @@ from typing import NamedTuple
 from ltx_pipelines_mlx.utils.media_io import DEFAULT_IMAGE_CRF
 
 
+def _append_to_dest(namespace: argparse.Namespace, dest: str, item: object) -> None:
+    """Append ``item`` to the namespace list at ``dest`` (creating it if absent).
+
+    Shared by the repeatable list actions (:class:`ImageAction`,
+    :class:`SegmentAction`) so their append-to-dest handling can't drift.
+    """
+    existing = getattr(namespace, dest, None) or []
+    existing.append(item)
+    setattr(namespace, dest, existing)
+
+
 class ImageConditioningInput(NamedTuple):
     """One image conditioning entry for multi-anchor I2V.
 
@@ -85,9 +96,7 @@ class ImageAction(argparse.Action):
             crf=crf,
         )
 
-        existing = getattr(namespace, self.dest, None) or []
-        existing.append(item)
-        setattr(namespace, self.dest, existing)
+        _append_to_dest(namespace, self.dest, item)
 
 
 class SegmentInput(NamedTuple):
@@ -133,9 +142,13 @@ class SegmentAction(argparse.Action):
             if length <= 0:
                 parser.error(f"{option_string}: LEN_FRAMES must be positive, got {length}")
 
-        existing = getattr(namespace, self.dest, None) or []
-        existing.append(SegmentInput(text=text, length=length))
-        setattr(namespace, self.dest, existing)
+        _append_to_dest(namespace, self.dest, SegmentInput(text=text, length=length))
 
 
-__all__ = ["DEFAULT_IMAGE_CRF", "ImageAction", "ImageConditioningInput"]
+__all__ = [
+    "DEFAULT_IMAGE_CRF",
+    "ImageAction",
+    "ImageConditioningInput",
+    "SegmentAction",
+    "SegmentInput",
+]

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/utils/args.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/utils/args.py
@@ -90,4 +90,52 @@ class ImageAction(argparse.Action):
         setattr(namespace, self.dest, existing)
 
 
+class SegmentInput(NamedTuple):
+    """One Prompt Relay segment: a local prompt + optional latent-frame length.
+
+    Args:
+        text: Local prompt gated to this segment's time window.
+        length: Segment length in *latent* frames, or ``None`` to auto-distribute
+            evenly across the timeline.
+    """
+
+    text: str
+    length: int | None = None
+
+
+class SegmentAction(argparse.Action):
+    """Variadic argparse action accepting ``TEXT [LEN_FRAMES]``. Repeatable.
+
+    Each invocation appends one :class:`SegmentInput` (in timeline order) to the
+    namespace list. ``--segment "a red car"`` auto-distributes; ``--segment "a red
+    car" 4`` pins that segment to 4 latent frames.
+    """
+
+    def __call__(  # type: ignore[override]
+        self,
+        parser: argparse.ArgumentParser,
+        namespace: argparse.Namespace,
+        values,
+        option_string: str | None = None,
+    ) -> None:
+        if not isinstance(values, list):
+            values = [values]
+        if len(values) not in (1, 2):
+            parser.error(f"{option_string}: expected TEXT [LEN_FRAMES], got {len(values)}: {values}")
+
+        text = values[0]
+        length: int | None = None
+        if len(values) == 2:
+            try:
+                length = int(values[1])
+            except (ValueError, TypeError) as e:
+                parser.error(f"{option_string}: could not parse LEN_FRAMES from {values[1]!r}: {e}")
+            if length <= 0:
+                parser.error(f"{option_string}: LEN_FRAMES must be positive, got {length}")
+
+        existing = getattr(namespace, self.dest, None) or []
+        existing.append(SegmentInput(text=text, length=length))
+        setattr(namespace, self.dest, existing)
+
+
 __all__ = ["DEFAULT_IMAGE_CRF", "ImageAction", "ImageConditioningInput"]

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/utils/samplers.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/utils/samplers.py
@@ -82,6 +82,7 @@ def denoise_loop(
     audio_positions: mx.array | None = None,
     video_attention_mask: mx.array | None = None,
     audio_attention_mask: mx.array | None = None,
+    video_cross_attention_mask: mx.array | None = None,
     show_progress: bool = True,
 ) -> DenoiseOutput:
     """Run the Euler denoising loop for joint audio+video.
@@ -147,6 +148,8 @@ def denoise_loop(
             video_attention_mask=video_attention_mask,
             audio_attention_mask=audio_attention_mask,
         )
+        if video_cross_attention_mask is not None:
+            call_kwargs["video_cross_attention_mask"] = video_cross_attention_mask
 
         # Pass per-token timesteps when mask is not uniform
         if not video_uniform:
@@ -250,6 +253,7 @@ def res2s_denoise_loop(
     audio_positions: mx.array | None = None,
     video_attention_mask: mx.array | None = None,
     audio_attention_mask: mx.array | None = None,
+    video_cross_attention_mask: mx.array | None = None,
     show_progress: bool = True,
     bongmath: bool = True,
     bongmath_max_iter: int = 100,
@@ -366,6 +370,9 @@ def res2s_denoise_loop(
             video_attention_mask=video_attention_mask,
             audio_attention_mask=audio_attention_mask,
         )
+        # Prompt Relay: positive-context passes only; overridden to None on uncond.
+        if video_cross_attention_mask is not None:
+            base_kwargs["video_cross_attention_mask"] = video_cross_attention_mask
         if not video_uniform:
             base_kwargs["video_timesteps"] = _compute_per_token_timesteps(sig, video_state.denoise_mask)
         if not audio_uniform:
@@ -394,7 +401,12 @@ def res2s_denoise_loop(
                 neg_a_embeds = (
                     audio_guider.negative_context if audio_guider.negative_context is not None else audio_text_embeds
                 )
-                neg_kw = {**base_kwargs, "video_text_embeds": neg_v_embeds, "audio_text_embeds": neg_a_embeds}
+                neg_kw = {
+                    **base_kwargs,
+                    "video_text_embeds": neg_v_embeds,
+                    "audio_text_embeds": neg_a_embeds,
+                    "video_cross_attention_mask": None,  # never mask the negative prompt
+                }
                 neg_v, neg_a = run_pass("uncond", neg_kw)
 
             # 3. Perturbed prediction for STG
@@ -594,6 +606,7 @@ def guided_denoise_loop(
     audio_positions: mx.array | None = None,
     video_attention_mask: mx.array | None = None,
     audio_attention_mask: mx.array | None = None,
+    video_cross_attention_mask: mx.array | None = None,
     show_progress: bool = True,
     tap: callable | None = None,
     teacache=None,  # mlx_arsenal.diffusion.TeaCacheController-compatible
@@ -712,6 +725,12 @@ def guided_denoise_loop(
             video_attention_mask=video_attention_mask,
             audio_attention_mask=audio_attention_mask,
         )
+        # Prompt Relay gates the video->text cross-attention. Applied to every
+        # positive-context pass (cond/ptb/mod) via base_kwargs, but overridden to
+        # None on the unconditional (negative) pass below — matching the reference,
+        # which never masks the negative prompt.
+        if video_cross_attention_mask is not None:
+            base_kwargs["video_cross_attention_mask"] = video_cross_attention_mask
 
         # Per-token timesteps for conditioning
         if not video_uniform:
@@ -795,6 +814,7 @@ def guided_denoise_loop(
                 **base_kwargs,
                 "video_text_embeds": neg_video_embeds,
                 "audio_text_embeds": neg_audio_embeds,
+                "video_cross_attention_mask": None,  # never mask the negative prompt
             }
             neg_video_x0, neg_audio_x0 = _run_pass("uncond", neg_kwargs)
 

--- a/tests/test_prompt_relay.py
+++ b/tests/test_prompt_relay.py
@@ -1,0 +1,220 @@
+"""Unit tests for Prompt Relay mask construction (ltx_core_mlx.conditioning.prompt_relay).
+
+Pure-CPU / no model load — exercises token-range mapping, length distribution, and
+the additive cross-attention penalty mask.
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+import numpy as np
+import pytest
+
+from ltx_core_mlx.conditioning.prompt_relay import (
+    build_relay_mask,
+    distribute_segment_lengths,
+    map_token_ranges,
+)
+from ltx_core_mlx.model.transformer.transformer import BasicAVTransformerBlock
+
+
+class _FakeTokenizer:
+    """Whitespace tokenizer: prepends a BOS id, one id per word. No EOS."""
+
+    eos_token_id = 99
+
+    def encode(self, text: str) -> list[int]:
+        words = text.split()
+        return [1] + [1000 + i for i, _ in enumerate(words)]
+
+
+def test_map_token_ranges_basic():
+    tok = _FakeTokenizer()
+    combined, ranges = map_token_ranges(tok, "global prompt", ["red car", "blue sky"])
+    # combined prompt is global + space-prefixed locals
+    assert combined == "global prompt red car blue sky"
+    # global = BOS + 2 words = 3 tokens; each local adds its words
+    assert ranges == [(3, 5), (5, 7)]
+
+
+def test_map_token_ranges_rejects_empty_local():
+    tok = _FakeTokenizer()
+    with pytest.raises(ValueError):
+        map_token_ranges(tok, "global", ["   "])
+
+
+def test_distribute_segment_lengths_auto_and_explicit():
+    # auto: ceil(4/2)=2 each
+    assert distribute_segment_lengths(2, 4) == [2, 2]
+    # auto with clamp: ceil(5/2)=3 -> [3, 2] (second clamped to remaining)
+    assert distribute_segment_lengths(2, 5) == [3, 2]
+    # explicit passes through, clamped to timeline
+    assert distribute_segment_lengths(3, 6, [2, 2, 10]) == [2, 2, 2]
+    # mixed pinned + auto: pinned kept, leftover spread across the None beats
+    assert distribute_segment_lengths(3, 12, [4, None, None]) == [4, 4, 4]
+    assert distribute_segment_lengths(2, 10, [3, None]) == [3, 7]
+    # pinned already fills the clip -> auto beats collapse to 0
+    assert distribute_segment_lengths(2, 5, [5, None]) == [5, 0]
+    with pytest.raises(ValueError):
+        distribute_segment_lengths(2, 4, [1])  # count mismatch
+
+
+def test_build_relay_mask_shape_and_dtype():
+    mask = build_relay_mask(
+        token_ranges=[(2, 3), (3, 4)],
+        segment_lengths=[2, 2],
+        num_video_tokens=4,
+        tokens_per_frame=1,
+        latent_frames=4,
+        num_text_tokens=6,
+    )
+    assert mask.shape == (1, 1, 4, 6)
+    assert mask.dtype == mx.bfloat16
+
+
+def test_build_relay_mask_temporal_gating():
+    # F=4 latent frames, 1 token/frame -> Nv=4; Nk=6.
+    # seg0 tokens=[2,3), window centred on frame 1; seg1 tokens=[3,4), centred on frame 3.
+    mask = np.array(
+        build_relay_mask(
+            token_ranges=[(2, 3), (3, 4)],
+            segment_lengths=[2, 2],
+            num_video_tokens=4,
+            tokens_per_frame=1,
+            latent_frames=4,
+            num_text_tokens=6,
+            dtype=mx.float32,
+        )
+    )[0, 0]
+
+    # Global-prompt columns (0,1) and register/padding columns (4,5) are always free.
+    assert np.all(mask[:, 0] == 0.0)
+    assert np.all(mask[:, 1] == 0.0)
+    assert np.all(mask[:, 4] == 0.0)
+    assert np.all(mask[:, 5] == 0.0)
+
+    # seg0's token (col 2): free at its midpoint frame (1), penalised far away (frame 3).
+    assert mask[1, 2] == 0.0
+    assert mask[3, 2] < 0.0
+    # seg1's token (col 3): free at its midpoint frame (3), penalised at frame 0.
+    assert mask[3, 3] == 0.0
+    assert mask[0, 3] < 0.0
+
+
+def test_build_relay_mask_appended_keyframe_rows_free():
+    # Nv exceeds F*tokens_per_frame by 2 appended keyframe tokens -> those rows free.
+    mask = np.array(
+        build_relay_mask(
+            token_ranges=[(2, 3)],
+            segment_lengths=[2],
+            num_video_tokens=6,  # 4 real + 2 appended
+            tokens_per_frame=1,
+            latent_frames=4,
+            num_text_tokens=6,
+            dtype=mx.float32,
+        )
+    )[0, 0]
+    # Appended rows (4, 5) receive zero penalty everywhere.
+    assert np.all(mask[4, :] == 0.0)
+    assert np.all(mask[5, :] == 0.0)
+
+
+def _make_block() -> BasicAVTransformerBlock:
+    return BasicAVTransformerBlock(
+        video_dim=32,
+        audio_dim=16,
+        video_num_heads=4,
+        audio_num_heads=4,
+        video_head_dim=8,
+        audio_head_dim=4,
+        av_cross_num_heads=4,
+        av_cross_head_dim=4,
+    )
+
+
+def _block_kwargs(bsz: int, nv: int, nt: int):
+    # Force a nonzero text-cross-attn residual gate (adaln chunk 8 = gate_ca);
+    # otherwise the zero-init gate scales attn2's contribution to zero and the
+    # cross-attention mask would be unobservable at the block output.
+    video_adaln = mx.zeros((bsz, 9 * 32))
+    video_adaln = video_adaln.at[:, 8 * 32 : 9 * 32].add(1.0)
+    return dict(
+        video_hidden=mx.random.normal((bsz, nv, 32)),
+        audio_hidden=mx.random.normal((bsz, 4, 16)),
+        video_adaln_params=video_adaln,
+        audio_adaln_params=mx.zeros((bsz, 9 * 16)),
+        video_prompt_adaln_params=mx.zeros((bsz, 2 * 32)),
+        audio_prompt_adaln_params=mx.zeros((bsz, 2 * 16)),
+        av_ca_video_params=mx.zeros((bsz, 4 * 32)),
+        av_ca_audio_params=mx.zeros((bsz, 4 * 16)),
+        av_ca_a2v_gate_params=mx.zeros((bsz, 32)),
+        av_ca_v2a_gate_params=mx.zeros((bsz, 16)),
+        video_text_embeds=mx.random.normal((bsz, nt, 32)),
+        audio_text_embeds=mx.random.normal((bsz, nt, 16)),
+    )
+
+
+def test_cross_attention_mask_flows_through_block_and_changes_output():
+    """The video_cross_attention_mask reaches attn2 and alters its contribution."""
+    mx.random.seed(0)
+    block = _make_block()
+    B, nv, nt = 1, 8, 6
+    kwargs = _block_kwargs(B, nv, nt)
+
+    v_none, _ = block(**kwargs, video_cross_attention_mask=None)
+
+    # Strong negative bias on the last 3 text columns for every video token.
+    mask = mx.zeros((1, 1, nv, nt))
+    mask = mask.at[:, :, :, 3:].add(-1e4)
+    v_masked, _ = block(**kwargs, video_cross_attention_mask=mask)
+
+    mx.synchronize()
+    assert v_masked.shape == (B, nv, 32)
+    # Masking a subset of text keys must change the block output.
+    assert float(mx.max(mx.abs(v_masked - v_none))) > 1e-4
+
+
+def test_guided_loop_masks_conditional_pass_only():
+    """Under CFG, the relay mask reaches the conditional pass but never the uncond one."""
+    from ltx_core_mlx.components.guiders import (
+        MultiModalGuiderParams,
+        create_multimodal_guider_factory,
+    )
+    from ltx_core_mlx.conditioning.types.latent_cond import LatentState
+    from ltx_pipelines_mlx.utils.samplers import guided_denoise_loop
+
+    B, nv, na, nt, c = 1, 4, 2, 6, 8
+    v_state = LatentState(mx.zeros((B, nv, c)), mx.zeros((B, nv, c)), mx.ones((B, nv, 1)))
+    a_state = LatentState(mx.zeros((B, na, c)), mx.zeros((B, na, c)), mx.ones((B, na, 1)))
+
+    # cfg_scale != 1 -> unconditional pass runs; stg/modality off -> no ptb/mod passes.
+    params = MultiModalGuiderParams(cfg_scale=2.0, stg_scale=0.0, modality_scale=1.0, stg_blocks=[])
+    v_factory = create_multimodal_guider_factory(params, negative_context=mx.zeros((B, nt, c)))
+    a_factory = create_multimodal_guider_factory(params, negative_context=mx.zeros((B, nt, c)))
+
+    recorded: list = []
+
+    class _Recorder:
+        def __call__(self, **kw):
+            recorded.append(kw.get("video_cross_attention_mask"))
+            return kw["video_latent"], kw["audio_latent"]
+
+    mask = mx.zeros((1, 1, nv, nt))
+    guided_denoise_loop(
+        model=_Recorder(),
+        video_state=v_state,
+        audio_state=a_state,
+        video_text_embeds=mx.zeros((B, nt, c)),
+        audio_text_embeds=mx.zeros((B, nt, c)),
+        video_guider_factory=v_factory,
+        audio_guider_factory=a_factory,
+        sigmas=[1.0, 0.0],
+        video_cross_attention_mask=mask,
+        show_progress=False,
+    )
+
+    # Two passes: exactly one carries the mask (cond), one carries None (uncond).
+    masked = [m for m in recorded if m is not None]
+    unmasked = [m for m in recorded if m is None]
+    assert len(masked) == 1, f"expected 1 masked pass, got {len(masked)} of {len(recorded)}"
+    assert len(unmasked) == 1, f"expected 1 unmasked pass, got {len(unmasked)}"

--- a/tests/test_prompt_relay_findings.py
+++ b/tests/test_prompt_relay_findings.py
@@ -1,0 +1,177 @@
+"""Regression tests for the PR #61 review findings (temporal prompt gating).
+
+Each test encodes the *expected* (correct) behavior after the fixes: an out-of-band
+condition (zero-length beat, overflowing token range, out-of-range epsilon,
+combined-prompt truncation) must be rejected loudly rather than silently mis-gated.
+Pure-CPU, no model.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from ltx_core_mlx.conditioning.prompt_relay import (
+    build_relay_mask,
+    distribute_segment_lengths,
+    map_token_ranges,
+)
+
+
+class _FakeTokenizer:
+    """Whitespace tokenizer: prepends a BOS id, one id per word. No EOS.
+
+    Mirrors tests/test_prompt_relay.py's fixture (and Gemma's convention).
+    """
+
+    eos_token_id = 99
+
+    def encode(self, text: str) -> list[int]:
+        words = text.split()
+        return [1] + [1000 + i for i, _ in enumerate(words)]
+
+
+def _mask_np(**kw) -> np.ndarray:
+    """build_relay_mask -> squeezed float32 numpy (Nv, Nk)."""
+    import mlx.core as mx
+
+    defaults = dict(
+        num_video_tokens=kw.pop("nv"),
+        tokens_per_frame=kw.pop("tpf"),
+        latent_frames=kw.pop("frames"),
+        num_text_tokens=kw.pop("nk"),
+    )
+    m = build_relay_mask(dtype=mx.float32, **defaults, **kw)
+    return np.array(m)[0, 0]
+
+
+# ---------------------------------------------------------------------------
+# Finding 1 — zero-length segments must not silently attend to ALL frames
+# ---------------------------------------------------------------------------
+
+
+class TestZeroLengthSegmentUngated:
+    def test_pinned_fills_clip_second_segment_rejected(self):
+        """--segment "a" 5 --segment "b" on a 5-frame clip -> lengths [5, 0]."""
+        lengths = distribute_segment_lengths(2, 5, [5, None])
+        assert lengths == [5, 0]  # distribute still clamps (existing behavior)
+        with pytest.raises(ValueError):
+            _mask_np(
+                token_ranges=[(3, 5), (5, 7)],
+                segment_lengths=lengths,
+                nv=5,
+                tpf=1,
+                frames=5,
+                nk=16,
+            )
+
+    def test_auto_split_more_segments_than_it_can_fit(self):
+        """3 auto segments over 4 frames -> [2, 2, 0]; the collapsed beat is rejected."""
+        lengths = distribute_segment_lengths(3, 4)
+        assert lengths == [2, 2, 0]
+        with pytest.raises(ValueError):
+            _mask_np(
+                token_ranges=[(3, 5), (5, 7), (7, 9)],
+                segment_lengths=lengths,
+                nv=4,
+                tpf=1,
+                frames=4,
+                nk=16,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Finding 2 — token ranges past num_text_tokens must not silently clip
+# ---------------------------------------------------------------------------
+
+
+class TestTokenRangeOverflow:
+    def test_range_beyond_text_axis_rejected(self):
+        with pytest.raises(ValueError):
+            _mask_np(
+                token_ranges=[(20, 30)],  # entirely past Nk=16
+                segment_lengths=[4],
+                nv=8,
+                tpf=1,
+                frames=8,
+                nk=16,
+            )
+
+    def test_map_token_ranges_rejects_truncating_prompt(self):
+        """A combined prompt longer than max_length is rejected (left-truncation
+        would shift every surviving column)."""
+        tok = _FakeTokenizer()
+        global_prompt = " ".join(f"g{i}" for i in range(10))  # 10 words + BOS = 11 > 8
+        with pytest.raises(ValueError):
+            map_token_ranges(tok, global_prompt, ["red car"], max_length=8)
+
+    def test_map_token_ranges_within_limit_ok(self):
+        """Control: a combined prompt under the limit maps normally."""
+        tok = _FakeTokenizer()
+        combined, ranges = map_token_ranges(tok, "global", ["red car"], max_length=64)
+        assert combined == "global red car"
+        assert ranges == [(2, 4)]
+
+
+# ---------------------------------------------------------------------------
+# Finding 3 — odd-length segments keep their free anchor frame (floor midpoint)
+# ---------------------------------------------------------------------------
+
+
+class TestOddSegmentMidpointParity:
+    def test_odd_length_segment_keeps_a_zero_penalty_anchor_frame(self):
+        mask = _mask_np(
+            token_ranges=[(3, 5)],
+            segment_lengths=[3],
+            nv=3,
+            tpf=1,
+            frames=3,
+            nk=8,
+        )
+        seg_col = mask[:, 3]  # per-frame penalty for the segment's first token
+        assert np.any(seg_col == 0.0), (
+            f"length-3 segment has no zero-penalty frame (per-frame bias: "
+            f"{seg_col.tolist()}); reference floor-divides the midpoint"
+        )
+
+    def test_even_length_segment_unaffected_control(self):
+        mask = _mask_np(
+            token_ranges=[(3, 5)],
+            segment_lengths=[2],
+            nv=2,
+            tpf=1,
+            frames=2,
+            nk=8,
+        )
+        assert mask[1, 3] == 0.0  # frame 1 is the (floored) midpoint: free
+
+
+# ---------------------------------------------------------------------------
+# Finding 4 — out-of-range epsilon must be rejected, not silently defaulted
+# ---------------------------------------------------------------------------
+
+
+class TestEpsilonNotSilentlyDiscarded:
+    def _mask_for_eps(self, eps: float) -> np.ndarray:
+        return _mask_np(
+            token_ranges=[(3, 5)],
+            segment_lengths=[2],
+            nv=6,
+            tpf=1,
+            frames=6,
+            nk=8,
+            epsilon=eps,
+        )
+
+    def test_epsilon_one_rejected(self):
+        with pytest.raises(ValueError):
+            self._mask_for_eps(1.0)  # sigma -> inf; must not silently sharpen
+
+    def test_negative_epsilon_rejected(self):
+        with pytest.raises(ValueError):
+            self._mask_for_eps(-0.5)
+
+    def test_in_range_epsilon_ok(self):
+        """Control: the documented default stays valid."""
+        m = self._mask_for_eps(1e-3)
+        assert m.shape == (6, 8)


### PR DESCRIPTION
## What

Ports [WhatDreamsCost](https://github.com/WhatDreamsCost/WhatDreamsCost-ComfyUI) / Kijai **Prompt Relay** to ltx-2-mlx: sequence local prompts over time within a single generation. A training-free additive Gaussian penalty on the **video→text cross-attention (`attn2`)** gates each local prompt's token range to a slice of the timeline. The global `--prompt` still applies to every frame; each `--segment` biases its own window.

Method: <https://gordonchen19.github.io/Prompt-Relay/>

## Usage

```bash
ltx-2-mlx generate --distilled --frame-rate 24 \
  --prompt "cinematic film, a red-haired woman in a bedroom" \
  --segment "sitting on the bed" \
  --segment "standing and turning to the window" \
  --segment "looking back over her shoulder" \
  -o out.mp4
```

- `--segment "text" [LEN]` — repeatable, timeline order. `LEN` is optional (latent frames); omit to auto-distribute. Pinned + auto beats mix: pinned beats keep their length, the remainder is spread across the auto beats.
- `--relay-epsilon` (falloff, default `1e-3`), `--relay-strength` (penalty multiplier, default `1.0`).

## How it works

- New `conditioning/prompt_relay.py`: token-range mapping (incremental tokenization against the front-packed Gemma connector output), segment-length distribution, and the `(1,1,Nv,Nk)` additive bias.
- Threads a new `video_cross_attention_mask` kwarg through `LTXModel → BasicAVTransformerBlock → attn2` (previously unmasked) and the three denoise loops.
- `BasePipeline._prompt_relay_setup` / `_prompt_relay_mask` are shared by all generate modes (distilled, one-stage, two-stage, two-stage-hq); the mask is rebuilt per stage because tokens-per-frame differs between half/full res.
- **CFG-safe**: on `guided_denoise_loop` / `res2s_denoise_loop` the mask is applied to the positive-context passes (cond/ptb/mod) only and never to the unconditional pass — matching the reference, which never masks the negative prompt.
- Guarded against modality tiling (the mask can't be tiled across a split `Nv`).

## Testing

`tests/test_prompt_relay.py` (8 tests): mask math, token-range mapping, mixed pinned/auto lengths, a block-level test proving the mask reaches `attn2` and changes its output, and a guided-loop test proving cond-only masking under CFG.

- **Distilled** path verified end-to-end (real generation, both stages).
- **Dev / two-stage / HQ** paths are unit- and inspection-verified (cond-only routing test + signature/import checks); I don't have the dev model locally to run them end-to-end, so an extra pair of eyes on those wirings is welcome.

## Scope / limitations

- Video only for now — audio `attn2` is left unmasked (clean follow-up).
- Not compatible with `--tile-frames` / `--tile-spatial`.