### PR TITLE
fix: stop the Gemma encoder from widening a stricter cache limit (#79)

### DIFF
--- a/packages/ltx-core-mlx/src/ltx_core_mlx/text_encoders/gemma/encoders/base_encoder.py
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/text_encoders/gemma/encoders/base_encoder.py
@@ -77,10 +77,21 @@ class GemmaLanguageModel(nn.Module):
 
     @staticmethod
     def _ensure_metal_headroom() -> None:
-        """Set Metal cache limit to leave headroom for the GPU watchdog."""
+        """Cap the Metal cache limit to leave headroom (min semantics).
+
+        This is a CAP below the default, never a raise: a stricter limit
+        already configured (e.g. ``mx.set_cache_limit(0)`` by low-ram
+        streaming) is a deliberate setting and must survive prompt encoding
+        (#79 — the unconditional set used to clobber low-ram's 0 for the
+        whole rest of the run, retaining 8-21 GB of cache through decode).
+        ``mx.set_cache_limit`` returns the previous value, which is the only
+        way to read the current limit.
+        """
         try:
-            mem_limit = mx.device_info()["memory_size"]
-            mx.set_cache_limit(int(mem_limit * 0.9))
+            cap = int(mx.device_info()["memory_size"] * 0.9)
+            previous = mx.set_cache_limit(cap)
+            if previous < cap:
+                mx.set_cache_limit(previous)
         except Exception:
             pass
 

--- a/tests/test_metal_headroom.py
+++ b/tests/test_metal_headroom.py
@@ -1,0 +1,55 @@
+"""#79: the Gemma encoder must not widen a stricter configured cache limit.
+
+`--low-ram` sets `mx.set_cache_limit(0)` at pipeline init so freed buffers
+return to the OS. `_ensure_metal_headroom()` (called at every prompt
+encoding) used to unconditionally set the limit to 0.9x device memory,
+silently clobbering the low-ram setting for the whole rest of the run —
+observed as 8-21 GB of retained cache during video decode on 32 GB Macs.
+
+The headroom call was meant to CAP the cache below the default, never to
+raise a stricter limit: min semantics.
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+import pytest
+
+from ltx_core_mlx.text_encoders.gemma.encoders.base_encoder import GemmaLanguageModel
+
+HEADROOM = int(mx.device_info()["memory_size"] * 0.9)
+
+
+def _current_cache_limit() -> int:
+    """mx has no getter; set_cache_limit returns the previous value."""
+    cur = mx.set_cache_limit(0)
+    mx.set_cache_limit(cur)
+    return cur
+
+
+@pytest.fixture
+def restore_cache_limit():
+    prev = _current_cache_limit()
+    yield
+    mx.set_cache_limit(prev)
+
+
+def test_stricter_limit_is_preserved(restore_cache_limit):
+    """The low-ram case: a configured 0 must survive prompt encoding."""
+    mx.set_cache_limit(0)
+    GemmaLanguageModel._ensure_metal_headroom()
+    assert _current_cache_limit() == 0
+
+
+def test_intermediate_stricter_limit_is_preserved(restore_cache_limit):
+    """Any limit below the cap is a deliberate user setting — keep it."""
+    mx.set_cache_limit(HEADROOM // 4)
+    GemmaLanguageModel._ensure_metal_headroom()
+    assert _current_cache_limit() == HEADROOM // 4
+
+
+def test_looser_limit_is_capped(restore_cache_limit):
+    """The original purpose: cap a looser/default limit to 0.9x memory."""
+    mx.set_cache_limit(HEADROOM * 2)
+    GemmaLanguageModel._ensure_metal_headroom()
+    assert _current_cache_limit() == HEADROOM


### PR DESCRIPTION
## Problem (#79)

`--low-ram` sets `mx.set_cache_limit(0)` at pipeline init, but `_ensure_metal_headroom()` (called at **every prompt encoding**) unconditionally reset the process-global limit to 0.9× device memory and never restored it. Everything downstream — transformer load, denoise, VAE decode — then ran with a ~30 GB cache limit: 3-17 GB of retained cache during denoise and **8-21 GB during decode** observed on a 32 GB Mac, feeding exactly the jetsam pressure #74 addressed. Six standalone repros confirmed MLX honors `cache_limit(0)` on every suspected path — the clobber was ours, not upstream's.

## Fix

`_ensure_metal_headroom` was always meant as a **cap** below the default, never a raise. Min semantics via `set_cache_limit`'s returned previous value: apply the 0.9×mem cap; if the previous limit was stricter, restore it. One method, one call site.

## Scope

Code touched: text encoder only. Behavior affected: the whole run in `--low-ram` mode (the limit is process-global and the encoder runs first). Non-low-ram runs: strictly unchanged (default limit > cap → capped as before, pinned by test).

## Validation — no regression across pipelines

- TDD: `tests/test_metal_headroom.py` — stricter limit (0 and intermediate) preserved, looser limit still capped.
- **Full suite: 625 passed**; the 3 failures (`test_generate_tiny_video`, `test_generate_small_video`, `test_t2v_real_prompt`) are pre-existing ffmpeg-environment failures, verified identical on clean `main`.
- Real `--distilled --low-ram` run under smeltr: **`cache_bytes` = 0 on all 276 memory polls across the entire run** (pre-fix equivalent run: up to 21.3 GB during decode), wall time unchanged (138.4 s vs 137.3 s — the encode now also runs at limit 0 in low-ram, and the alloc churn is free in practice).

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HNcW12C5eFE9hCL2EnMYmW