### PR TITLE
feat: ic-lora --upsample-only + control-aware --refine-steps

### DIFF
--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/cli.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/cli.py
@@ -409,6 +409,18 @@ examples:
         ),
     )
     ic.add_argument(
+        "--refine-steps",
+        type=int,
+        default=None,
+        help=(
+            "With --upsample-only, run an N-step control-aware refine after the "
+            "upsample: re-encodes the control at full resolution and re-applies it "
+            "with the IC-LoRA fused, cleaning upsampler artifacts without the "
+            "adherence drift of two-stage. 3 ~ matches the standard Stage 2 depth; "
+            "higher = more cleanup + more drift from the draft (capped at 8)."
+        ),
+    )
+    ic.add_argument(
         "--single-stage",
         action="store_true",
         help=(
@@ -1020,6 +1032,8 @@ def _cmd_ic_lora(args: argparse.Namespace) -> None:
     if not args.quiet:
         if args.single_stage:
             topology = "single-stage full-res"
+        elif args.upsample_only and args.refine_steps:
+            topology = f"upsample + {args.refine_steps}-step control-aware refine (half-res gen + 2x upsample)"
         elif args.upsample_only:
             topology = "upsample-only (half-res gen + 2x upsample, no refine)"
         else:
@@ -1065,6 +1079,7 @@ def _cmd_ic_lora(args: argparse.Namespace) -> None:
         skip_stage_2=args.skip_stage_2,
         single_stage=args.single_stage,
         upsample_only=args.upsample_only,
+        refine_steps=args.refine_steps,
     )
     _print_result(args.output, t0, args.quiet)
 

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/cli.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/cli.py
@@ -399,6 +399,16 @@ examples:
     )
     ic.add_argument("--skip-stage-2", action="store_true", help="Skip stage 2 upsampling (half resolution output)")
     ic.add_argument(
+        "--upsample-only",
+        action="store_true",
+        help=(
+            "Half-res generative pass (control applied throughout) + 2x latent "
+            "upsample, then decode directly at full resolution — skips the Stage 2 "
+            "refine that drops control adherence. ~3x faster than --single-stage; "
+            "control fidelity sits between two-stage and native single-stage."
+        ),
+    )
+    ic.add_argument(
         "--single-stage",
         action="store_true",
         help=(
@@ -1008,7 +1018,12 @@ def _cmd_ic_lora(args: argparse.Namespace) -> None:
     video_conditioning = [(path, float(strength)) for path, strength in args.video_conditioning]
 
     if not args.quiet:
-        topology = "single-stage full-res" if args.single_stage else "two-stage"
+        if args.single_stage:
+            topology = "single-stage full-res"
+        elif args.upsample_only:
+            topology = "upsample-only (half-res gen + 2x upsample, no refine)"
+        else:
+            topology = "two-stage"
         print(f"Mode: IC-LoRA ({topology})")
         for path, strength in lora_paths:
             print(f"  LoRA: {path} (strength={strength})")
@@ -1049,6 +1064,7 @@ def _cmd_ic_lora(args: argparse.Namespace) -> None:
         conditioning_attention_strength=args.conditioning_strength,
         skip_stage_2=args.skip_stage_2,
         single_stage=args.single_stage,
+        upsample_only=args.upsample_only,
     )
     _print_result(args.output, t0, args.quiet)
 

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ic_lora.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ic_lora.py
@@ -364,6 +364,7 @@ class ICLoraPipeline(BasePipeline):
         conditioning_attention_mask: mx.array | None = None,
         skip_stage_2: bool = False,
         single_stage: bool = False,
+        upsample_only: bool = False,
     ) -> tuple[mx.array, mx.array]:
         """Generate video with IC-LoRA reference conditioning.
 
@@ -387,6 +388,14 @@ class ICLoraPipeline(BasePipeline):
                 pose/reference conditioning applied throughout (matches the Comfy
                 single-stage IC-LoRA workflows, e.g. Union Control). No upsampler,
                 no Stage 2 refine. Takes precedence over ``skip_stage_2``.
+            upsample_only: Run the half-res generative stage (conditioning applied
+                throughout, same as Stage 1), upscale the latent 2x with the
+                LatentUpsampler, and decode directly — skipping the Stage 2 refine
+                that drops control adherence. Output is at full target resolution.
+                Cheaper than ``single_stage`` (gen runs at half res) but the control
+                is encoded at half res, so fine-detail adherence sits between
+                two-stage and native single-stage. Ignored if ``single_stage`` or
+                ``skip_stage_2`` is set.
 
         Returns:
             Tuple of (video_latent, audio_latent).
@@ -419,7 +428,18 @@ class ICLoraPipeline(BasePipeline):
         # --- Stage 1: generation with IC-LoRA ---
         # Two-stage generates at half res (Stage 2 upscales 2x). Single-stage
         # generates directly at full target res (Comfy Union Control topology).
-        gen_h, gen_w = (height, width) if single_stage else (height // 2, width // 2)
+        if single_stage:
+            gen_h, gen_w = height, width
+        else:
+            # Half-res stages must land on a VAE-compatible grid: image
+            # conditioning encodes at these exact pixel dims, and the VAE's
+            # space_to_depth requires multiples of 32 (raw height//2 can leave a
+            # remainder, e.g. 928//2=464). Floor to a multiple of 32. This is
+            # latent-neutral — compute_video_latent_shape already floors //32, so
+            # the latent grid (and the ref-video resolution, which snaps the same
+            # way) is unchanged versus the raw half dims.
+            gen_h = (height // 2 // 32) * 32
+            gen_w = (width // 2 // 32) * 32
         F, H_half, W_half = compute_video_latent_shape(num_frames, gen_h, gen_w)
         video_shape = (1, F * H_half * W_half, 128)
         audio_T = compute_audio_token_count(num_frames, frame_rate=frame_rate)
@@ -507,6 +527,18 @@ class ICLoraPipeline(BasePipeline):
         video_up_mlx = self.vae_encoder.normalize_latent(video_up_mlx)
         video_upscaled = video_up_mlx.transpose(0, 4, 1, 2, 3)  # back to (B,C,F,H,W)
         mx.eval(video_upscaled)
+
+        # upsample_only: decode the upscaled latent directly, skipping the Stage 2
+        # refine (which re-noises and denoises without re-applying the control
+        # reference, drifting off the conditioning). The upsampler output is
+        # already a normalized model-space latent, so it decodes like any other.
+        if upsample_only:
+            audio_latent = self.audio_patchifier.unpatchify(output_1.audio_latent)
+            if self.low_memory:
+                self.image_conditioner.free()
+                self.upsampler = None
+                aggressive_cleanup()
+            return video_upscaled, audio_latent
 
         # Derive full-resolution latent dims from the ACTUAL upscaled shape,
         # not the target height/width (which may round differently).
@@ -617,6 +649,7 @@ class ICLoraPipeline(BasePipeline):
         conditioning_attention_strength: float = 1.0,
         skip_stage_2: bool = False,
         single_stage: bool = False,
+        upsample_only: bool = False,
     ) -> str:
         """Generate IC-LoRA conditioned video+audio and save to file.
 
@@ -634,6 +667,7 @@ class ICLoraPipeline(BasePipeline):
             conditioning_attention_strength: Attention strength for conditioning.
             skip_stage_2: Skip upscale + refine.
             single_stage: Full-res one-pass generation (Union Control topology).
+            upsample_only: Half-res gen + latent upsample, no refine (full-res output).
 
         Returns:
             Path to the output video file.
@@ -652,6 +686,7 @@ class ICLoraPipeline(BasePipeline):
             conditioning_attention_strength=conditioning_attention_strength,
             skip_stage_2=skip_stage_2,
             single_stage=single_stage,
+            upsample_only=upsample_only,
         )
 
         # Free generation components to make room for decoders

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ic_lora.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ic_lora.py
@@ -365,6 +365,7 @@ class ICLoraPipeline(BasePipeline):
         skip_stage_2: bool = False,
         single_stage: bool = False,
         upsample_only: bool = False,
+        refine_steps: int | None = None,
     ) -> tuple[mx.array, mx.array]:
         """Generate video with IC-LoRA reference conditioning.
 
@@ -396,6 +397,16 @@ class ICLoraPipeline(BasePipeline):
                 is encoded at half res, so fine-detail adherence sits between
                 two-stage and native single-stage. Ignored if ``single_stage`` or
                 ``skip_stage_2`` is set.
+            refine_steps: Only meaningful with ``upsample_only``. When > 0, run a
+                *control-aware* refine after the upsample instead of decoding raw:
+                the control reference is re-encoded at full resolution and re-appended
+                with the IC-LoRA kept fused, then a short denoise cleans the upsampler
+                artifacts while the (now full-res) control sharpens adherence. Unlike
+                the legacy two-stage Stage 2, this does NOT reload a clean model and
+                does NOT drop the control. Steps map onto the distilled sigma tail:
+                more steps start from a higher sigma (more cleanup, more drift from the
+                draft). Capped at ``len(DISTILLED_SIGMAS) - 1``. ``refine_steps=3``
+                matches the STAGE_2_SIGMAS schedule.
 
         Returns:
             Tuple of (video_latent, audio_latent).
@@ -528,11 +539,15 @@ class ICLoraPipeline(BasePipeline):
         video_upscaled = video_up_mlx.transpose(0, 4, 1, 2, 3)  # back to (B,C,F,H,W)
         mx.eval(video_upscaled)
 
-        # upsample_only: decode the upscaled latent directly, skipping the Stage 2
-        # refine (which re-noises and denoises without re-applying the control
-        # reference, drifting off the conditioning). The upsampler output is
-        # already a normalized model-space latent, so it decodes like any other.
-        if upsample_only:
+        # upsample_only without refine: decode the upscaled latent directly,
+        # skipping any Stage 2 denoise. The upsampler output is already a
+        # normalized model-space latent, so it decodes like any other.
+        # With refine_steps > 0 we instead fall through to a control-aware refine
+        # (below) that keeps the IC-LoRA fused and re-applies the control at full
+        # res — cleaning upsampler artifacts without the adherence drift of the
+        # legacy two-stage Stage 2.
+        control_aware_refine = upsample_only and bool(refine_steps)
+        if upsample_only and not control_aware_refine:
             audio_latent = self.audio_patchifier.unpatchify(output_1.audio_latent)
             if self.low_memory:
                 self.image_conditioner.free()
@@ -571,27 +586,57 @@ class ICLoraPipeline(BasePipeline):
                 )
             )
 
+        # Control-aware refine: re-encode the control reference at full resolution
+        # and append it (with the IC-LoRA still fused, below) so the refine tracks
+        # the control — the whole point of this path. Stage 1 only saw the control
+        # at half res; here it gets the full-res signal to recover fine detail
+        # (e.g. fast-moving limbs). Legacy two-stage skips this, which is why its
+        # Stage 2 drifts off the conditioning.
+        if control_aware_refine:
+            append_ic_lora_reference_video_conditionings(
+                conditionings_2,
+                video_conditioning,
+                height=enc_h_full,
+                width=enc_w_full,
+                num_frames=num_frames,
+                video_encoder=self.vae_encoder,
+                reference_downscale_factor=self.reference_downscale_factor,
+                conditioning_attention_strength=conditioning_attention_strength,
+                conditioning_attention_mask=conditioning_attention_mask,
+            )
+
         # Free VAE encoder + upsampler before Stage 2.
         if self.low_memory:
             self.image_conditioner.free()
             self.upsampler = None
         # Dev mode keeps both LoRAs fused across stages (matches Comfy two-stage
         # IC-LoRA workflows, which never reload a clean model). Legacy distilled
-        # mode reloads the clean transformer (separate model ledgers).
-        if not self.dev_mode:
+        # mode reloads the clean transformer (separate model ledgers). The
+        # control-aware refine also keeps the fused model — the IC-LoRA must stay
+        # present to consume the re-appended reference tokens.
+        if not self.dev_mode and not control_aware_refine:
             self._reload_clean_transformer()
 
         video_tokens_up, _ = self.video_patchifier.patchify(video_upscaled)
 
-        sigmas_2 = STAGE_2_SIGMAS[: stage2_steps + 1] if stage2_steps else STAGE_2_SIGMAS
+        if control_aware_refine:
+            # Refine depth maps onto the distilled sigma tail: N steps ending at
+            # 0.0, starting from a higher sigma for larger N (more cleanup, more
+            # drift from the upscaled draft). refine_steps=3 == STAGE_2_SIGMAS.
+            n = max(1, min(int(refine_steps), len(DISTILLED_SIGMAS) - 1))
+            sigmas_2 = DISTILLED_SIGMAS[len(DISTILLED_SIGMAS) - 1 - n :]
+        else:
+            sigmas_2 = STAGE_2_SIGMAS[: stage2_steps + 1] if stage2_steps else STAGE_2_SIGMAS
         start_sigma = sigmas_2[0]
 
         video_positions_2 = compute_video_positions(F, H_full, W_full, frame_rate=frame_rate)
 
         # Stage 2 video: scalar-blend bit-matches legacy inline arithmetic.
-        # IC-LoRA Stage 1 already accepts a small RNG-shift drift due to the
-        # reference-token shape change; Stage 2 stays bit-exact since cond_2
-        # is at most a LatentIndex replace (no shape change).
+        # In legacy two-stage, cond_2 is at most a LatentIndex replace (no shape
+        # change) so Stage 2 stays bit-exact. The control-aware refine additionally
+        # appends the reference tokens here (same shape-change / RNG-shift pattern
+        # as Stage 1's reference append), so it is intentionally not bit-exact with
+        # the legacy path.
         video_state_2 = create_noised_state(
             base_shape=video_tokens_up.shape,
             conditionings=conditionings_2,
@@ -627,7 +672,13 @@ class ICLoraPipeline(BasePipeline):
         if self.low_memory:
             aggressive_cleanup()
 
-        video_latent = self.video_patchifier.unpatchify(output_2.video_latent, (F, H_full, W_full))
+        # Control-aware refine appended reference tokens — strip them before
+        # unpatchify (mirrors the Stage 1 gen-token extraction). Legacy two-stage
+        # has no appended tokens, so its full latent unpatchifies as-is.
+        video_out = output_2.video_latent
+        if control_aware_refine:
+            video_out = video_out[:, : F * H_full * W_full, :]
+        video_latent = self.video_patchifier.unpatchify(video_out, (F, H_full, W_full))
         audio_latent = self.audio_patchifier.unpatchify(output_2.audio_latent)
 
         return video_latent, audio_latent
@@ -650,6 +701,7 @@ class ICLoraPipeline(BasePipeline):
         skip_stage_2: bool = False,
         single_stage: bool = False,
         upsample_only: bool = False,
+        refine_steps: int | None = None,
     ) -> str:
         """Generate IC-LoRA conditioned video+audio and save to file.
 
@@ -668,6 +720,8 @@ class ICLoraPipeline(BasePipeline):
             skip_stage_2: Skip upscale + refine.
             single_stage: Full-res one-pass generation (Union Control topology).
             upsample_only: Half-res gen + latent upsample, no refine (full-res output).
+            refine_steps: With upsample_only, run an N-step control-aware refine
+                after the upsample (full-res control re-applied, IC-LoRA fused).
 
         Returns:
             Path to the output video file.
@@ -687,6 +741,7 @@ class ICLoraPipeline(BasePipeline):
             skip_stage_2=skip_stage_2,
             single_stage=single_stage,
             upsample_only=upsample_only,
+            refine_steps=refine_steps,
         )
 
         # Free generation components to make room for decoders


### PR DESCRIPTION
## Summary

Adds two cheaper IC-LoRA topologies for Apple Silicon, where native single-stage at usable resolutions is prohibitively slow (~30 min for a 20s 480×928 clip on high-end Macs):

- **`--upsample-only`** — half-res generative pass (control applied throughout, same as Stage 1), 2× latent upsample, decode directly. No refine. Fast rough draft.
- **`--refine-steps N`** — with `--upsample-only`, run an N-step *control-aware* refine after the upsample: re-encode the control at full resolution and re-append it with the IC-LoRA kept fused. Cleans upsampler artifacts while the now-full-res control sharpens adherence.

Legacy two-stage and single-stage paths are untouched.

## Why the refine is not just two-stage Stage 2

Same input latent, same resolution, same sigma schedule (`--refine-steps 3` == `STAGE_2_SIGMAS`). The difference is what steers the refine:

| | latent res | sigma schedule (steps=3) | control reference | model |
|---|---|---|---|---|
| two-stage Stage 2 (non-dev) | full | `STAGE_2_SIGMAS` | dropped | clean distilled (no IC-LoRA) |
| `--refine-steps 3` | full | `STAGE_2_SIGMAS` (identical) | re-appended @ full res | distilled + IC-LoRA fused |

Two-stage Stage 2 is a control-*blind* cleanup (reference dropped, clean model reloaded); this is a control-*aware* one. Both changes are needed together — the re-appended reference tokens are only meaningful because the IC-LoRA stays fused to consume them. Bonus: the control is re-encoded at full res for the refine, sharper than the half-res signal Stage 1 saw.

## Refine depth

`--refine-steps` maps onto the distilled sigma tail — N steps ending at 0.0, higher N starts from a higher sigma (more cleanup, more drift from the draft):

| N | start σ | behavior |
|---|---|---|
| 1 | 0.42 | lightest — de-fuzz, closest to draft |
| 3 | 0.91 | matches standard Stage 2 depth |
| 4 | 0.98 | more aggressive limb/artifact reconstruction |
| 8 | 1.0 | full regeneration at full res |

Capped at `len(DISTILLED_SIGMAS) - 1 = 8`.

## Also fixed

Half-res gen dims are floored to a multiple of 32 so image conditioning encodes on a VAE-compatible grid (raw `height // 2` can leave a remainder, e.g. `928 // 2 = 464`, crashing the encoder's `space_to_depth`). Latent-neutral — the latent grid already floors `// 32` — so it also hardens the default two-stage path for image-conditioned runs at non-64-divisible dims.

## Results (480×928 → 448×896 out, 481 frames, seed 42, union-control ref0.5, M5 Pro 64GB Macbook Pro)

| topology | wall time | quality notes |
|---|---|---|
| single-stage (baseline) | ~30 min | reference quality, control-tight |
| `--upsample-only` | ~4.4 min | fast; blurred edges, scattered fast-motion, missing arm (dance sequence) |
| `--upsample-only --refine-steps 3` | ~14 min | close to single-stage; upper-body scatter and missing arm resolved; residual softness on fast-moving hands is genuine motion blur, not refinement artifacts |

Timing breakdown for `--refine-steps 3` (run 1): Stage 1 8×23.09s = 3:04, refine 3×190.84s = 9:32, decode 80.9s → ~14 min (~2.1× faster than single-stage). The refine step is ~8× a Stage 1 step: full-res gen tokens (4×) plus the appended full-res control tokens with O(n²) attention.

Second validation run (different reference image + conditioning, `--refine-steps 3`): Stage 1 3:01, refine 9:06, decode 79.0s → ~13.5 min (consistent). Movements stayed true to the conditioning video — the control-aware refine generalized. Quality was below run 1, but the cause was an input mismatch (the conditioning image was not framed to the control stick figure, forcing a zoom-out that cost face identity), not a refine-mechanism regression. Framing the reference image to the control subject matters for final quality.

## Scope / safety

- New behavior is gated behind `--upsample-only` (+ `--refine-steps > 0`); the default two-stage path is bit-for-bit unchanged (`control_aware_refine=False` preserves the clean-model reload, the `STAGE_2_SIGMAS` schedule, and no-append behavior).
- CI gates pass locally: `ruff check packages/ tests/`, `ruff format --check packages/ tests/`, AST syntax pass. Existing IC-LoRA tests (14) pass.
