### PR TITLE
fix: ic-lora dev-mode fuses distilled lora in the main pass; add --single-stage

### DIFF
--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/cli.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/cli.py
@@ -368,6 +368,40 @@ examples:
         help="IC-LoRA conditioning attention strength 0.0-1.0 (default: 1.0)",
     )
     ic.add_argument("--skip-stage-2", action="store_true", help="Skip stage 2 upsampling (half resolution output)")
+    ic.add_argument(
+        "--single-stage",
+        action="store_true",
+        help=(
+            "Single-stage full-resolution generation with the reference conditioning "
+            "applied throughout (Comfy Union Control topology). No upsampler / Stage 2. "
+            "Tracks the control signal more tightly than two-stage; slower at large res."
+        ),
+    )
+
+    ic.add_argument(
+        "--dev-transformer",
+        default=None,
+        help=(
+            "Dev (non-distilled) transformer filename. Enables dev mode: the "
+            "distilled LoRA is fused alongside the IC-LoRA (Comfy IC-LoRA recipe). "
+            "e.g. transformer.safetensors in a dev model dir"
+        ),
+    )
+
+    ic.add_argument(
+        "--distilled-lora",
+        default="ltx-2.3-22b-distilled-lora-384-1.1.safetensors",
+        help=(
+            "Distilled LoRA fused alongside the IC-LoRA in dev mode "
+            "(default: ltx-2.3-22b-distilled-lora-384-1.1.safetensors)"
+        ),
+    )
+    ic.add_argument(
+        "--distilled-lora-strength",
+        type=float,
+        default=0.5,
+        help="Distilled LoRA strength in dev mode (default: 0.5)",
+    )
 
     # --- lipdub ---
     ld = sub.add_parser(
@@ -924,7 +958,8 @@ def _cmd_ic_lora(args: argparse.Namespace) -> None:
     video_conditioning = [(path, float(strength)) for path, strength in args.video_conditioning]
 
     if not args.quiet:
-        print("Mode: IC-LoRA (two-stage)")
+        topology = "single-stage full-res" if args.single_stage else "two-stage"
+        print(f"Mode: IC-LoRA ({topology})")
         for path, strength in lora_paths:
             print(f"  LoRA: {path} (strength={strength})")
         for path, strength in video_conditioning:
@@ -936,8 +971,18 @@ def _cmd_ic_lora(args: argparse.Namespace) -> None:
         gemma_model_id=args.gemma,
         low_memory=True,
         low_ram_streaming=getattr(args, "low_ram", False),
+        dev_transformer=getattr(args, "dev_transformer", None),
+        distilled_lora=getattr(args, "distilled_lora", None),
+        distilled_lora_strength=getattr(args, "distilled_lora_strength", 0.5),
     )
     pipe.verbose = not args.quiet
+
+    if not args.quiet and pipe.dev_mode:
+        # _effective_lora_paths resolves + validates the distilled LoRA (raises
+        # early if missing) and returns it appended after the task IC-LoRA(s).
+        # A missing --dev-transformer already hard-fails in the constructor.
+        for path, strength in pipe._effective_lora_paths()[len(lora_paths):]:
+            print(f"  Distilled LoRA (dev mode): {path} (strength={strength})")
 
     pipe.generate_and_save(
         prompt=args.prompt,
@@ -953,6 +998,7 @@ def _cmd_ic_lora(args: argparse.Namespace) -> None:
         images=args.images,
         conditioning_attention_strength=args.conditioning_strength,
         skip_stage_2=args.skip_stage_2,
+        single_stage=args.single_stage,
     )
     _print_result(args.output, t0, args.quiet)
 

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/cli.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/cli.py
@@ -981,7 +981,7 @@ def _cmd_ic_lora(args: argparse.Namespace) -> None:
         # _effective_lora_paths resolves + validates the distilled LoRA (raises
         # early if missing) and returns it appended after the task IC-LoRA(s).
         # A missing --dev-transformer already hard-fails in the constructor.
-        for path, strength in pipe._effective_lora_paths()[len(lora_paths):]:
+        for path, strength in pipe._effective_lora_paths()[len(lora_paths) :]:
             print(f"  Distilled LoRA (dev mode): {path} (strength={strength})")
 
     pipe.generate_and_save(

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ic_lora.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ic_lora.py
@@ -66,6 +66,9 @@ class ICLoraPipeline(BasePipeline):
         gemma_model_id: str = "mlx-community/gemma-3-12b-it-4bit",
         low_memory: bool = True,
         low_ram_streaming: bool = False,
+        dev_transformer: str | None = None,
+        distilled_lora: str | None = None,
+        distilled_lora_strength: float = 0.5,
     ):
         super().__init__(
             model_dir,
@@ -95,6 +98,25 @@ class ICLoraPipeline(BasePipeline):
                     )
                 self.reference_downscale_factor = scale
 
+        # Dev mode detection. If --dev-transformer is given the file MUST exist:
+        # the model dir ships both dev and distilled transformers, so a missing
+        # dev transformer means a typo, not a legitimate fallback. Silently
+        # reverting to distilled mode here would also drop the distilled LoRA and
+        # reproduce the exact bad-output config dev mode is meant to fix.
+        self.dev_transformer_name = dev_transformer
+        self.dev_mode = False
+        if dev_transformer:
+            dev_path = self.model_dir / dev_transformer
+            if not dev_path.exists():
+                raise FileNotFoundError(
+                    f"--dev-transformer '{dev_transformer}' not found in model dir: {dev_path}"
+                )
+            self.dev_mode = True
+            logger.info(f"Dev mode enabled: using {dev_transformer}")
+
+        self.distilled_lora_path = distilled_lora
+        self.distilled_lora_strength = distilled_lora_strength
+
     def load(self) -> None:
         """Load generation components: DiT, VAE encoder, upsampler.
 
@@ -108,9 +130,12 @@ class ICLoraPipeline(BasePipeline):
 
         # DiT (largest component)
         if self.dit is None:
-            transformer_path = model_dir / "transformer.safetensors"
-            if not transformer_path.exists():
-                transformer_path = self._resolve_safetensors(model_dir, "transformer-distilled")
+            if self.dev_mode and self.dev_transformer_name:
+                transformer_path = model_dir / self.dev_transformer_name
+            else:
+                transformer_path = model_dir / "transformer.safetensors"
+                if not transformer_path.exists():
+                    transformer_path = self._resolve_safetensors(model_dir, "transformer-distilled")
             self.dit = self._load_transformer_with_optional_streaming(transformer_path)
 
         # VAE encoder (for encoding control videos and I2V images)
@@ -135,6 +160,24 @@ class ICLoraPipeline(BasePipeline):
 
         self._loaded = True
 
+    def _effective_lora_paths(self) -> list[tuple[str, float]]:
+        """LoRA (path, strength) list fused into the transformer for generation.
+
+        In dev mode this is the task IC-LoRA(s) plus the distilled LoRA @0.5,
+        matching the Comfy IC-LoRA recipe: dev checkpoint + IC-LoRA @1.0 +
+        distilled-lora @0.5 fused into the *same* model. In distilled mode it is
+        just the task IC-LoRA(s).
+        """
+        paths = list(self._lora_paths)
+        if self.dev_mode and self.distilled_lora_path:
+            distilled_file = Path(self.distilled_lora_path)
+            if not distilled_file.is_absolute():
+                distilled_file = self.model_dir / self.distilled_lora_path
+            if not distilled_file.exists():
+                raise FileNotFoundError(f"Distilled LoRA not found: {distilled_file}")
+            paths.append((str(distilled_file), self.distilled_lora_strength))
+        return paths
+
     def _fuse_loras(self) -> None:
         """Fuse all LoRA weights into the transformer.
 
@@ -143,8 +186,13 @@ class ICLoraPipeline(BasePipeline):
         the LoRAs are attached as ``BlockLoraSource`` to the streaming
         wrapper instead of being fused in-place — fusion happens at
         each block bind.
+
+        In dev mode the distilled LoRA is fused alongside the task IC-LoRA
+        (see :meth:`_effective_lora_paths`); LoRA deltas are additive, so
+        fusing them together in one pass is order-independent.
         """
-        if not self._lora_paths:
+        lora_paths = self._effective_lora_paths()
+        if not lora_paths:
             return
 
         assert self.dit is not None
@@ -153,7 +201,7 @@ class ICLoraPipeline(BasePipeline):
             from ltx_core_mlx.loader.block_streaming import BlockLoraSource
 
             sources: list = list(object.__getattribute__(self.dit, "_lora_sources"))
-            for lora_path, strength in self._lora_paths:
+            for lora_path, strength in lora_paths:
                 sources.append(
                     BlockLoraSource(
                         lora_path,
@@ -173,7 +221,7 @@ class ICLoraPipeline(BasePipeline):
 
         loader = SafetensorsStateDictLoader()
         lora_sds = []
-        for lora_path, strength in self._lora_paths:
+        for lora_path, strength in lora_paths:
             lora_sd = loader.load(lora_path, sd_ops=LTXV_LORA_COMFY_RENAMING_MAP)
             lora_sds.append(LoraStateDictWithStrength(state_dict=lora_sd, strength=strength))
             logger.info(f"Loaded LoRA: {lora_path} (strength={strength})")
@@ -184,7 +232,7 @@ class ICLoraPipeline(BasePipeline):
         self.dit.load_weights(list(fused_sd.sd.items()))
         aggressive_cleanup()
 
-        logger.info(f"Fused {len(self._lora_paths)} LoRA(s) into transformer")
+        logger.info(f"Fused {len(lora_paths)} LoRA(s) into transformer")
 
     def _reload_clean_transformer(self) -> None:
         """Reload the transformer without LoRA for Stage 2.
@@ -196,6 +244,9 @@ class ICLoraPipeline(BasePipeline):
         In ``low_ram_streaming`` mode we just clear the LoraSources from
         the streaming wrapper instead of full reload — the underlying
         block weights are streamed fresh from the safetensors.
+
+        Only used in the legacy distilled (non-dev) path. In dev mode both
+        LoRAs are retained across stages, so this is not called.
         """
         if self.low_ram_streaming and self.dit is not None:
             old_sources = list(object.__getattribute__(self.dit, "_lora_sources"))
@@ -314,6 +365,7 @@ class ICLoraPipeline(BasePipeline):
         conditioning_attention_strength: float = 1.0,
         conditioning_attention_mask: mx.array | None = None,
         skip_stage_2: bool = False,
+        single_stage: bool = False,
     ) -> tuple[mx.array, mx.array]:
         """Generate video with IC-LoRA reference conditioning.
 
@@ -333,6 +385,10 @@ class ICLoraPipeline(BasePipeline):
             conditioning_attention_mask: Optional pixel-space mask (1, 1, F, H, W)
                 matching reference video dimensions. Values in [0, 1].
             skip_stage_2: Skip upscale + refine, output at half resolution.
+            single_stage: Generate in one pass at full target resolution with the
+                pose/reference conditioning applied throughout (matches the Comfy
+                single-stage IC-LoRA workflows, e.g. Union Control). No upsampler,
+                no Stage 2 refine. Takes precedence over ``skip_stage_2``.
 
         Returns:
             Tuple of (video_latent, audio_latent).
@@ -362,9 +418,11 @@ class ICLoraPipeline(BasePipeline):
         # Fuse LoRA into transformer for Stage 1
         self._fuse_loras()
 
-        # --- Stage 1: Half-resolution generation with IC-LoRA ---
-        half_h, half_w = height // 2, width // 2
-        F, H_half, W_half = compute_video_latent_shape(num_frames, half_h, half_w)
+        # --- Stage 1: generation with IC-LoRA ---
+        # Two-stage generates at half res (Stage 2 upscales 2x). Single-stage
+        # generates directly at full target res (Comfy Union Control topology).
+        gen_h, gen_w = (height, width) if single_stage else (height // 2, width // 2)
+        F, H_half, W_half = compute_video_latent_shape(num_frames, gen_h, gen_w)
         video_shape = (1, F * H_half * W_half, 128)
         audio_T = compute_audio_token_count(num_frames, frame_rate=frame_rate)
         audio_shape = (1, audio_T, 128)
@@ -376,8 +434,8 @@ class ICLoraPipeline(BasePipeline):
         stage_1_conditionings = self._create_conditionings(
             images=images,
             video_conditioning=video_conditioning,
-            height=half_h,
-            width=half_w,
+            height=gen_h,
+            width=gen_w,
             num_frames=num_frames,
             frame_rate=frame_rate,
             conditioning_attention_strength=conditioning_attention_strength,
@@ -410,7 +468,8 @@ class ICLoraPipeline(BasePipeline):
             initial_latent=None,
         )
 
-        # Denoise stage 1
+        # Denoise stage 1. Dev and distilled share the fixed 8-step DISTILLED_SIGMAS
+        # (the Comfy IC-LoRA workflows use these exact ManualSigmas for stage 1).
         sigmas_1 = DISTILLED_SIGMAS[: stage1_steps + 1] if stage1_steps else DISTILLED_SIGMAS
         x0_model = X0Model(self.dit)
 
@@ -430,7 +489,9 @@ class ICLoraPipeline(BasePipeline):
         gen_tokens = output_1.video_latent[:, : F * H_half * W_half, :]
         video_half = self.video_patchifier.unpatchify(gen_tokens, (F, H_half, W_half))
 
-        if skip_stage_2:
+        # single_stage: full-res one-pass output (Union Control topology).
+        # skip_stage_2: half-res preview. Either way, return after Stage 1.
+        if single_stage or skip_stage_2:
             audio_latent = self.audio_patchifier.unpatchify(output_1.audio_latent)
             return video_half, audio_latent
 
@@ -480,12 +541,15 @@ class ICLoraPipeline(BasePipeline):
                 )
             )
 
-        # Free VAE encoder + upsampler + fused DiT before loading clean transformer
+        # Free VAE encoder + upsampler before Stage 2.
         if self.low_memory:
             self.image_conditioner.free()
             self.upsampler = None
-        # Reload clean transformer without LoRA (matches reference: separate model ledgers)
-        self._reload_clean_transformer()
+        # Dev mode keeps both LoRAs fused across stages (matches Comfy two-stage
+        # IC-LoRA workflows, which never reload a clean model). Legacy distilled
+        # mode reloads the clean transformer (separate model ledgers).
+        if not self.dev_mode:
+            self._reload_clean_transformer()
 
         video_tokens_up, _ = self.video_patchifier.patchify(video_upscaled)
 
@@ -554,6 +618,7 @@ class ICLoraPipeline(BasePipeline):
         images: list[tuple[str, int, float]] | None = None,
         conditioning_attention_strength: float = 1.0,
         skip_stage_2: bool = False,
+        single_stage: bool = False,
     ) -> str:
         """Generate IC-LoRA conditioned video+audio and save to file.
 
@@ -570,6 +635,7 @@ class ICLoraPipeline(BasePipeline):
             images: Optional list of (image_path, frame_index, strength) for I2V.
             conditioning_attention_strength: Attention strength for conditioning.
             skip_stage_2: Skip upscale + refine.
+            single_stage: Full-res one-pass generation (Union Control topology).
 
         Returns:
             Path to the output video file.
@@ -587,6 +653,7 @@ class ICLoraPipeline(BasePipeline):
             images=images,
             conditioning_attention_strength=conditioning_attention_strength,
             skip_stage_2=skip_stage_2,
+            single_stage=single_stage,
         )
 
         # Free generation components to make room for decoders

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ic_lora.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ic_lora.py
@@ -108,9 +108,7 @@ class ICLoraPipeline(BasePipeline):
         if dev_transformer:
             dev_path = self.model_dir / dev_transformer
             if not dev_path.exists():
-                raise FileNotFoundError(
-                    f"--dev-transformer '{dev_transformer}' not found in model dir: {dev_path}"
-                )
+                raise FileNotFoundError(f"--dev-transformer '{dev_transformer}' not found in model dir: {dev_path}")
             self.dev_mode = True
             logger.info(f"Dev mode enabled: using {dev_transformer}")
 

--- a/tests/test_iclora_dev_lora.py
+++ b/tests/test_iclora_dev_lora.py
@@ -1,0 +1,121 @@
+"""Unit tests for IC-LoRA dev-mode LoRA fusion + dev-transformer detection.
+
+Covers the two behavioral guarantees added when running the Comfy IC-LoRA recipe
+(dev checkpoint + task IC-LoRA @1.0 + distilled LoRA @0.5 fused together):
+
+- ``ICLoraPipeline._effective_lora_paths`` — appends the distilled LoRA in dev
+  mode (relative paths resolved against ``model_dir``, absolute passed through),
+  leaves the IC-LoRA list untouched in distilled mode, and hard-fails on a
+  missing distilled LoRA. This is the core of the fix: a future refactor that
+  drops the distilled LoRA from the generation pass (the original bug) breaks
+  these tests.
+- ``ICLoraPipeline.__init__`` — a supplied ``--dev-transformer`` that does not
+  exist raises immediately rather than silently reverting to distilled mode
+  (which would also drop the distilled LoRA and reproduce the bad-output config).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from ltx_pipelines_mlx.ic_lora import ICLoraPipeline
+
+
+def _bare_pipe(
+    model_dir: Path,
+    *,
+    dev_mode: bool,
+    distilled_lora_path: str | None,
+    distilled_lora_strength: float = 0.5,
+    lora_paths: list[tuple[str, float]] | None = None,
+) -> ICLoraPipeline:
+    """Construct just enough of ICLoraPipeline to exercise _effective_lora_paths.
+
+    Bypasses the heavy __init__ (model dir resolve, block construction, LoRA
+    download) via object.__new__ and sets only the attributes the method reads.
+    """
+    pipe = object.__new__(ICLoraPipeline)
+    pipe.model_dir = Path(model_dir)
+    pipe.dev_mode = dev_mode
+    pipe.distilled_lora_path = distilled_lora_path
+    pipe.distilled_lora_strength = distilled_lora_strength
+    pipe._lora_paths = list(lora_paths or [])
+    return pipe
+
+
+# --- _effective_lora_paths ---------------------------------------------------
+
+
+def test_distilled_mode_returns_ic_lora_only(tmp_path):
+    """Non-dev mode ignores the distilled LoRA even if one is configured."""
+    ic = [("ic.safetensors", 1.0)]
+    pipe = _bare_pipe(tmp_path, dev_mode=False, distilled_lora_path="distilled.safetensors", lora_paths=ic)
+    assert pipe._effective_lora_paths() == ic
+
+
+def test_dev_mode_appends_distilled_relative(tmp_path):
+    """Dev mode appends the distilled LoRA at its strength, resolved vs model_dir."""
+    distilled = tmp_path / "distilled.safetensors"
+    distilled.write_bytes(b"")
+    ic = [("ic.safetensors", 1.0)]
+    pipe = _bare_pipe(
+        tmp_path,
+        dev_mode=True,
+        distilled_lora_path="distilled.safetensors",
+        distilled_lora_strength=0.5,
+        lora_paths=ic,
+    )
+    assert pipe._effective_lora_paths() == [*ic, (str(distilled), 0.5)]
+
+
+def test_dev_mode_appends_distilled_absolute(tmp_path):
+    """An absolute distilled path is passed through unchanged (not re-rooted)."""
+    other = tmp_path / "elsewhere"
+    other.mkdir()
+    distilled = other / "distilled.safetensors"
+    distilled.write_bytes(b"")
+    pipe = _bare_pipe(
+        tmp_path,
+        dev_mode=True,
+        distilled_lora_path=str(distilled),
+        distilled_lora_strength=0.25,
+        lora_paths=[("ic.safetensors", 1.0)],
+    )
+    assert pipe._effective_lora_paths()[-1] == (str(distilled), 0.25)
+
+
+def test_dev_mode_missing_distilled_raises(tmp_path):
+    """A configured-but-absent distilled LoRA fails fast with a clear error."""
+    pipe = _bare_pipe(tmp_path, dev_mode=True, distilled_lora_path="nope.safetensors", lora_paths=[])
+    with pytest.raises(FileNotFoundError, match="Distilled LoRA not found"):
+        pipe._effective_lora_paths()
+
+
+def test_dev_mode_without_distilled_configured(tmp_path):
+    """Dev mode with no distilled LoRA set leaves the IC-LoRA list untouched."""
+    ic = [("ic.safetensors", 1.0)]
+    pipe = _bare_pipe(tmp_path, dev_mode=True, distilled_lora_path=None, lora_paths=ic)
+    assert pipe._effective_lora_paths() == ic
+
+
+# --- dev-transformer detection (via real __init__) ---------------------------
+
+
+def test_missing_dev_transformer_hard_fails(tmp_path):
+    """A supplied --dev-transformer that doesn't exist raises, no silent fallback."""
+    with pytest.raises(FileNotFoundError, match="dev-transformer"):
+        ICLoraPipeline(model_dir=str(tmp_path), lora_paths=None, dev_transformer="missing.safetensors")
+
+
+def test_present_dev_transformer_enables_dev_mode(tmp_path):
+    (tmp_path / "transformer.safetensors").write_bytes(b"")
+    pipe = ICLoraPipeline(model_dir=str(tmp_path), lora_paths=None, dev_transformer="transformer.safetensors")
+    assert pipe.dev_mode is True
+    assert pipe.dev_transformer_name == "transformer.safetensors"
+
+
+def test_no_dev_transformer_stays_distilled_mode(tmp_path):
+    pipe = ICLoraPipeline(model_dir=str(tmp_path), lora_paths=None)
+    assert pipe.dev_mode is False


### PR DESCRIPTION
## Problem

The `ic-lora` pipeline diverged from the reference ComfyUI-LTXVideo IC-LoRA workflows, giving poor output on the Union Control workflow — weak prompt adherence with the distilled checkpoint, and motion/hand distortion when swapping in the dev checkpoint.

Comparing against every `LTX-2.3_ICLoRA_*` example workflow shows one consistent recipe:

- **dev** checkpoint (`ltx-2.3-22b-dev`), not distilled
- task IC-LoRA @ **1.0** **and** `distilled-lora-384-1.1` @ **0.5** fused into the **same** model for the main pass (the distilled LoRA @0.5 is what lets the dev model sample in 8 steps — it is not a stage-2-only thing)
- stage-1 sigmas = the fixed 8-step `DISTILLED_SIGMAS` (ManualSigmas), **not** a dynamic shift schedule
- two-stage variants keep **both** LoRAs across both stages — they never reload a clean model

The previous dev-mode implementation fused the distilled LoRA only in stage 2, substituted a dynamic dev sigma schedule, and silently fell back to distilled mode on a bad `--dev-transformer` — reproducing the exact degraded config.

## Changes

- **`_effective_lora_paths`** appends the distilled LoRA alongside the task IC-LoRA so both fuse together **before stage 1** (LoRA deltas are additive; order-independent). Fixes the motion/hand distortion.
- **Dev-mode two-stage keeps both LoRAs across stages** (skips the clean-transformer reload). Legacy distilled (non-dev) path unchanged.
- **Revert the dynamic dev sigma schedule** — dev and distilled share `DISTILLED_SIGMAS`.
- **Hard-fail on a missing `--dev-transformer`** instead of silently reverting to distilled mode (which would also drop the distilled LoRA).
- **Restore** the `low_ram_streaming` cleanup branch that had been gutted.
- **Add `--single-stage`**: full-res one-pass generation with the reference conditioning applied throughout (Comfy Union Control topology — no upsampler / stage 2). Tracks the control video noticeably tighter than two-stage, since two-stage generates stage 1 at half res and drops the reference in the stage-2 refine.
- CLI: bump `--distilled-lora` default to `384-1.1`; print dev-mode / distilled LoRA and topology in the run summary.

## Validation

- Confirmed end-to-end on a pose (DWPose) Union Control dance clip: dev + both LoRAs gives strong prompt adherence and clean motion; `--single-stage` tracks the control skeleton tightly at full res.
- New unit tests cover `_effective_lora_paths` (distilled / dev / relative / absolute / missing distilled) and dev-transformer detection.

## Notes

- No collision with the other open PRs (#60 quant-fix, #61 prompt-relay): the only shared file is `cli.py` with #61, in fully disjoint regions (`ic-lora` subparser + `_cmd_ic_lora` vs the generate command). `ic_lora.py` is untouched by any open PR.