### PR TITLE
feat: warn on output dimension snapping via shared helper

### DIFF
--- a/packages/ltx-core-mlx/src/ltx_core_mlx/components/patchifiers.py
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/components/patchifiers.py
@@ -5,7 +5,14 @@ Ported from ltx-core/src/ltx_core/components/patchifiers.py
 
 from __future__ import annotations
 
+import logging
+
 import mlx.core as mx
+
+logger = logging.getLogger(__name__)
+
+# VAE spatial compression: pixel dims must be multiples of this to encode cleanly.
+SPATIAL_COMPRESSION = 32
 
 
 class VideoLatentPatchifier:
@@ -115,3 +122,60 @@ def compute_video_latent_shape(
     H = height // spatial_compression
     W = width // spatial_compression
     return F, H, W
+
+
+def snap_output_dimensions(
+    height: int,
+    width: int,
+    *,
+    two_stage: bool,
+    warn: bool = True,
+) -> tuple[int, int]:
+    """Snap output dimensions down to the grid the VAE + pipeline topology require.
+
+    The video VAE encodes in blocks of ``SPATIAL_COMPRESSION`` (32) px, so every
+    pipeline already floors its latent grid ``//32`` (see
+    :func:`compute_video_latent_shape`). Two-stage pipelines additionally generate
+    Stage 1 at half resolution (``height // 2``) and upscale ``2x``, so the *full*
+    dimension must be a multiple of ``64`` for the half-res grid to itself be a
+    multiple of 32. Single-stage pipelines only need multiples of ``32``.
+
+    This snap is not a new behavior — non-conforming dims are already floored
+    silently downstream (and the CLI default ``--height 480`` is not a multiple of
+    64, so a bare two-stage run already snaps 480 -> 448). This helper centralizes
+    the arithmetic so every pipeline reports the same output size the same way,
+    rather than each silently rounding. It is a pure floor: it never raises and
+    never rounds up (staying within the requested/memory budget), and it is
+    idempotent, so it composes safely through nested/chained flows.
+
+    Args:
+        height: Requested output height in pixels.
+        width: Requested output width in pixels.
+        two_stage: True for half-res Stage-1 pipelines (modulus 64); False for
+            single-stage / one-stage pipelines (modulus 32).
+        warn: When True, log an informational warning (once) if either dim was
+            snapped, naming the resulting output size.
+
+    Returns:
+        ``(snapped_height, snapped_width)`` — each floored to the required
+        multiple and clamped to at least one tile.
+    """
+    modulus = 2 * SPATIAL_COMPRESSION if two_stage else SPATIAL_COMPRESSION
+    snapped_height = max(modulus, (height // modulus) * modulus)
+    snapped_width = max(modulus, (width // modulus) * modulus)
+
+    if warn and (snapped_height != height or snapped_width != width):
+        stage = "two-stage half-res" if two_stage else "single-stage"
+        hint = " Use --single-stage for exact dims." if two_stage else ""
+        logger.warning(
+            "%s snaps dims to multiples of %d; output will be %dx%d (requested %dx%d).%s",
+            stage,
+            modulus,
+            snapped_height,
+            snapped_width,
+            height,
+            width,
+            hint,
+        )
+
+    return snapped_height, snapped_width

--- a/packages/ltx-core-mlx/src/ltx_core_mlx/components/patchifiers.py
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/components/patchifiers.py
@@ -171,10 +171,10 @@ def snap_output_dimensions(
             "%s snaps dims to multiples of %d; output will be %dx%d (requested %dx%d).%s",
             stage,
             modulus,
-            snapped_height,
             snapped_width,
-            height,
+            snapped_height,
             width,
+            height,
             hint,
         )
 

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/a2vid_two_stage.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/a2vid_two_stage.py
@@ -19,7 +19,10 @@ from ltx_core_mlx.components.guiders import (
     MultiModalGuiderParams,
     create_multimodal_guider_factory,
 )
-from ltx_core_mlx.components.patchifiers import compute_video_latent_shape
+from ltx_core_mlx.components.patchifiers import (
+    compute_video_latent_shape,
+    snap_output_dimensions,
+)
 from ltx_core_mlx.conditioning.types.latent_cond import (
     LatentState,
 )
@@ -183,6 +186,8 @@ class A2VidPipelineTwoStage(TI2VidTwoStagesPipeline):
         assert self.dit is not None
 
         # --- Stage 1: Half resolution with CFG, audio frozen ---
+        # Snap to the two-stage grid (multiples of 64) and report if it changed.
+        height, width = snap_output_dimensions(height, width, two_stage=True)
         half_h, half_w = height // 2, width // 2
         F, H_half, W_half = compute_video_latent_shape(num_frames, half_h, half_w)
         video_shape = (1, F * H_half * W_half, 128)

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/distilled.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/distilled.py
@@ -23,7 +23,10 @@ from __future__ import annotations
 
 import mlx.core as mx
 
-from ltx_core_mlx.components.patchifiers import compute_video_latent_shape
+from ltx_core_mlx.components.patchifiers import (
+    compute_video_latent_shape,
+    snap_output_dimensions,
+)
 from ltx_core_mlx.model.transformer.model import X0Model
 from ltx_core_mlx.utils.memory import aggressive_cleanup
 from ltx_core_mlx.utils.positions import (
@@ -162,6 +165,8 @@ class DistilledPipeline(TI2VidTwoStagesPipeline):
         assert self.upsampler is not None
 
         # --- Stage 1: half resolution ---
+        # Snap to the two-stage grid (multiples of 64) and report if it changed.
+        height, width = snap_output_dimensions(height, width, two_stage=True)
         half_h, half_w = height // 2, width // 2
         F, H_half, W_half = compute_video_latent_shape(num_frames, half_h, half_w)
         video_shape = (1, F * H_half * W_half, 128)

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ic_lora.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ic_lora.py
@@ -18,7 +18,10 @@ from pathlib import Path
 
 import mlx.core as mx
 
-from ltx_core_mlx.components.patchifiers import compute_video_latent_shape
+from ltx_core_mlx.components.patchifiers import (
+    compute_video_latent_shape,
+    snap_output_dimensions,
+)
 from ltx_core_mlx.loader import (
     LTXV_LORA_BLOCK_PREFIX,
     LTXV_LORA_COMFY_RENAMING_MAP,
@@ -437,20 +440,18 @@ class ICLoraPipeline(BasePipeline):
         self._fuse_loras()
 
         # --- Stage 1: generation with IC-LoRA ---
-        # Two-stage generates at half res (Stage 2 upscales 2x). Single-stage
-        # generates directly at full target res (Comfy Union Control topology).
+        # Two-stage generates at half res (Stage 2 upscales 2x, so full dims must
+        # be multiples of 64); single-stage generates directly at full target res
+        # (Comfy Union Control topology, multiples of 32). Snap up front and report
+        # if the requested dims changed; downstream derivations stay consistent.
+        height, width = snap_output_dimensions(height, width, two_stage=not single_stage)
         if single_stage:
             gen_h, gen_w = height, width
         else:
-            # Half-res stages must land on a VAE-compatible grid: image
-            # conditioning encodes at these exact pixel dims, and the VAE's
-            # space_to_depth requires multiples of 32 (raw height//2 can leave a
-            # remainder, e.g. 928//2=464). Floor to a multiple of 32. This is
-            # latent-neutral — compute_video_latent_shape already floors //32, so
-            # the latent grid (and the ref-video resolution, which snaps the same
-            # way) is unchanged versus the raw half dims.
-            gen_h = (height // 2 // 32) * 32
-            gen_w = (width // 2 // 32) * 32
+            # Stage 1 encodes image conditioning at these exact half-res pixel dims;
+            # the snap above guarantees height/width are multiples of 64, so half is
+            # already a multiple of 32 (the VAE space_to_depth grid).
+            gen_h, gen_w = height // 2, width // 2
         F, H_half, W_half = compute_video_latent_shape(num_frames, gen_h, gen_w)
         video_shape = (1, F * H_half * W_half, 128)
         audio_T = compute_audio_token_count(num_frames, frame_rate=frame_rate)

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/iclora_utils.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/iclora_utils.py
@@ -114,7 +114,7 @@ def append_ic_lora_reference_video_conditionings(
     scale = reference_downscale_factor
     if scale != 1 and (height % scale != 0 or width % scale != 0):
         raise ValueError(
-            f"Output dimensions ({height}x{width}) must be divisible by reference_downscale_factor ({scale})"
+            f"Output dimensions ({width}x{height}) must be divisible by reference_downscale_factor ({scale})"
         )
 
     _, ref_H_lat, ref_W_lat = compute_video_latent_shape(num_frames, height // scale, width // scale)

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/keyframe_interpolation.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/keyframe_interpolation.py
@@ -19,7 +19,10 @@ from ltx_core_mlx.components.guiders import (
     MultiModalGuiderParams,
     create_multimodal_guider_factory,
 )
-from ltx_core_mlx.components.patchifiers import compute_video_latent_shape
+from ltx_core_mlx.components.patchifiers import (
+    compute_video_latent_shape,
+    snap_output_dimensions,
+)
 from ltx_core_mlx.conditioning.types.keyframe_cond import VideoConditionByKeyframeIndex
 from ltx_core_mlx.model.transformer.model import X0Model
 from ltx_core_mlx.model.video_vae.video_vae import VideoEncoder
@@ -150,6 +153,8 @@ class KeyframeInterpolationPipeline(TI2VidTwoStagesPipeline):
 
         # Compute half-res latent dimensions (matching reference: height//2, width//2
         # with integer division by spatial compression factor 32).
+        # Snap to the two-stage grid (multiples of 64) and report if it changed.
+        height, width = snap_output_dimensions(height, width, two_stage=True)
         half_h, half_w = height // 2, width // 2
         F_half, H_half, W_half = compute_video_latent_shape(num_frames, half_h, half_w)
 

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/lipdub.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/lipdub.py
@@ -16,7 +16,10 @@ import logging
 
 import mlx.core as mx
 
-from ltx_core_mlx.components.patchifiers import compute_video_latent_shape
+from ltx_core_mlx.components.patchifiers import (
+    compute_video_latent_shape,
+    snap_output_dimensions,
+)
 from ltx_core_mlx.conditioning.types.reference_audio_cond import AudioConditionByReferenceLatent
 from ltx_core_mlx.model.audio_vae import encode_audio
 from ltx_core_mlx.model.transformer.model import X0Model
@@ -171,6 +174,8 @@ class LipDubPipeline(ICLoraPipeline):
         self._fuse_loras()
 
         # ===== Stage 1 (half-res) =====
+        # Snap to the two-stage grid (multiples of 64) and report if it changed.
+        height, width = snap_output_dimensions(height, width, two_stage=True)
         half_h, half_w = height // 2, width // 2
         F, H_half, W_half = compute_video_latent_shape(num_frames, half_h, half_w)
         video_shape = (1, F * H_half * W_half, 128)

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ti2vid_one_stage.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ti2vid_one_stage.py
@@ -32,7 +32,10 @@ from ltx_core_mlx.components.guiders import (
     MultiModalGuiderParams,
     create_multimodal_guider_factory,
 )
-from ltx_core_mlx.components.patchifiers import compute_video_latent_shape
+from ltx_core_mlx.components.patchifiers import (
+    compute_video_latent_shape,
+    snap_output_dimensions,
+)
 from ltx_core_mlx.model.transformer.model import X0Model
 from ltx_core_mlx.utils.memory import aggressive_cleanup
 from ltx_core_mlx.utils.positions import (
@@ -153,6 +156,8 @@ class TI2VidOneStagePipeline(TI2VidTwoStagesPipeline):
         assert self.vae_encoder is not None
 
         # --- Single stage at full target resolution ---
+        # Snap to the single-stage grid (multiples of 32) and report if it changed.
+        height, width = snap_output_dimensions(height, width, two_stage=False)
         F, H, W = compute_video_latent_shape(num_frames, height, width)
         video_shape = (1, F * H * W, 128)
         audio_T = compute_audio_token_count(num_frames, frame_rate=frame_rate)

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ti2vid_two_stages.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ti2vid_two_stages.py
@@ -20,7 +20,10 @@ from ltx_core_mlx.components.guiders import (
     MultiModalGuiderParams,
     create_multimodal_guider_factory,
 )
-from ltx_core_mlx.components.patchifiers import compute_video_latent_shape
+from ltx_core_mlx.components.patchifiers import (
+    compute_video_latent_shape,
+    snap_output_dimensions,
+)
 from ltx_core_mlx.loader.fuse_loras import apply_loras
 from ltx_core_mlx.loader.primitives import LoraStateDictWithStrength, StateDict
 from ltx_core_mlx.loader.sd_ops import LTXV_LORA_COMFY_RENAMING_MAP
@@ -371,6 +374,8 @@ class TI2VidTwoStagesPipeline(BasePipeline):
         assert self.upsampler is not None
 
         # --- Stage 1: Half resolution with CFG ---
+        # Snap to the two-stage grid (multiples of 64) and report if it changed.
+        height, width = snap_output_dimensions(height, width, two_stage=True)
         half_h, half_w = height // 2, width // 2
         F, H_half, W_half = compute_video_latent_shape(num_frames, half_h, half_w)
         video_shape = (1, F * H_half * W_half, 128)

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ti2vid_two_stages_hq.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ti2vid_two_stages_hq.py
@@ -16,7 +16,10 @@ from ltx_core_mlx.components.guiders import (
     MultiModalGuiderParams,
     create_multimodal_guider_factory,
 )
-from ltx_core_mlx.components.patchifiers import compute_video_latent_shape
+from ltx_core_mlx.components.patchifiers import (
+    compute_video_latent_shape,
+    snap_output_dimensions,
+)
 from ltx_core_mlx.model.transformer.model import X0Model
 from ltx_core_mlx.utils.memory import aggressive_cleanup
 from ltx_core_mlx.utils.positions import compute_audio_positions, compute_audio_token_count, compute_video_positions
@@ -129,6 +132,8 @@ class TI2VidTwoStagesHQPipeline(TI2VidTwoStagesPipeline):
         assert self.upsampler is not None
 
         # --- Stage 1: Half resolution with res_2s sampler + guidance ---
+        # Snap to the two-stage grid (multiples of 64) and report if it changed.
+        height, width = snap_output_dimensions(height, width, two_stage=True)
         half_h, half_w = height // 2, width // 2
         F, H_half, W_half = compute_video_latent_shape(num_frames, half_h, half_w)
         video_shape = (1, F * H_half * W_half, 128)

--- a/tests/test_dimension_snapping.py
+++ b/tests/test_dimension_snapping.py
@@ -1,0 +1,98 @@
+"""Tests for output-dimension snapping (snap_output_dimensions).
+
+Two-stage pipelines generate Stage 1 at half resolution and upscale 2x, so full
+dims must be multiples of 64; single-stage pipelines only need multiples of 32.
+The helper floors down (never up), clamps to at least one tile, is idempotent,
+and logs an informational warning only when a dim actually changes.
+"""
+
+import logging
+
+from ltx_core_mlx.components.patchifiers import snap_output_dimensions
+
+
+class TestTwoStageSnapping:
+    def test_default_dims_snap_down(self):
+        """The CLI default 480x704 is not a multiple of 64 -> height snaps 480->448."""
+        h, w = snap_output_dimensions(480, 704, two_stage=True)
+        assert (h, w) == (448, 704)
+
+    def test_both_axes_snap(self):
+        # 928 -> 896 (14*64), 480 -> 448 (7*64)
+        h, w = snap_output_dimensions(928, 480, two_stage=True)
+        assert (h, w) == (896, 448)
+
+    def test_already_divisible_unchanged(self):
+        """Negative path: dims already multiples of 64 pass through untouched."""
+        for dims in [(64, 64), (960, 960), (512, 768), (448, 704)]:
+            assert snap_output_dimensions(*dims, two_stage=True) == dims
+
+    def test_clamps_to_one_tile(self):
+        """Below one 64px tile clamps up to 64 rather than 0."""
+        assert snap_output_dimensions(10, 10, two_stage=True) == (64, 64)
+
+
+class TestSingleStageSnapping:
+    def test_default_dims_pass_through(self):
+        """480x704 is clean for single-stage (both multiples of 32)."""
+        assert snap_output_dimensions(480, 704, two_stage=False) == (480, 704)
+
+    def test_snap_to_32(self):
+        # 100 -> 96 (3*32)
+        assert snap_output_dimensions(100, 100, two_stage=False) == (96, 96)
+
+    def test_between_grids(self):
+        """A multiple of 32 but not 64 is fine single-stage, would snap two-stage."""
+        assert snap_output_dimensions(480, 480, two_stage=False) == (480, 480)
+        assert snap_output_dimensions(480, 480, two_stage=True) == (448, 448)
+
+    def test_clamps_to_one_tile(self):
+        assert snap_output_dimensions(5, 5, two_stage=False) == (32, 32)
+
+
+class TestIdempotency:
+    def test_two_stage_idempotent(self):
+        once = snap_output_dimensions(928, 480, two_stage=True)
+        twice = snap_output_dimensions(*once, two_stage=True)
+        assert once == twice
+
+    def test_single_stage_idempotent(self):
+        once = snap_output_dimensions(100, 100, two_stage=False)
+        twice = snap_output_dimensions(*once, two_stage=False)
+        assert once == twice
+
+
+class TestWarning:
+    def test_warns_only_when_changed(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="ltx_core_mlx.components.patchifiers"):
+            snap_output_dimensions(480, 704, two_stage=True)  # snaps
+        assert len(caplog.records) == 1
+
+        caplog.clear()
+        with caplog.at_level(logging.WARNING, logger="ltx_core_mlx.components.patchifiers"):
+            snap_output_dimensions(448, 704, two_stage=True)  # no change
+        assert caplog.records == []
+
+    def test_warn_disabled(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="ltx_core_mlx.components.patchifiers"):
+            snap_output_dimensions(480, 704, two_stage=True, warn=False)
+        assert caplog.records == []
+
+    def test_two_stage_message_content(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="ltx_core_mlx.components.patchifiers"):
+            snap_output_dimensions(480, 704, two_stage=True)
+        msg = caplog.records[0].getMessage()
+        assert "two-stage" in msg
+        assert "multiples of 64" in msg
+        assert "448x704" in msg  # snapped output
+        assert "requested 480x704" in msg
+        assert "--single-stage" in msg  # actionable hint
+
+    def test_single_stage_message_has_no_single_stage_hint(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="ltx_core_mlx.components.patchifiers"):
+            snap_output_dimensions(100, 100, two_stage=False)
+        msg = caplog.records[0].getMessage()
+        assert "single-stage" in msg
+        assert "multiples of 32" in msg
+        assert "96x96" in msg
+        assert "--single-stage" not in msg  # no self-referential hint

--- a/tests/test_dimension_snapping.py
+++ b/tests/test_dimension_snapping.py
@@ -84,8 +84,8 @@ class TestWarning:
         msg = caplog.records[0].getMessage()
         assert "two-stage" in msg
         assert "multiples of 64" in msg
-        assert "448x704" in msg  # snapped output
-        assert "requested 480x704" in msg
+        assert "704x448" in msg  # snapped output (WxH)
+        assert "requested 704x480" in msg
         assert "--single-stage" in msg  # actionable hint
 
     def test_single_stage_message_has_no_single_stage_hint(self, caplog):


### PR DESCRIPTION
Follow-up to the dimension-snapping discussion on #68.

## What

Adds a shared `snap_output_dimensions(height, width, *, two_stage)` helper in
`ltx-core-mlx` (next to `compute_video_latent_shape`) and wires it into every
`generate` path. Two-stage pipelines generate Stage 1 at half resolution and
upscale 2x, so full dims must be multiples of 64; single-stage/one-stage need
multiples of 32. The helper is a pure, idempotent floor that clamps to at least
one tile and logs a **one-line informational warning** naming the resulting
output size — but only when a dim actually changes.

Per your call on #68, this is **snap-down + warn, not fail-fast**: rounding is
already established repo-wide behavior (non-conforming dims were floored
silently downstream — the CLI default `--height 480` isn't a multiple of 64, so
a bare two-stage run has always snapped 480→448), and it produces a correct
result at slightly different dims, so a warning is the right loudness. **Defaults
are unchanged.**

## Changes

- New `snap_output_dimensions` + module constant `SPATIAL_COMPRESSION` in
  `components/patchifiers.py`.
- Wired into the top of every generate path: one-stage, two-stage, two-stage-HQ,
  distilled, keyframe, a2vid, lipdub, ic-lora (`hdr_ic_lora` inherits ic-lora's).
  Callers pass `two_stage=` per topology; the snapped dims flow downstream so the
  output matches the warning.
- Collapsed ic-lora's existing explicit `(height//2//32)*32` half-res floor from
  #68 into the shared helper, so the invariant lives in exactly one place.
- Unit tests: both moduli, positive/negative paths, clamp-to-one-tile,
  idempotency, and warning content (including that the `--single-stage` hint is
  two-stage only).

## Local validation

M-series 64 GB, q8 dev transformer, 25 frames, `--frame-rate 24`, seed 42.
ffprobe reports `width,height` (W×H). Positive path = snap fires; negative =
clean dims pass through untouched. Both moduli covered.

| pipeline | requested (W×H) | snap warning | output (W×H) |
|---|---|---|---|
| `--one-stage` | 704×480 | none (÷32 clean) | **704×480** |
| `--one-stage` | 704×500 | `single-stage snaps dims to multiples of 32; output will be 480x704 (requested 500x704).` | **704×480** |
| `--two-stage` | 704×480 | `two-stage half-res snaps dims to multiples of 64; output will be 448x704 (requested 480x704). Use --single-stage for exact dims.` | **704×448** |
| `--two-stage` | 704×448 | none (÷64 clean) | **704×448** |

Two-stage default (704×480 requested) → **704×448**, byte-identical dims to the
explicit 704×448 run, confirming the snap only surfaces flooring that already
happened silently.

`ruff check` + `format --check` clean; full suite 594 passed / 22 skipped.