### PR TITLE
AdaLN: sigma-dedupe + lazy per-block gather — bitwise-identical, multi-GB peak-memory cut on Apple Silicon

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1071,6 +1071,22 @@ LTX-2 mitigates both by inserting `mx.eval` at strategic points so each command 
 
 Mac Studio / M-series Ultra users who have never seen a watchdog crash may recover full lazy-graph pipelining by setting `LTX2_GEMMA_EVAL_EVERY=0` and `LTX2_DIT_EVAL_EVERY=0`. This disables all eval guards and restores maximum throughput at the cost of watchdog safety on machines where those guards were needed.
 
+### AdaLN dedupe switches (per-token timesteps only)
+
+The per-token AdaLN path deduplicates identical sigma rows into one shrunken
+GEMM (bitwise-verified per module by a one-time calibration; the calibrating
+call returns the exact reference) and defers the per-token gather into the
+blocks. Both are on by default and bit-identical by construction:
+
+- `LTX2_ADALN_DEDUPE=0` — disable the dedupe entirely.
+- `LTX2_ADALN_LAZY=0` — keep the dedupe but materialise the gather eagerly
+  (the `--low-ram` streamer does this automatically: the lazy carrier cannot
+  cross the compiled block, and the compiled block is what keeps the 48
+  per-block syncs under the Metal watchdog).
+- `LTX2_ADALN_DEDUPE_MIN_ROWS` (default 1024), `LTX2_ADALN_DEDUPE_MAX_FRAC`
+  (default 0.5) — thresholds below/above which the dedupe is not attempted.
+- `LTX2_ADALN_DEDUPE_DEBUG=1` — log calibration verdicts.
+
 ### `LTX2_GEMMA_MAX_LENGTH`
 
 Caps the padded Gemma sequence length (default `1024`). Reducing to `512` halves Gemma forward time but **shifts left-padded RoPE positions away from the LTX training distribution** — quality risk. Use only as a last resort on heavily contended systems.

--- a/packages/ltx-core-mlx/src/ltx_core_mlx/loader/block_streaming.py
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/loader/block_streaming.py
@@ -358,18 +358,7 @@ class StreamingLTXModel(nn.Module):
             # perturbations are active. This loses the compile speedup
             # but the eager block's per-step latency is dominated by
             # attention compute, so the regression is small (~5-10%).
-            #
-            # The lazy AdaLN carrier (``PerTokenAdaLNParams``) is the same
-            # class of non-tree argument: it only ever reaches the blocks
-            # when per-token timesteps are in play AND the dedupe+lazy
-            # pair is enabled, so gate on exactly that. The eager block
-            # keeps the lazy memory cut; only the compile speedup is
-            # forfeited on those steps.
-            from ltx_core_mlx.model.transformer import model as _model_mod
-
-            per_token = kwargs.get("video_timesteps") is not None or kwargs.get("audio_timesteps") is not None
-            lazy_carrier_possible = _model_mod._ADALN_DEDUPE and _model_mod._ADALN_LAZY
-            use_compiled = kwargs.get("perturbations") is None and not (per_token and lazy_carrier_possible)
+            use_compiled = kwargs.get("perturbations") is None
 
             def provider(idx: int) -> nn.Module:
                 streamer.bind(

--- a/packages/ltx-core-mlx/src/ltx_core_mlx/loader/block_streaming.py
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/loader/block_streaming.py
@@ -358,7 +358,18 @@ class StreamingLTXModel(nn.Module):
             # perturbations are active. This loses the compile speedup
             # but the eager block's per-step latency is dominated by
             # attention compute, so the regression is small (~5-10%).
-            use_compiled = kwargs.get("perturbations") is None
+            #
+            # The lazy AdaLN carrier (``PerTokenAdaLNParams``) is the same
+            # class of non-tree argument: it only ever reaches the blocks
+            # when per-token timesteps are in play AND the dedupe+lazy
+            # pair is enabled, so gate on exactly that. The eager block
+            # keeps the lazy memory cut; only the compile speedup is
+            # forfeited on those steps.
+            from ltx_core_mlx.model.transformer import model as _model_mod
+
+            per_token = kwargs.get("video_timesteps") is not None or kwargs.get("audio_timesteps") is not None
+            lazy_carrier_possible = _model_mod._ADALN_DEDUPE and _model_mod._ADALN_LAZY
+            use_compiled = kwargs.get("perturbations") is None and not (per_token and lazy_carrier_possible)
 
             def provider(idx: int) -> nn.Module:
                 streamer.bind(

--- a/packages/ltx-core-mlx/src/ltx_core_mlx/loader/block_streaming.py
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/loader/block_streaming.py
@@ -382,7 +382,22 @@ class StreamingLTXModel(nn.Module):
                 return compiled if use_compiled else shared
 
             kwargs["block_provider"] = provider
-        return self.inner(*args, **kwargs)
+        # The lazy AdaLN carrier (``PerTokenAdaLNParams``) is a non-tree
+        # argument, so it cannot cross the compiled block -- and the compiled
+        # block is load-bearing here: it is what keeps 48 per-block syncs
+        # under the Metal watchdog (see the module docstring). Rather than
+        # falling back to the eager block (forfeiting that protection), keep
+        # the GEMM dedupe but materialise its result eagerly for the duration
+        # of this forward: the lazy activation cut is forfeited under
+        # streaming, the watchdog/compile properties are not.
+        from ltx_core_mlx.model.transformer import model as _model_mod
+
+        lazy_prev = _model_mod._ADALN_LAZY
+        _model_mod._ADALN_LAZY = False
+        try:
+            return self.inner(*args, **kwargs)
+        finally:
+            _model_mod._ADALN_LAZY = lazy_prev
 
     def __getattr__(self, name: str):
         try:

--- a/packages/ltx-core-mlx/src/ltx_core_mlx/model/transformer/adaln.py
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/model/transformer/adaln.py
@@ -47,3 +47,84 @@ class AdaLayerNormSingle(nn.Module):
         embedded = self.emb(timestep_emb)
         params = self.linear(nn.silu(embedded))
         return params, embedded
+
+
+class PerTokenAdaLNParams:
+    """Per-token AdaLN parameters held in deduplicated form.
+
+    With per-token timesteps the AdaLN projection produces a
+    ``(B, N, num_params * dim)`` float32 tensor (the sinusoidal timestep
+    embedding is float32 and MLX promotes), which stays resident for the whole
+    transformer stack. At video resolutions that is gigabytes -- 2.95 GB for
+    the 9-parameter video head alone at 20 000 tokens -- even though the tensor
+    only ever holds a handful of distinct rows, one per conditioning group.
+
+    This carries the distinct rows plus the inverse index instead, and expands
+    a single ``(B, N, dim)`` parameter slice at a time, inside the block that
+    consumes it. Blocks obtain those slices through
+    ``BasicAVTransformerBlock._unpack_adaln``.
+
+    Expansion is bitwise identical to gathering up front: a gather is a pure
+    row permutation and the elementwise scale-shift-table add commutes with it
+    exactly (both operate element by element, with no reduction whose order
+    could change).
+    """
+
+    __slots__ = ("batch", "inverse", "num_params", "tokens", "unique")
+
+    def __init__(
+        self,
+        unique: mx.array,
+        inverse: mx.array,
+        batch: int,
+        tokens: int,
+        num_params: int,
+    ):
+        """
+        Args:
+            unique: (U, num_params * dim) distinct rows of the projection.
+            inverse: (B * N,) row index into ``unique`` for every token.
+            batch: B.
+            tokens: N.
+            num_params: Number of modulation parameters packed per row.
+        """
+        self.unique = unique
+        self.inverse = inverse
+        self.batch = int(batch)
+        self.tokens = int(tokens)
+        self.num_params = int(num_params)
+
+    # -- mx.array-compatible surface, so callers can introspect without
+    #    materialising anything --------------------------------------------
+    @property
+    def ndim(self) -> int:
+        return 3
+
+    @property
+    def shape(self) -> tuple[int, int, int]:
+        return (self.batch, self.tokens, int(self.unique.shape[-1]))
+
+    @property
+    def dtype(self):
+        return self.unique.dtype
+
+    @property
+    def unique_rows(self) -> int:
+        return int(self.unique.shape[0])
+
+    def gather(self) -> mx.array:
+        """Materialise the full ``(B, N, num_params * dim)`` tensor."""
+        return mx.take(self.unique, self.inverse, axis=0).reshape(self.batch, self.tokens, -1)
+
+    def unpack(self, table: mx.array, num_params: int, dim: int) -> list[mx.array]:
+        """Expand per parameter: ``[(B, N, dim)] * num_params``.
+
+        Equivalent, bit for bit, to unpacking ``self.gather()`` the eager way
+        (reshape to ``(B, N, P, dim)``, add ``table``, slice each ``P``).
+        """
+        packed = self.unique.reshape(-1, self.num_params, dim)[:, :num_params, :]
+        packed = packed + table[None, :num_params, :]
+        return [
+            mx.take(packed[:, i, :], self.inverse, axis=0).reshape(self.batch, self.tokens, dim)
+            for i in range(num_params)
+        ]

--- a/packages/ltx-core-mlx/src/ltx_core_mlx/model/transformer/model.py
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/model/transformer/model.py
@@ -23,6 +23,7 @@ from enum import Enum
 
 import mlx.core as mx
 import mlx.nn as nn
+import numpy as _np
 
 from ltx_core_mlx.guidance.perturbations import BatchedPerturbationConfig
 from ltx_core_mlx.model.transformer.adaln import AdaLayerNormSingle
@@ -39,6 +40,213 @@ from ltx_core_mlx.model.transformer.transformer import BasicAVTransformerBlock
 # Set to 0 to disable (full lazy graph, original behaviour).
 _DIT_EVAL_EVERY = int(_os.environ.get("LTX2_DIT_EVAL_EVERY", "8"))
 _mx_eval = getattr(mx, "eval")  # noqa: B009
+
+# ---------------------------------------------------------------------------
+# AdaLN per-token dedupe
+# ---------------------------------------------------------------------------
+# When per-token timesteps are in play (any conditioning that puts some tokens
+# at a different sigma than the target tokens) the AdaLN MLP is evaluated on
+# every one of the B*N tokens, every step -- even though the per-token
+# conditioning vector only ever takes a handful of distinct values (the target
+# sigma, plus one per conditioning group). Deduplicating the rows turns a
+# B*N-row GEMM into a handful-of-rows GEMM plus a gather.
+#
+# Bit-exactness caveat (measured, not assumed): MLX dispatches different Metal
+# GEMM kernels depending on the row count, so a naively shrunk GEMM is NOT
+# guaranteed to reproduce the full-size one bit-for-bit -- the K-reduction
+# order can change. This implementation therefore
+#   (a) pads the unique rows up to a row count that lands on the same kernel
+#       as the full-size GEMM, and
+#   (b) verifies -- once per shape signature, against the real full-size
+#       result, with mx.array_equal -- that the deduped path is bitwise
+#       identical before it is ever used for a returned value.
+# If no candidate row count reproduces the full-size result exactly, the
+# signature is permanently marked not-deduplicable and the original code path
+# runs. The optimisation can therefore never change a single output bit.
+#
+# LTX2_ADALN_DEDUPE=0 disables it entirely.
+_ADALN_DEDUPE = _os.environ.get("LTX2_ADALN_DEDUPE", "1") != "0"
+# Below this many rows the GEMM is cheap and the bookkeeping is not worth it.
+_ADALN_DEDUPE_MIN_ROWS = int(_os.environ.get("LTX2_ADALN_DEDUPE_MIN_ROWS", "1024"))
+# Only worth it when the unique rows are a small fraction of the total.
+_ADALN_DEDUPE_MAX_FRAC = float(_os.environ.get("LTX2_ADALN_DEDUPE_MAX_FRAC", "0.5"))
+# Candidate padded row counts, cheapest first. 0 = "use the unique rows as-is".
+_ADALN_DEDUPE_PADS = (0, 256, 1024, 4096)
+# Chunk size (rows) for the one-time bitwise verification, to bound peak memory.
+_ADALN_VERIFY_CHUNK = 2048
+
+# signature -> padded row count to use, or None once proven not bit-identical.
+_ADALN_DEDUPE_PLAN: dict[tuple, int | None] = {}
+
+
+def _adaln_signature(adaln_module: AdaLayerNormSingle, flat: mx.array, padded_rows: int) -> tuple:
+    """Shape/dtype signature that determines MLX kernel selection.
+
+    Kernel choice depends on shapes, dtypes and strides -- never on values --
+    so a verdict established once for a signature holds for every later call
+    with the same signature. ``padded_rows`` is part of the signature because
+    it is the row count of the *shrunken* GEMM being validated.
+    """
+    lin = adaln_module.linear
+    w = lin.weight
+    return (
+        int(flat.shape[0]),
+        int(flat.shape[1]),
+        int(padded_rows),
+        int(adaln_module.num_params),
+        tuple(int(s) for s in w.shape),
+        str(w.dtype),
+        type(lin).__name__,
+        str(flat.dtype),
+    )
+
+
+def _unique_rows(flat: mx.array) -> tuple[mx.array, mx.array, int] | None:
+    """Exact unique-row decomposition of ``flat`` (M, D).
+
+    Uses the raw bit patterns of two columns of the sinusoidal timestep
+    embedding as a cheap grouping key (cos and sin of the fundamental
+    frequency -- jointly injective in the timestep over the principal period),
+    then *verifies the grouping exactly* against the full rows. A key collision
+    can therefore only ever cost the optimisation, never correctness.
+
+    Returns:
+        ``(reps, inverse, U)`` with ``reps`` (U, D) and ``inverse`` (M,) such
+        that ``mx.take(reps, inverse, axis=0)`` is bitwise ``flat``; or None
+        when the rows are not usefully duplicated.
+    """
+    m, d = int(flat.shape[0]), int(flat.shape[1])
+    half = d // 2
+    key = mx.stack([flat[:, 0], flat[:, half]], axis=1).astype(mx.float32)
+    key_bits = _np.ascontiguousarray(_np.asarray(key)).view(_np.uint32)
+    packed = (key_bits[:, 0].astype(_np.uint64) << _np.uint64(32)) | key_bits[:, 1].astype(_np.uint64)
+    uniq, first_idx, inverse = _np.unique(packed, return_index=True, return_inverse=True)
+    u = int(uniq.shape[0])
+    if u >= m or u > m * _ADALN_DEDUPE_MAX_FRAC:
+        return None
+    idx = mx.array(first_idx.astype(_np.int32))
+    inv = mx.array(_np.ascontiguousarray(inverse.reshape(-1)).astype(_np.int32))
+    reps = mx.take(flat, idx, axis=0)
+    # Exact grouping check: every row must equal its representative, bitwise.
+    if not bool(mx.array_equal(mx.take(reps, inv, axis=0), flat).item()):
+        return None
+    return reps, inv, u
+
+
+def _pad_rows(reps: mx.array, target: int) -> mx.array:
+    """Repeat the last row until ``reps`` has at least ``target`` rows.
+
+    Padding rows are pure filler: each GEMM output row is independent, so the
+    extra rows only influence which Metal kernel MLX selects.
+    """
+    u = int(reps.shape[0])
+    if target <= u:
+        return reps
+    filler = mx.broadcast_to(reps[-1:], (target - u, int(reps.shape[1])))
+    return mx.concatenate([reps, filler], axis=0)
+
+
+def _gathered_equals(out_u: mx.array, inv: mx.array, ref: mx.array) -> bool:
+    """Bitwise ``mx.take(out_u, inv, axis=0) == ref``, chunked to bound memory."""
+    if out_u.shape[-1] != ref.shape[-1]:
+        return False
+    m = int(ref.shape[0])
+    for start in range(0, m, _ADALN_VERIFY_CHUNK):
+        stop = min(start + _ADALN_VERIFY_CHUNK, m)
+        gathered = mx.take(out_u, inv[start:stop], axis=0)
+        equal = bool(mx.array_equal(gathered, ref[start:stop]).item())
+        del gathered
+        if not equal:
+            return False
+    return True
+
+
+def _dedupe_adaln(adaln_module: AdaLayerNormSingle, flat: mx.array) -> tuple[mx.array, mx.array]:
+    """Evaluate ``adaln_module`` on ``flat`` (M, D), deduplicating equal rows.
+
+    Bitwise identical to ``adaln_module(flat)`` for every input: whenever the
+    deduped path has not been *proven* equal for this shape signature, the
+    original full-size call is what is returned.
+    """
+    m = int(flat.shape[0])
+    if not _ADALN_DEDUPE or m < _ADALN_DEDUPE_MIN_ROWS:
+        return adaln_module(flat)
+
+    grouped = _unique_rows(flat)
+    if grouped is None:  # no useful duplication in this input
+        return adaln_module(flat)
+    reps, inv, u = grouped
+
+    # Verdicts are keyed on the *shrunken* row count actually used, so a change
+    # in the number of unique rows re-validates instead of silently reusing a
+    # verdict established for a different GEMM shape.
+    pending: list[tuple[int, tuple]] = []
+    for rows in _candidate_rows(u, m):
+        sig = _adaln_signature(adaln_module, flat, rows)
+        verdict = _ADALN_DEDUPE_PLAN.get(sig, -1)
+        if verdict is None:
+            continue  # already proven not bit-identical -- try a larger padding
+        if verdict == -1:
+            pending.append((rows, sig))
+            continue
+        params_u, embedded_u = adaln_module(_pad_rows(reps, rows))
+        return mx.take(params_u, inv, axis=0), mx.take(embedded_u, inv, axis=0)
+
+    if pending:
+        # First time for these shapes: compute the reference once, test the
+        # candidates against it, and return the reference itself so the
+        # calibrating call is exact by construction.
+        return _calibrate_adaln_dedupe(adaln_module, flat, reps, inv, u, pending)
+    return adaln_module(flat)
+
+
+def _candidate_rows(u: int, m: int) -> list[int]:
+    """Shrunken row counts worth trying, cheapest first, de-duplicated."""
+    out: list[int] = []
+    for pad in _ADALN_DEDUPE_PADS:
+        rows = max(u, pad)
+        if rows >= m:
+            break  # no saving left at this padding or beyond
+        if rows not in out:
+            out.append(rows)
+    return out
+
+
+def _calibrate_adaln_dedupe(
+    adaln_module: AdaLayerNormSingle,
+    flat: mx.array,
+    reps: mx.array,
+    inv: mx.array,
+    u: int,
+    pending: list[tuple[int, tuple]],
+) -> tuple[mx.array, mx.array]:
+    """Find a shrunken row count that reproduces the full-size GEMM exactly.
+
+    Returns the *reference* (full-size) result, so the calibrating call is
+    exact by construction. Records a verdict per candidate in
+    ``_ADALN_DEDUPE_PLAN``.
+    """
+    debug = bool(_os.environ.get("LTX2_ADALN_DEDUPE_DEBUG"))
+    ref_params, ref_embedded = adaln_module(flat)
+    _mx_eval(ref_params, ref_embedded)
+
+    for rows, sig in pending:
+        params_u, embedded_u = adaln_module(_pad_rows(reps, rows))
+        _mx_eval(params_u, embedded_u)
+        ok = _gathered_equals(params_u, inv, ref_params) and _gathered_equals(embedded_u, inv, ref_embedded)
+        del params_u, embedded_u
+        mx.clear_cache()
+        _ADALN_DEDUPE_PLAN[sig] = rows if ok else None
+        if debug:
+            print(
+                f"[adaln-dedupe] tokens={sig[0]} nparams={sig[3]} unique={u} gemm_rows={rows} -> "
+                f"{'ACCEPTED' if ok else 'rejected (not bit-identical)'}",
+                flush=True,
+            )
+        if ok:
+            break
+
+    return ref_params, ref_embedded
 
 
 class Modality(Enum):
@@ -295,10 +503,17 @@ class LTXModel(nn.Module):
             Tuple of (params, embedded_timestep):
             - params: (B, N, num_params * dim)
             - embedded_timestep: (B, N, dim)
+
+        The AdaLN MLP is row-independent and the per-token conditioning vector
+        takes only a few distinct values in practice, so the flattened rows are
+        deduplicated before the GEMM and gathered back afterwards. The deduped
+        path is only ever used after it has been proven bitwise identical to
+        the full-size path for that shape signature (see the module header);
+        otherwise this falls back to the original full-size GEMM.
         """
         B, N, D = t_emb_per_token.shape
         flat = t_emb_per_token.reshape(B * N, D)
-        params, embedded = adaln_module(flat)
+        params, embedded = _dedupe_adaln(adaln_module, flat)
         return params.reshape(B, N, -1), embedded.reshape(B, N, -1)
 
     def compute_gate_signal(

--- a/packages/ltx-core-mlx/src/ltx_core_mlx/model/transformer/model.py
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/model/transformer/model.py
@@ -87,17 +87,37 @@ _ADALN_DEDUPE_PADS = (0, 256, 1024, 4096)
 # Chunk size (rows) for the one-time bitwise verification, to bound peak memory.
 _ADALN_VERIFY_CHUNK = 2048
 
-# signature -> padded row count to use, or None once proven not bit-identical.
-_ADALN_DEDUPE_PLAN: dict[tuple, int | None] = {}
+# The dedupe plan (signature -> padded row count, or None once proven not
+# bit-identical) lives ON each AdaLayerNormSingle instance, never in a module
+# global. Bit-equality between the shrunken and full GEMM is only evidence
+# about the kernel pair exercised with *this module's weights*; a verdict
+# earned by one module must not be transported to another whose weights (or
+# very identity) differ. A global plan did exactly that and broke bit-identity
+# on M1 CI while passing on newer chips (#86 review). Plain dict of
+# primitives: MLX's Module tree operations only traverse array/Module values,
+# so the plan never appears in parameters() or load_weights contracts.
+
+
+def _dedupe_plan_of(adaln_module: AdaLayerNormSingle) -> dict[tuple, int | None]:
+    """Return the module's own calibration plan, creating it on first use."""
+    plan = adaln_module.__dict__.get("_adaln_dedupe_plan")
+    if plan is None:
+        plan = {}
+        adaln_module.__dict__["_adaln_dedupe_plan"] = plan
+    return plan
 
 
 def _adaln_signature(adaln_module: AdaLayerNormSingle, flat: mx.array, padded_rows: int) -> tuple:
-    """Shape/dtype signature that determines MLX kernel selection.
+    """Per-module shape/dtype signature for the calibration verdict.
 
-    Kernel choice depends on shapes, dtypes and strides -- never on values --
-    so a verdict established once for a signature holds for every later call
-    with the same signature. ``padded_rows`` is part of the signature because
-    it is the row count of the *shrunken* GEMM being validated.
+    A verdict certifies bit-equality between the shrunken and the full GEMM
+    *for this module's weights* at these shapes. Agreement across M x 36864
+    float32 outputs is overwhelming evidence that the same kernel pair (and
+    reduction order) was exercised -- in which case equality is universal for
+    every input -- but that reasoning is only sound while the GEMM it was
+    established on does not change, which is why the plan lives on the module
+    (see ``_dedupe_plan_of``) and ``padded_rows`` -- the row count of the
+    shrunken GEMM being validated -- is part of the key.
     """
     lin = adaln_module.linear
     w = lin.weight
@@ -215,7 +235,7 @@ def _dedupe_adaln(adaln_module: AdaLayerNormSingle, flat: mx.array) -> tuple[mx.
     pending: list[tuple[int, tuple]] = []
     for rows in _candidate_rows(u, m):
         sig = _adaln_signature(adaln_module, flat, rows)
-        verdict = _ADALN_DEDUPE_PLAN.get(sig, -1)
+        verdict = _dedupe_plan_of(adaln_module).get(sig, -1)
         if verdict is None:
             continue  # already proven not bit-identical -- try a larger padding
         if verdict == -1:
@@ -258,7 +278,7 @@ def _calibrate_adaln_dedupe(
 
     Returns the *reference* (full-size) result, so the calibrating call is
     exact by construction. Records a verdict per candidate in
-    ``_ADALN_DEDUPE_PLAN``.
+    the module's own dedupe plan (see ``_dedupe_plan_of``).
     """
     debug = bool(_os.environ.get("LTX2_ADALN_DEDUPE_DEBUG"))
     ref_params, ref_embedded = adaln_module(flat)
@@ -270,7 +290,7 @@ def _calibrate_adaln_dedupe(
         ok = _gathered_equals(params_u, inv, ref_params) and _gathered_equals(embedded_u, inv, ref_embedded)
         del params_u, embedded_u
         mx.clear_cache()
-        _ADALN_DEDUPE_PLAN[sig] = rows if ok else None
+        _dedupe_plan_of(adaln_module)[sig] = rows if ok else None
         if debug:
             print(
                 f"[adaln-dedupe] tokens={sig[0]} nparams={sig[3]} unique={u} gemm_rows={rows} -> "

--- a/packages/ltx-core-mlx/src/ltx_core_mlx/model/transformer/model.py
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/model/transformer/model.py
@@ -26,7 +26,7 @@ import mlx.nn as nn
 import numpy as _np
 
 from ltx_core_mlx.guidance.perturbations import BatchedPerturbationConfig
-from ltx_core_mlx.model.transformer.adaln import AdaLayerNormSingle
+from ltx_core_mlx.model.transformer.adaln import AdaLayerNormSingle, PerTokenAdaLNParams
 from ltx_core_mlx.model.transformer.timestep_embedding import get_timestep_embedding
 from ltx_core_mlx.model.transformer.transformer import BasicAVTransformerBlock
 
@@ -42,7 +42,7 @@ _DIT_EVAL_EVERY = int(_os.environ.get("LTX2_DIT_EVAL_EVERY", "8"))
 _mx_eval = getattr(mx, "eval")  # noqa: B009
 
 # ---------------------------------------------------------------------------
-# AdaLN per-token dedupe
+# AdaLN per-token dedupe + deferred per-block gather
 # ---------------------------------------------------------------------------
 # When per-token timesteps are in play (any conditioning that puts some tokens
 # at a different sigma than the target tokens) the AdaLN MLP is evaluated on
@@ -66,6 +66,18 @@ _mx_eval = getattr(mx, "eval")  # noqa: B009
 #
 # LTX2_ADALN_DEDUPE=0 disables it entirely.
 _ADALN_DEDUPE = _os.environ.get("LTX2_ADALN_DEDUPE", "1") != "0"
+# Keep the deduplicated form all the way into the blocks instead of gathering
+# the full (B*N, num_params*dim) float32 tensor here. See PerTokenAdaLNParams:
+# that tensor is 2.95 GB for the 9-parameter video head at 20 000 tokens, plus
+# 1.31 GB for the 4-parameter AV cross-attention head, and it stays resident
+# across all 48 blocks. Deferring the gather into
+# BasicAVTransformerBlock._unpack_adaln expands one (B, N, dim) slice at a time
+# instead, which the block frees as it goes.
+#
+# Requires the dedupe (there is nothing to defer without it); falls back to the
+# eager gather whenever the dedupe declines.
+# LTX2_ADALN_LAZY=0 disables it independently of the dedupe.
+_ADALN_LAZY = _os.environ.get("LTX2_ADALN_LAZY", "1") != "0"
 # Below this many rows the GEMM is cheap and the bookkeeping is not worth it.
 _ADALN_DEDUPE_MIN_ROWS = int(_os.environ.get("LTX2_ADALN_DEDUPE_MIN_ROWS", "1024"))
 # Only worth it when the unique rows are a small fraction of the total.
@@ -161,8 +173,26 @@ def _gathered_equals(out_u: mx.array, inv: mx.array, ref: mx.array) -> bool:
     return True
 
 
-def _dedupe_adaln(adaln_module: AdaLayerNormSingle, flat: mx.array) -> tuple[mx.array, mx.array]:
+def _trim_rows(x: mx.array, u: int) -> mx.array:
+    """Drop the padding rows added by ``_pad_rows``, copying into a new buffer.
+
+    ``x[:u]`` would keep the padded buffer alive behind a view; a gather makes
+    the small result independent so the padded GEMM output can be released.
+    Row selection is a pure copy, so this is exact.
+    """
+    if int(x.shape[0]) == u:
+        return x
+    return mx.take(x, mx.arange(u, dtype=mx.int32), axis=0)
+
+
+def _dedupe_adaln(adaln_module: AdaLayerNormSingle, flat: mx.array) -> tuple[mx.array, mx.array, mx.array | None]:
     """Evaluate ``adaln_module`` on ``flat`` (M, D), deduplicating equal rows.
+
+    Returns ``(params, embedded, inverse)``. When ``inverse`` is None the two
+    arrays are already the full ``(M, ·)`` result; otherwise they hold only the
+    distinct rows and ``mx.take(x, inverse, axis=0)`` reconstructs the full
+    result exactly. Keeping the two forms distinct is what lets the caller
+    defer the gather (see ``PerTokenAdaLNParams``).
 
     Bitwise identical to ``adaln_module(flat)`` for every input: whenever the
     deduped path has not been *proven* equal for this shape signature, the
@@ -170,11 +200,13 @@ def _dedupe_adaln(adaln_module: AdaLayerNormSingle, flat: mx.array) -> tuple[mx.
     """
     m = int(flat.shape[0])
     if not _ADALN_DEDUPE or m < _ADALN_DEDUPE_MIN_ROWS:
-        return adaln_module(flat)
+        params, embedded = adaln_module(flat)
+        return params, embedded, None
 
     grouped = _unique_rows(flat)
     if grouped is None:  # no useful duplication in this input
-        return adaln_module(flat)
+        params, embedded = adaln_module(flat)
+        return params, embedded, None
     reps, inv, u = grouped
 
     # Verdicts are keyed on the *shrunken* row count actually used, so a change
@@ -190,14 +222,16 @@ def _dedupe_adaln(adaln_module: AdaLayerNormSingle, flat: mx.array) -> tuple[mx.
             pending.append((rows, sig))
             continue
         params_u, embedded_u = adaln_module(_pad_rows(reps, rows))
-        return mx.take(params_u, inv, axis=0), mx.take(embedded_u, inv, axis=0)
+        return _trim_rows(params_u, u), _trim_rows(embedded_u, u), inv
 
     if pending:
         # First time for these shapes: compute the reference once, test the
         # candidates against it, and return the reference itself so the
         # calibrating call is exact by construction.
-        return _calibrate_adaln_dedupe(adaln_module, flat, reps, inv, u, pending)
-    return adaln_module(flat)
+        ref_params, ref_embedded = _calibrate_adaln_dedupe(adaln_module, flat, reps, inv, u, pending)
+        return ref_params, ref_embedded, None
+    params, embedded = adaln_module(flat)
+    return params, embedded, None
 
 
 def _candidate_rows(u: int, m: int) -> list[int]:
@@ -492,7 +526,7 @@ class LTXModel(nn.Module):
         self,
         adaln_module: AdaLayerNormSingle,
         t_emb_per_token: mx.array,
-    ) -> tuple[mx.array, mx.array]:
+    ) -> tuple[mx.array | PerTokenAdaLNParams, mx.array | PerTokenAdaLNParams]:
         """Apply AdaLN with per-token timestep embeddings.
 
         Args:
@@ -500,21 +534,33 @@ class LTXModel(nn.Module):
             t_emb_per_token: (B, N, timestep_embedding_dim).
 
         Returns:
-            Tuple of (params, embedded_timestep):
-            - params: (B, N, num_params * dim)
-            - embedded_timestep: (B, N, dim)
+            Tuple of (params, embedded_timestep), logically shaped
+            (B, N, num_params * dim) and (B, N, dim). Both are either plain
+            ``mx.array`` or, when the rows deduplicated and ``LTX2_ADALN_LAZY``
+            is on, ``PerTokenAdaLNParams`` -- the distinct rows plus an index,
+            expanded later by whoever consumes them.
 
         The AdaLN MLP is row-independent and the per-token conditioning vector
         takes only a few distinct values in practice, so the flattened rows are
-        deduplicated before the GEMM and gathered back afterwards. The deduped
-        path is only ever used after it has been proven bitwise identical to
-        the full-size path for that shape signature (see the module header);
-        otherwise this falls back to the original full-size GEMM.
+        deduplicated before the GEMM. The deduped path is only ever used after
+        it has been proven bitwise identical to the full-size path for that
+        shape signature (see the module header); otherwise this falls back to
+        the original full-size GEMM.
         """
         B, N, D = t_emb_per_token.shape
         flat = t_emb_per_token.reshape(B * N, D)
-        params, embedded = _dedupe_adaln(adaln_module, flat)
-        return params.reshape(B, N, -1), embedded.reshape(B, N, -1)
+        params, embedded, inv = _dedupe_adaln(adaln_module, flat)
+        if inv is None:
+            return params.reshape(B, N, -1), embedded.reshape(B, N, -1)
+        if _ADALN_LAZY:
+            return (
+                PerTokenAdaLNParams(params, inv, B, N, adaln_module.num_params),
+                PerTokenAdaLNParams(embedded, inv, B, N, 1),
+            )
+        return (
+            mx.take(params, inv, axis=0).reshape(B, N, -1),
+            mx.take(embedded, inv, axis=0).reshape(B, N, -1),
+        )
 
     def compute_gate_signal(
         self,
@@ -812,7 +858,7 @@ class LTXModel(nn.Module):
     def _output_block(
         self,
         x: mx.array,
-        embedded_timestep: mx.array,
+        embedded_timestep: mx.array | PerTokenAdaLNParams,
         scale_shift_table: mx.array,
         proj: nn.Linear,
     ) -> mx.array:
@@ -822,6 +868,11 @@ class LTXModel(nn.Module):
         The table (2, dim) provides learnable base values; the embedded_timestep
         provides per-sample (or per-token) conditioning.
         """
+        # Per-token embedded timesteps arrive deduplicated and are only needed
+        # here, after the block stack -- expand at the point of use so the
+        # (B, N, dim) float32 tensor never spans the 48-block loop.
+        if isinstance(embedded_timestep, PerTokenAdaLNParams):
+            embedded_timestep = embedded_timestep.gather()
         # embedded_timestep: (B, dim) for scalar or (B, N, dim) for per-token
         if embedded_timestep.ndim == 2:
             embedded_timestep = embedded_timestep[:, None, :]  # (B, 1, dim)

--- a/packages/ltx-core-mlx/src/ltx_core_mlx/model/transformer/model.py
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/model/transformer/model.py
@@ -94,8 +94,10 @@ _ADALN_VERIFY_CHUNK = 2048
 # earned by one module must not be transported to another whose weights (or
 # very identity) differ. A global plan did exactly that and broke bit-identity
 # on M1 CI while passing on newer chips (#86 review). Plain dict of
-# primitives: MLX's Module tree operations only traverse array/Module values,
-# so the plan never appears in parameters() or load_weights contracts.
+# primitives, stored via ``module.__dict__`` on purpose: that BYPASSES
+# ``nn.Module.__setattr__`` (which would route a dict into the module tree and
+# expose it to tree traversals). Never assign the plan with plain attribute
+# syntax.
 
 
 def _dedupe_plan_of(adaln_module: AdaLayerNormSingle) -> dict[tuple, int | None]:
@@ -110,14 +112,16 @@ def _dedupe_plan_of(adaln_module: AdaLayerNormSingle) -> dict[tuple, int | None]
 def _adaln_signature(adaln_module: AdaLayerNormSingle, flat: mx.array, padded_rows: int) -> tuple:
     """Per-module shape/dtype signature for the calibration verdict.
 
-    A verdict certifies bit-equality between the shrunken and the full GEMM
-    *for this module's weights* at these shapes. Agreement across M x 36864
-    float32 outputs is overwhelming evidence that the same kernel pair (and
-    reduction order) was exercised -- in which case equality is universal for
-    every input -- but that reasoning is only sound while the GEMM it was
-    established on does not change, which is why the plan lives on the module
-    (see ``_dedupe_plan_of``) and ``padded_rows`` -- the row count of the
-    shrunken GEMM being validated -- is part of the key.
+    A verdict certifies bit-equality between the shrunken and the full GEMM,
+    established empirically for this module's weights at these exact shapes.
+    That evidence does not transport: not to another module, not to other
+    weights, not to other shapes -- the M1-CI failures that motivated the
+    per-module plan are the proof that kernel-pair agreement observed on one
+    GEMM says nothing about another. Hence the plan lives on the module (see
+    ``_dedupe_plan_of``), ``padded_rows`` -- the row count of the shrunken
+    GEMM being validated -- is part of the key, and so is the identity of the
+    weight array itself, so a fine-tune step that swaps the weight buffer
+    invalidates every verdict earned under the old values.
     """
     lin = adaln_module.linear
     w = lin.weight
@@ -126,6 +130,7 @@ def _adaln_signature(adaln_module: AdaLayerNormSingle, flat: mx.array, padded_ro
         int(flat.shape[1]),
         int(padded_rows),
         int(adaln_module.num_params),
+        id(w),
         tuple(int(s) for s in w.shape),
         str(w.dtype),
         type(lin).__name__,

--- a/packages/ltx-core-mlx/src/ltx_core_mlx/model/transformer/transformer.py
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/model/transformer/transformer.py
@@ -22,6 +22,7 @@ import mlx.core as mx
 import mlx.nn as nn
 
 from ltx_core_mlx.guidance.perturbations import BatchedPerturbationConfig, PerturbationType
+from ltx_core_mlx.model.transformer.adaln import PerTokenAdaLNParams
 from ltx_core_mlx.model.transformer.attention import Attention
 from ltx_core_mlx.model.transformer.feed_forward import FeedForward
 
@@ -157,16 +158,27 @@ class BasicAVTransformerBlock(nn.Module):
         self._norm_eps = norm_eps
 
     @staticmethod
-    def _unpack_adaln(params: mx.array, table: mx.array, num_params: int, dim: int) -> list[mx.array]:
+    def _unpack_adaln(
+        params: mx.array | PerTokenAdaLNParams,
+        table: mx.array,
+        num_params: int,
+        dim: int,
+    ) -> list[mx.array]:
         """Unpack AdaLN parameters and add scale_shift_table.
 
-        Handles both scalar (B, P*dim) and per-token (B, N, P*dim) inputs.
+        Handles scalar (B, P*dim) and per-token (B, N, P*dim) inputs, plus
+        per-token parameters still in deduplicated form
+        (``PerTokenAdaLNParams``), which are expanded one (B, N, dim) slice at
+        a time here instead of being materialised in full up front. All three
+        produce bit-identical values.
 
         Returns:
             List of P arrays, each broadcastable with (B, N, dim):
             - Scalar mode: (B, 1, dim)
             - Per-token mode: (B, N, dim)
         """
+        if isinstance(params, PerTokenAdaLNParams):
+            return params.unpack(table, num_params, dim)
         if params.ndim == 2:
             # Scalar: (B, P*dim) → (B, P, dim)
             p = params.reshape(-1, num_params, dim)
@@ -186,7 +198,7 @@ class BasicAVTransformerBlock(nn.Module):
     def compute_video_normed_sa(
         self,
         video_hidden: mx.array,
-        video_adaln_params: mx.array,
+        video_adaln_params: mx.array | PerTokenAdaLNParams,
     ) -> mx.array:
         """Modulated video input to self-attention — the TeaCache gate signal.
 
@@ -212,12 +224,12 @@ class BasicAVTransformerBlock(nn.Module):
         self,
         video_hidden: mx.array,
         audio_hidden: mx.array,
-        video_adaln_params: mx.array,
-        audio_adaln_params: mx.array,
+        video_adaln_params: mx.array | PerTokenAdaLNParams,
+        audio_adaln_params: mx.array | PerTokenAdaLNParams,
         video_prompt_adaln_params: mx.array,
         audio_prompt_adaln_params: mx.array,
-        av_ca_video_params: mx.array,
-        av_ca_audio_params: mx.array,
+        av_ca_video_params: mx.array | PerTokenAdaLNParams,
+        av_ca_audio_params: mx.array | PerTokenAdaLNParams,
         av_ca_a2v_gate_params: mx.array,
         av_ca_v2a_gate_params: mx.array,
         video_text_embeds: mx.array | None = None,

--- a/tests/test_adaln_dedupe.py
+++ b/tests/test_adaln_dedupe.py
@@ -1,0 +1,168 @@
+"""Bit-exactness tests for the AdaLN per-token dedupe.
+
+The dedupe replaces a ``B*N``-row AdaLN GEMM with a handful-of-rows GEMM plus
+a gather. It is only allowed to be used when it reproduces the full-size GEMM
+*bit for bit*, so every test here asserts ``mx.array_equal`` (exact), never
+``allclose``.
+
+Runnable either under pytest or directly::
+
+    python tests/test_adaln_dedupe.py
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+import numpy as np
+
+from ltx_core_mlx.model.transformer import model as model_mod
+from ltx_core_mlx.model.transformer.adaln import AdaLayerNormSingle
+from ltx_core_mlx.model.transformer.model import LTXModel
+from ltx_core_mlx.model.transformer.timestep_embedding import get_timestep_embedding
+
+TIMESTEP_DIM = 256
+SCALE = 1000.0
+
+
+def _embed(per_token_timesteps: mx.array) -> mx.array:
+    """Mirror ``LTXModel._embed_timestep_per_token`` without building a model."""
+    b, n = per_token_timesteps.shape
+    flat = (per_token_timesteps * SCALE).reshape(-1)
+    return get_timestep_embedding(flat, TIMESTEP_DIM).reshape(b, n, -1)
+
+
+def _module(dim: int, num_params: int, seed: int = 0) -> AdaLayerNormSingle:
+    mx.random.seed(seed)
+    mod = AdaLayerNormSingle(dim, num_params=num_params, timestep_dim=TIMESTEP_DIM)
+    mod.set_dtype(mx.bfloat16)  # matches the shipped checkpoints: AdaLN stays bf16
+    mx.eval(mod.parameters())
+    return mod
+
+
+def _reference(mod: AdaLayerNormSingle, t_emb: mx.array) -> tuple[mx.array, mx.array]:
+    """The pre-optimisation implementation, verbatim."""
+    b, n, d = t_emb.shape
+    params, embedded = mod(t_emb.reshape(b * n, d))
+    return params.reshape(b, n, -1), embedded.reshape(b, n, -1)
+
+
+def _deduped(mod: AdaLayerNormSingle, t_emb: mx.array) -> tuple[mx.array, mx.array]:
+    return LTXModel._adaln_per_token(None, mod, t_emb)  # method never touches `self`
+
+
+def _assert_identical(mod: AdaLayerNormSingle, t_emb: mx.array, label: str) -> None:
+    ref_p, ref_e = _reference(mod, t_emb)
+    got_p, got_e = _deduped(mod, t_emb)
+    mx.eval(ref_p, ref_e, got_p, got_e)
+    assert got_p.shape == ref_p.shape, f"{label}: params shape {got_p.shape} != {ref_p.shape}"
+    assert got_e.shape == ref_e.shape, f"{label}: embedded shape {got_e.shape} != {ref_e.shape}"
+    assert bool(mx.array_equal(got_p, ref_p).item()), f"{label}: params not bit-identical"
+    assert bool(mx.array_equal(got_e, ref_e).item()), f"{label}: embedded not bit-identical"
+    del ref_p, ref_e, got_p, got_e
+    mx.clear_cache()
+
+
+# --- sigma patterns ---------------------------------------------------------
+
+
+def _pattern(name: str, b: int, n: int, sigma: float = 0.7, seed: int = 3) -> mx.array:
+    """Build a (B, N) per-token timestep array for a given conditioning shape."""
+    rng = np.random.default_rng(seed)
+    if name == "uniform":  # no conditioning: every token at the same sigma
+        vals = np.full((b, n), sigma, dtype=np.float32)
+    elif name == "two":  # i2v / extend: conditioning at 0, target at sigma
+        vals = np.full((b, n), sigma, dtype=np.float32)
+        vals[:, : n // 8] = 0.0
+    elif name == "four":  # several conditioning groups at different strengths
+        vals = np.full((b, n), sigma, dtype=np.float32)
+        vals[:, : n // 16] = 0.0
+        vals[:, n // 16 : n // 8] = sigma * 0.25
+        vals[:, n // 8 : n // 6] = sigma * 0.5
+    elif name == "ramp":  # worst case: a continuous per-token sigma ramp
+        vals = np.linspace(0.0, sigma, n, dtype=np.float32)[None, :].repeat(b, axis=0)
+        vals = vals + rng.standard_normal((b, n)).astype(np.float32) * 1e-6
+    else:  # pragma: no cover
+        raise ValueError(name)
+    return mx.array(vals).astype(mx.bfloat16)
+
+
+PATTERNS = ("uniform", "two", "four", "ramp")
+SHAPES = ((1, 8192), (1, 20000), (1, 30000), (2, 8192))
+
+
+def test_dedupe_is_bit_identical_video() -> None:
+    """9-param video AdaLN at 4096, every sigma pattern x realistic shapes."""
+    mod = _module(4096, 9)
+    for pattern in PATTERNS:
+        for batch, tokens in SHAPES:
+            _assert_identical(mod, _embed(_pattern(pattern, batch, tokens)), f"video/{pattern}/{batch}x{tokens}")
+
+
+def test_dedupe_is_bit_identical_other_heads() -> None:
+    """Audio (2048) and the 4-param AV cross-attention heads."""
+    for dim, num_params in ((2048, 9), (4096, 4), (2048, 4)):
+        mod = _module(dim, num_params, seed=dim + num_params)
+        for pattern in PATTERNS:
+            _assert_identical(mod, _embed(_pattern(pattern, 1, 20000)), f"{dim}/{num_params}/{pattern}")
+
+
+def test_dedupe_repeats_are_stable_across_calls() -> None:
+    """After calibration the fast path must keep matching, step after step."""
+    mod = _module(4096, 9, seed=11)
+    for sigma in (1.0, 0.8, 0.55, 0.3, 0.05):
+        _assert_identical(mod, _embed(_pattern("two", 1, 20000, sigma=sigma)), f"sigma={sigma}")
+
+
+def test_small_inputs_take_the_original_path() -> None:
+    """Below the row threshold nothing is deduped, and results still match."""
+    mod = _module(2048, 9, seed=5)
+    _assert_identical(mod, _embed(_pattern("two", 1, 512)), "small")
+
+
+def test_kill_switch_disables_dedupe() -> None:
+    prev = model_mod._ADALN_DEDUPE
+    model_mod._ADALN_DEDUPE = False
+    try:
+        mod = _module(2048, 9, seed=7)
+        _assert_identical(mod, _embed(_pattern("two", 1, 8192)), "kill-switch")
+    finally:
+        model_mod._ADALN_DEDUPE = prev
+
+
+def test_unique_rows_grouping_is_exact() -> None:
+    """The grouping key must never merge rows that are not bitwise equal."""
+    rng = np.random.default_rng(0)
+    reps = rng.standard_normal((5, TIMESTEP_DIM)).astype(np.float32)
+    idx = rng.integers(0, 5, size=8192)
+    flat = mx.array(reps[idx])
+    grouped = model_mod._unique_rows(flat)
+    assert grouped is not None
+    got_reps, inv, u = grouped
+    assert u == 5, f"expected 5 unique rows, got {u}"
+    assert bool(mx.array_equal(mx.take(got_reps, inv, axis=0), flat).item())
+
+
+def test_unique_rows_declines_on_continuous_ramp() -> None:
+    """A continuous per-token sigma ramp has no duplication to exploit."""
+    vals = np.linspace(0.0, 1.0, 8192, dtype=np.float32)
+    flat = get_timestep_embedding(mx.array(vals) * SCALE, TIMESTEP_DIM)
+    assert model_mod._unique_rows(flat) is None
+
+
+if __name__ == "__main__":
+    import time
+    import traceback
+
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if not name.startswith("test_") or not callable(fn):
+            continue
+        t0 = time.time()
+        try:
+            fn()
+            print(f"PASS  {name}  ({time.time() - t0:.1f}s)")
+        except Exception:  # noqa: BLE001
+            failures += 1
+            print(f"FAIL  {name}  ({time.time() - t0:.1f}s)")
+            traceback.print_exc()
+    raise SystemExit(1 if failures else 0)

--- a/tests/test_adaln_dedupe.py
+++ b/tests/test_adaln_dedupe.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import mlx.core as mx
 import numpy as np
+import pytest
 
 from ltx_core_mlx.model.transformer import model as model_mod
 from ltx_core_mlx.model.transformer.adaln import AdaLayerNormSingle, PerTokenAdaLNParams
@@ -267,25 +268,6 @@ def test_scalar_and_per_token_unpack_paths_still_work() -> None:
     assert len(out) == 9 and out[0].shape == (2, 7, 32)
 
 
-if __name__ == "__main__":
-    import time
-    import traceback
-
-    failures = 0
-    for name, fn in sorted(globals().items()):
-        if not name.startswith("test_") or not callable(fn):
-            continue
-        t0 = time.time()
-        try:
-            fn()
-            print(f"PASS  {name}  ({time.time() - t0:.1f}s)")
-        except Exception:
-            failures += 1
-            print(f"FAIL  {name}  ({time.time() - t0:.1f}s)")
-            traceback.print_exc()
-    raise SystemExit(1 if failures else 0)
-
-
 def test_verdict_does_not_transport_between_modules() -> None:
     """The M1-CI bug class (#86 review): a verdict earned by one module's
     weights must never be reused by a same-shaped module with other weights.
@@ -299,6 +281,9 @@ def test_verdict_does_not_transport_between_modules() -> None:
     mod_b = _module(4096, 9, seed=2)
 
     LTXModel._adaln_per_token(None, mod_a, t_emb)  # calibrates A
+    probe_a, _ = LTXModel._adaln_per_token(None, mod_a, t_emb)
+    if not isinstance(probe_a, PerTokenAdaLNParams):
+        pytest.skip("calibration rejects the shrunken GEMM on this hardware; transport is moot")
     params_b, _ = LTXModel._adaln_per_token(None, mod_b, t_emb)
     assert not isinstance(params_b, PerTokenAdaLNParams), (
         "module B skipped its own calibration: verdict transported from module A"
@@ -319,3 +304,22 @@ def test_plan_never_reaches_module_parameters() -> None:
     assert "_adaln_dedupe_plan" in mod.__dict__, "plan was never created"
     leaked = [k for k, _ in tree_flatten(mod.parameters()) if "dedupe" in k]
     assert leaked == [], f"plan leaked into parameters(): {leaked}"
+
+
+if __name__ == "__main__":
+    import time
+    import traceback
+
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if not name.startswith("test_") or not callable(fn):
+            continue
+        t0 = time.time()
+        try:
+            fn()
+            print(f"PASS  {name}  ({time.time() - t0:.1f}s)")
+        except Exception:
+            failures += 1
+            print(f"FAIL  {name}  ({time.time() - t0:.1f}s)")
+            traceback.print_exc()
+    raise SystemExit(1 if failures else 0)

--- a/tests/test_adaln_dedupe.py
+++ b/tests/test_adaln_dedupe.py
@@ -1,9 +1,11 @@
-"""Bit-exactness tests for the AdaLN per-token dedupe.
+"""Bit-exactness tests for the AdaLN per-token dedupe and deferred gather.
 
 The dedupe replaces a ``B*N``-row AdaLN GEMM with a handful-of-rows GEMM plus
-a gather. It is only allowed to be used when it reproduces the full-size GEMM
-*bit for bit*, so every test here asserts ``mx.array_equal`` (exact), never
-``allclose``.
+a gather. The deferred gather then keeps the deduplicated form all the way into
+the transformer blocks, so the full ``(B*N, num_params*dim)`` float32 tensor is
+never materialised. Neither is allowed to be used unless it reproduces the
+original *bit for bit*, so every test here asserts ``mx.array_equal`` (exact),
+never ``allclose``.
 
 Runnable either under pytest or directly::
 
@@ -16,9 +18,10 @@ import mlx.core as mx
 import numpy as np
 
 from ltx_core_mlx.model.transformer import model as model_mod
-from ltx_core_mlx.model.transformer.adaln import AdaLayerNormSingle
+from ltx_core_mlx.model.transformer.adaln import AdaLayerNormSingle, PerTokenAdaLNParams
 from ltx_core_mlx.model.transformer.model import LTXModel
 from ltx_core_mlx.model.transformer.timestep_embedding import get_timestep_embedding
+from ltx_core_mlx.model.transformer.transformer import BasicAVTransformerBlock
 
 TIMESTEP_DIM = 256
 SCALE = 1000.0
@@ -46,8 +49,14 @@ def _reference(mod: AdaLayerNormSingle, t_emb: mx.array) -> tuple[mx.array, mx.a
     return params.reshape(b, n, -1), embedded.reshape(b, n, -1)
 
 
+def _materialise(x):
+    """Expand a deferred-gather carrier; pass plain arrays through."""
+    return x.gather() if isinstance(x, PerTokenAdaLNParams) else x
+
+
 def _deduped(mod: AdaLayerNormSingle, t_emb: mx.array) -> tuple[mx.array, mx.array]:
-    return LTXModel._adaln_per_token(None, mod, t_emb)  # method never touches `self`
+    params, embedded = LTXModel._adaln_per_token(None, mod, t_emb)  # method never touches `self`
+    return _materialise(params), _materialise(embedded)
 
 
 def _assert_identical(mod: AdaLayerNormSingle, t_emb: mx.array, label: str) -> None:
@@ -149,6 +158,110 @@ def test_unique_rows_declines_on_continuous_ramp() -> None:
     assert model_mod._unique_rows(flat) is None
 
 
+# --- deferred per-block gather ----------------------------------------------
+
+
+def _eager_unpack(params: mx.array, table: mx.array, num_params: int, dim: int) -> list[mx.array]:
+    """The pre-optimisation ``_unpack_adaln`` per-token branch, verbatim."""
+    b, n, _ = params.shape
+    p = params.reshape(b, n, num_params, dim)
+    p = p + table[None, None, :num_params, :]
+    return [p[:, :, i, :] for i in range(num_params)]
+
+
+def _assert_unpack_identical(dim: int, num_params: int, pattern: str, batch: int, tokens: int) -> None:
+    mod = _module(dim, num_params, seed=dim + num_params)
+    t_emb = _embed(_pattern(pattern, batch, tokens))
+    label = f"{dim}/{num_params}/{pattern}/{batch}x{tokens}"
+
+    lazy_params, _ = LTXModel._adaln_per_token(None, mod, t_emb)
+    assert isinstance(lazy_params, PerTokenAdaLNParams), f"{label}: expected a deferred-gather carrier"
+    assert lazy_params.shape == (batch, tokens, num_params * dim), f"{label}: carrier reports {lazy_params.shape}"
+    assert lazy_params.unique_rows < tokens, f"{label}: carrier kept {lazy_params.unique_rows} rows"
+
+    table = mx.random.normal((num_params, dim)).astype(mx.bfloat16)
+    mx.eval(table)
+
+    eager = _eager_unpack(lazy_params.gather(), table, num_params, dim)
+    lazy = BasicAVTransformerBlock._unpack_adaln(lazy_params, table, num_params, dim)
+    mx.eval(eager, lazy)
+    assert len(lazy) == len(eager)
+    for i, (got, ref) in enumerate(zip(lazy, eager, strict=True)):
+        assert got.shape == ref.shape, f"{label}: param {i} shape {got.shape} != {ref.shape}"
+        assert got.dtype == ref.dtype, f"{label}: param {i} dtype {got.dtype} != {ref.dtype}"
+        assert bool(mx.array_equal(got, ref).item()), f"{label}: param {i} not bit-identical"
+    del eager, lazy
+    mx.clear_cache()
+
+
+def test_lazy_unpack_is_bit_identical() -> None:
+    """Deferred per-block expansion == eager unpack of the gathered tensor."""
+    for pattern in ("uniform", "two", "four"):
+        _assert_unpack_identical(4096, 9, pattern, 1, 20000)
+    for dim, num_params in ((2048, 9), (4096, 4), (2048, 4)):
+        _assert_unpack_identical(dim, num_params, "two", 1, 20000)
+    _assert_unpack_identical(4096, 9, "two", 2, 8192)  # batch > 1
+    _assert_unpack_identical(4096, 9, "ramp", 1, 20000)  # worst case, still deduped
+
+
+def test_lazy_carrier_holds_only_the_distinct_rows() -> None:
+    """The whole point: what survives the call is a handful of rows, not B*N."""
+    mod = _module(4096, 9, seed=21)
+    params, embedded = LTXModel._adaln_per_token(None, mod, _embed(_pattern("two", 1, 20000)))
+    assert isinstance(params, PerTokenAdaLNParams)
+    assert isinstance(embedded, PerTokenAdaLNParams)
+    assert params.unique_rows == 2, f"expected 2 distinct rows, got {params.unique_rows}"
+    assert embedded.unique_rows == 2, f"expected 2 distinct rows, got {embedded.unique_rows}"
+    assert params.shape == (1, 20000, 9 * 4096)
+    assert embedded.shape == (1, 20000, 4096)
+
+
+def test_lazy_kill_switch_materialises_eagerly() -> None:
+    """LTX2_ADALN_LAZY=0 restores the eager gather, bit for bit."""
+    mod = _module(2048, 9, seed=13)
+    t_emb = _embed(_pattern("two", 1, 8192))
+    ref_p, ref_e = _reference(mod, t_emb)
+
+    prev = model_mod._ADALN_LAZY
+    model_mod._ADALN_LAZY = False
+    try:
+        got_p, got_e = LTXModel._adaln_per_token(None, mod, t_emb)
+    finally:
+        model_mod._ADALN_LAZY = prev
+    assert isinstance(got_p, mx.array), "kill switch must return a plain array"
+    assert isinstance(got_e, mx.array), "kill switch must return a plain array"
+    mx.eval(ref_p, ref_e, got_p, got_e)
+    assert bool(mx.array_equal(got_p, ref_p).item()), "kill-switch params not bit-identical"
+    assert bool(mx.array_equal(got_e, ref_e).item()), "kill-switch embedded not bit-identical"
+
+
+def test_lazy_declines_when_dedupe_declines() -> None:
+    """Nothing to defer without the dedupe -- both fallbacks return arrays."""
+    mod = _module(2048, 9, seed=17)
+    small = _embed(_pattern("two", 1, 512))  # below the dedupe row threshold
+    params, embedded = LTXModel._adaln_per_token(None, mod, small)
+    assert isinstance(params, mx.array) and isinstance(embedded, mx.array)
+
+    prev = model_mod._ADALN_DEDUPE
+    model_mod._ADALN_DEDUPE = False
+    try:
+        params, embedded = LTXModel._adaln_per_token(None, mod, _embed(_pattern("two", 1, 8192)))
+    finally:
+        model_mod._ADALN_DEDUPE = prev
+    assert isinstance(params, mx.array) and isinstance(embedded, mx.array)
+
+
+def test_scalar_and_per_token_unpack_paths_still_work() -> None:
+    """Plain arrays keep both original ``_unpack_adaln`` branches."""
+    table = mx.zeros((9, 32))
+    scalar = mx.random.normal((2, 9 * 32))
+    out = BasicAVTransformerBlock._unpack_adaln(scalar, table, 9, 32)
+    assert len(out) == 9 and out[0].shape == (2, 1, 32)
+    per_token = mx.random.normal((2, 7, 9 * 32))
+    out = BasicAVTransformerBlock._unpack_adaln(per_token, table, 9, 32)
+    assert len(out) == 9 and out[0].shape == (2, 7, 32)
+
+
 if __name__ == "__main__":
     import time
     import traceback
@@ -161,7 +274,7 @@ if __name__ == "__main__":
         try:
             fn()
             print(f"PASS  {name}  ({time.time() - t0:.1f}s)")
-        except Exception:  # noqa: BLE001
+        except Exception:
             failures += 1
             print(f"FAIL  {name}  ({time.time() - t0:.1f}s)")
             traceback.print_exc()

--- a/tests/test_adaln_dedupe.py
+++ b/tests/test_adaln_dedupe.py
@@ -174,6 +174,9 @@ def _assert_unpack_identical(dim: int, num_params: int, pattern: str, batch: int
     t_emb = _embed(_pattern(pattern, batch, tokens))
     label = f"{dim}/{num_params}/{pattern}/{batch}x{tokens}"
 
+    # The plan lives on the module and the calibrating (first) call returns
+    # the exact reference, not a carrier -- warm it up, then exercise dedupe.
+    LTXModel._adaln_per_token(None, mod, t_emb)
     lazy_params, _ = LTXModel._adaln_per_token(None, mod, t_emb)
     assert isinstance(lazy_params, PerTokenAdaLNParams), f"{label}: expected a deferred-gather carrier"
     assert lazy_params.shape == (batch, tokens, num_params * dim), f"{label}: carrier reports {lazy_params.shape}"
@@ -207,7 +210,9 @@ def test_lazy_unpack_is_bit_identical() -> None:
 def test_lazy_carrier_holds_only_the_distinct_rows() -> None:
     """The whole point: what survives the call is a handful of rows, not B*N."""
     mod = _module(4096, 9, seed=21)
-    params, embedded = LTXModel._adaln_per_token(None, mod, _embed(_pattern("two", 1, 20000)))
+    t_emb = _embed(_pattern("two", 1, 20000))
+    LTXModel._adaln_per_token(None, mod, t_emb)  # calibrating call returns the reference
+    params, embedded = LTXModel._adaln_per_token(None, mod, t_emb)
     assert isinstance(params, PerTokenAdaLNParams)
     assert isinstance(embedded, PerTokenAdaLNParams)
     assert params.unique_rows == 2, f"expected 2 distinct rows, got {params.unique_rows}"
@@ -279,3 +284,38 @@ if __name__ == "__main__":
             print(f"FAIL  {name}  ({time.time() - t0:.1f}s)")
             traceback.print_exc()
     raise SystemExit(1 if failures else 0)
+
+
+def test_verdict_does_not_transport_between_modules() -> None:
+    """The M1-CI bug class (#86 review): a verdict earned by one module's
+    weights must never be reused by a same-shaped module with other weights.
+
+    Both modules share every signature component; only the weights differ.
+    Each must go through its own calibrating call (reference output, no
+    carrier) before its own dedupe kicks in.
+    """
+    t_emb = _embed(_pattern("two", 1, 4096))
+    mod_a = _module(4096, 9, seed=1)
+    mod_b = _module(4096, 9, seed=2)
+
+    LTXModel._adaln_per_token(None, mod_a, t_emb)  # calibrates A
+    params_b, _ = LTXModel._adaln_per_token(None, mod_b, t_emb)
+    assert not isinstance(params_b, PerTokenAdaLNParams), (
+        "module B skipped its own calibration: verdict transported from module A"
+    )
+    params_b2, _ = LTXModel._adaln_per_token(None, mod_b, t_emb)
+    assert isinstance(params_b2, PerTokenAdaLNParams), "module B never calibrated"
+
+
+def test_plan_never_reaches_module_parameters() -> None:
+    """The per-module plan is bookkeeping, not state: parameters() and the
+    weight-loading contracts must not see it."""
+    from mlx.utils import tree_flatten
+
+    mod = _module(2048, 4, seed=3)
+    t_emb = _embed(_pattern("two", 1, 4096))
+    LTXModel._adaln_per_token(None, mod, t_emb)
+    LTXModel._adaln_per_token(None, mod, t_emb)
+    assert "_adaln_dedupe_plan" in mod.__dict__, "plan was never created"
+    leaked = [k for k, _ in tree_flatten(mod.parameters()) if "dedupe" in k]
+    assert leaked == [], f"plan leaked into parameters(): {leaked}"


### PR DESCRIPTION
## Motivation

On a unified-memory Mac, peak GPU allocation is the binding constraint long before FLOPs are. The q4 tier exists precisely so 16 GB and 32 GB machines can run this — and on those machines a couple of gigabytes of transient allocation is the difference between a render finishing and the Metal allocator refusing.

Whenever per-token timesteps are active — i2v, keyframe/FFLF, extend, retake, reference-latent conditioning, IC-LoRA, lipdub; everything except plain t2v — the per-token AdaLN path allocates far more than it needs to, in two separate ways. Both are addressed here, in two commits, with no change to a single output bit.

## The two changes

### 1. `perf(transformer): deduplicate the per-token AdaLN GEMM`

`LTXModel._adaln_per_token` runs the AdaLN MLP + projection over every one of the `B*N` tokens, every step. But the per-token conditioning vector only ever takes a handful of distinct values: the target sigma, plus one per conditioning group. Every conditioning path in the tree builds its per-token sigma as `denoise_mask * sigma` where the mask is assembled from `mx.ones` / `mx.zeros` / `mx.full(1 - strength)`, and `strength` is a scalar per conditioning item — so distinct rows number 2 to 4 in practice, not 20 000.

The flattened rows are grouped, the MLP runs on the distinct set, and the result is expanded back. Isolated cost of exactly the AdaLN work one denoise step does in per-token mode (video 9-param + 4-param at dim 4096 plus the audio pair at 2048), median of 5, M4 Max:

| video tokens | before | after | saved / step |
|---:|---:|---:|---:|
| 8 192 | 0.327 s | 0.055 s | 0.273 s |
| 14 080 | 0.566 s | 0.065 s | 0.502 s |
| 20 000 | 0.795 s | 0.074 s | 0.721 s |
| 30 000 | 1.196 s | 0.094 s | 1.102 s |

In context that is ~1 % of a denoise step — the AdaLN GEMM is 10.5 TFLOP of roughly 760 TFLOP at 20 000 tokens. Real, free, but nobody will feel it. It is here mainly because it is the prerequisite for the second commit.

### 2. `perf(transformer): defer the per-token AdaLN gather into the blocks`

This is the one that matters.

The projection's output is **float32** — the sinusoidal timestep embedding is float32 and MLX promotes — and it is shaped `(B*N, num_params*dim)`. At 20 000 video tokens that is **2.95 GB** for the 9-parameter video head plus **1.31 GB** for the 4-parameter AV cross-attention head, and it stays resident for the entire 48-block stack because every block needs it. Each block then materialises its own full-size `(B, N, P, dim)` copy in `_unpack_adaln` in order to slice the parameters out.

Since commit 1 already computes the distinct rows, keep the tensor in that form. `_adaln_per_token` returns a `PerTokenAdaLNParams` — the distinct rows plus the inverse index, a few kilobytes — and `BasicAVTransformerBlock._unpack_adaln` expands one `(B, N, dim)` parameter slice at a time, inside the block that consumes it, where MLX frees each slice as it goes. The output-block embedded timestep is expanded after the stack, at its single point of use.

Peak GPU memory for one denoise step, `mx.get_peak_memory()`, M4 Max 64 GB, q4 distilled with all 48 blocks resident, i2v-shaped per-token sigmas (2 distinct). The 10.54 GB of resident weights is included in every figure, and each number is the min of 2–3 measured steps after warm-up (they were identical to the megabyte across repeats):

| video tokens | current `main` | + commit 1 | + commit 2 | saved vs `main` |
|---:|---:|---:|---:|---:|
| 8 192 | 16.25 GB | 16.13 GB | **12.73 GB** | **3.52 GB** |
| 20 000 | 24.06 GB | 23.76 GB | **15.50 GB** | **8.56 GB** |

Step activations alone — peak minus the 10.55 GB weights-and-inputs baseline:

| video tokens | current `main` | + commit 2 | cut |
|---:|---:|---:|---:|
| 8 192 | 5.70 GB | 2.18 GB | −62 % |
| 20 000 | 13.51 GB | 4.95 GB | −63 % |

Wall clock is unchanged to slightly better, so this is not a memory-for-time trade:

| measurement | `main` | commit 1 | commit 2 |
|---|---:|---:|---:|
| synthetic step, 8 192 tokens | 26.80 s | 26.54 s | 26.21 s |
| synthetic step, 20 000 tokens | 88.10 s | 88.04 s | 86.37 s |
| real render, 1024×576×97 i2v, stage-2 step (7 488 tokens) | 24.52 s | 24.42 s | 24.17 s |
| real render, 1024×576×97 i2v, total | 130.4 s | 129.7 s | 128.6 s |

A note on methodology: `mx.get_peak_memory()` is the metric, not process RSS. MLX's Metal allocations do not appear in the process resident set on macOS — a 4 GB `mx.zeros` moves `ps rss` and `ru_maxrss` by zero on this machine — so RSS was flat at 10.70 GB (the mmap'd safetensors pages) in every configuration and says nothing useful here.

## Bit-exactness

Every claim below is `mx.array_equal`, never `allclose`.

### Commit 2 is exact by construction

A gather is a pure row permutation and the scale-shift-table add is elementwise, so the two commute exactly: `take(x, inv)[m, d] + table[i, d]` and `take(x + table, inv)[m, d]` are the same IEEE operation on the same operands. There is no reduction whose order could change.

### Commit 1 is *not* exact by construction — and that is the interesting part

The intuition "same weights, same rows, just fewer of them, so the result must be identical" is **false on MLX**. MLX dispatches different Metal GEMM kernels depending on the row count `M`, and different kernels use a different K-reduction order, so the same input row can come out ~1 bf16 ULP apart depending on how many rows were in the batch. Characterisation sweep with fixed weights and identical rows, varying only `M`:

| shape | subset result matches full result? |
|---|---|
| bf16 matmul 256 → 4096 | matches for all `M ≥ 2`; `M = 1` (gemv path) differs |
| bf16 matmul 4096 → 4096 | small-`M` kernel differs from large-`M` kernel; crossover between `M = 64` and `M = 137` |
| bf16 `nn.Linear` 4096 → 36864 | matches for `M ≥ 2`, differs at `M = 1` |
| `QuantizedLinear` q8/q4 4096 → 36864 | small-`M` path differs from the gemm path; crossover between `M = 4` and `M = 64` |

With the real modules at 20 000 tokens: a 2-row GEMM is rejected, 256 rows is accepted for the 4096-dim heads, and the 2048-dim heads need 1024 rows. There is no safe constant to hard-code — the threshold moves with output width. Anyone who attempts this optimisation will hit this, so it is worth writing down.

Two things make the shipped version exact anyway:

- **Padding.** The distinct rows are repeated up to a candidate row count (`unique → 256 → 1024 → 4096`, cheapest first) so the shrunken GEMM lands on the same kernel as the full-size one. Padding rows are pure filler — each GEMM output row is independent — so they only influence kernel selection.
- **One-time self-verification.** The first time a shape signature is seen, the code computes the *real* full-size result, checks the shrunken result against it with `mx.array_equal` (chunked, to bound peak memory), and returns **the reference** for that call. Only a proven-equal configuration is ever used afterwards. Kernel selection depends on shapes, dtypes and strides and never on values, so one verification per signature is sound. If no candidate matches exactly, the signature is permanently marked not-deduplicable and the original path runs.

Cost of that safety: one extra full-size AdaLN GEMM per shape signature per process (~0.4 s once at 20 000 tokens), then every later step is cheap. The failure mode is "no speedup", never "wrong output".

The grouping itself is also verified rather than trusted: rows are grouped by the raw bit patterns of two columns of the sinusoidal embedding, then `mx.take(reps, inverse) == flat` is checked bitwise before the grouping is used. A key collision can only ever cost the optimisation.

(Helpfully, the AdaLN projections are not quantized in the shipped checkpoints — `quantize_config.json` says `"only_transformer_blocks": true` for both q4 and q8 — so the nastier quantized-matmul thresholds never apply on this path.)

### Validation performed

**Unit** — `tests/test_adaln_dedupe.py`, 12 tests, all exact. Covers sigma patterns `uniform` / `two` (i2v) / `four` (multiple conditioning groups) / `ramp` (continuous per-token sigma, the worst case); shapes `1×8192`, `1×20000`, `1×30000`, `2×8192`; heads `4096/9` (video), `2048/9` (audio), `4096/4` and `2048/4` (AV cross-attention). Both the deduped values and the deferred per-block expansion are asserted against the pre-optimisation implementation, reproduced verbatim in the test file. Both kill switches are tested, as are the two original `_unpack_adaln` branches.

**End-to-end** — same code, same seed, same everything; the only difference between runs is the two env vars. Final video and audio latents compared by sha256 (stronger than comparing mp4 bytes):

| render | tokens (stage 1 / stage 2) | video latent sha256 | audio latent |
|---|---|---|---|
| i2v 640×480×25, q4 distilled, seed 1234 | 320 / 1 120 | `3e06b79f…` — identical across all three configurations | identical |
| i2v 1024×576×97, q4 distilled, 8+3 steps, seed 1234 | 1 872 / 7 488 | `cbc1464c…` — identical across all three configurations | identical |

("all three configurations" = both optimisations on, dedupe only, and both off.)

**Suite** — `pytest -m "not slow"` on this branch: 618 passed, 21 failed. Same 21 failures on unmodified `main` (missing local weights / a trainer import), byte-identical failure lists. `ruff check` and `ruff format --check` clean on the touched files.

## Scope and escape hatches

One new class in `adaln.py`, one branch at the top of `_unpack_adaln`, and the dedupe machinery in `model.py`. No public API change, no change to any weight key, no change to scalar-timestep behaviour, and t2v never enters this path at all. `mx.checkpoint`-based gradient checkpointing is unaffected — the carrier is captured as a constant, exactly as the eager tensor was.

| env var | default | effect |
|---|---|---|
| `LTX2_ADALN_DEDUPE=0` | on | disables the deduplicated GEMM (and therefore the deferred gather, which has nothing to defer without it) |
| `LTX2_ADALN_LAZY=0` | on | disables the deferred gather only; the deduplicated result is expanded eagerly, as in commit 1 |
| `LTX2_ADALN_DEDUPE_MIN_ROWS` | 1024 | below this many rows the GEMM is cheap and the bookkeeping is skipped |
| `LTX2_ADALN_DEDUPE_MAX_FRAC` | 0.5 | decline when the distinct rows are more than this fraction of the total |
| `LTX2_ADALN_DEDUPE_DEBUG=1` | off | trace every calibration verdict |

Degenerate inputs degrade gracefully rather than break. A genuine continuous per-token sigma ramp — which no path in the tree currently produces — still partially deduplicates for free, because per-token timesteps arrive as bfloat16 and a 20 000-token linear ramp collapses to 1 021 distinct rows; the test suite covers that case and it stays bit-identical. Anything worse than that falls out to the original code path with no measurable overhead.

Happy to split this into two PRs if you would rather review them separately, though commit 2 depends on commit 1.
