### PR TITLE
fix(ci): unbreak the build and lint after hatchling 1.32 and ruff 0.16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,16 @@ jobs:
       - name: lint (ruff check)
         uses: astral-sh/ruff-action@278981a28ce3188b1e39527901f38254bf3aac89  # v4.1.0
         with:
+          # Pin to the locked ruff so CI matches local `uv run ruff`. Without
+          # this the action installs the newest release and a ruff upgrade
+          # reddens every open PR at once (0.16.0 did, by formatting the
+          # Python snippets in CLAUDE.md).
+          version-file: uv.lock
           args: check packages/ tests/
       - name: format (ruff format)
         uses: astral-sh/ruff-action@278981a28ce3188b1e39527901f38254bf3aac89  # v4.1.0
         with:
+          version-file: uv.lock
           args: format --check packages/ tests/
 
   syntax:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,6 +242,7 @@ Note: Connector attention **keeps** Sequential wrapping (`to_out.0.*` stays).
 
 ```python
 from ltx_core_mlx.utils.memory import aggressive_cleanup
+
 aggressive_cleanup()  # gc.collect() + mx.clear_cache()
 ```
 
@@ -253,7 +254,7 @@ Never decode all video frames in RAM. Stream frame-by-frame to ffmpeg:
 
 ```python
 for i in range(num_frames):
-    frame = decoder.decode_frame(latents[:, :, i:i+1])
+    frame = decoder.decode_frame(latents[:, :, i : i + 1])
     ffmpeg_proc.stdin.write(frame_to_bytes(frame))
     del frame
     if i % 8 == 0:
@@ -654,8 +655,8 @@ Timestep-aware residual caching (Liu et al., *Timestep Embedding Aware Cache*) f
 ```python
 pipeline.generate_and_save(
     prompt=...,
-    enable_teacache=True,           # default False
-    teacache_thresh=0.5,            # optional override
+    enable_teacache=True,  # default False
+    teacache_thresh=0.5,  # optional override
 )
 ```
 

--- a/packages/ltx-core-mlx/pyproject.toml
+++ b/packages/ltx-core-mlx/pyproject.toml
@@ -6,7 +6,6 @@ build-backend = "hatchling.build"
 name = "ltx-core-mlx"
 version = "0.14.19"
 description = "LTX-2.3 model library ported to MLX for Apple Silicon"
-readme = "../../README.md"
 license = "MIT"
 requires-python = ">=3.11"
 authors = [{ name = "dgrauet" }]

--- a/packages/ltx-pipelines-mlx/pyproject.toml
+++ b/packages/ltx-pipelines-mlx/pyproject.toml
@@ -6,7 +6,6 @@ build-backend = "hatchling.build"
 name = "ltx-pipelines-mlx"
 version = "0.14.19"
 description = "Generation pipelines for LTX-2.3 on MLX"
-readme = "../../README.md"
 license = "MIT"
 requires-python = ">=3.11"
 authors = [{ name = "dgrauet" }]

--- a/packages/ltx-trainer/pyproject.toml
+++ b/packages/ltx-trainer/pyproject.toml
@@ -6,7 +6,6 @@ build-backend = "hatchling.build"
 name = "ltx-trainer-mlx"
 version = "0.14.19"
 description = "LTX-2 training toolkit ported to MLX for Apple Silicon"
-readme = "../../README.md"
 license = "MIT"
 requires-python = ">=3.11"
 authors = [{ name = "dgrauet" }]


### PR DESCRIPTION
`main` has been red — and unbuildable locally — since 2026-08-11. Two
upstream releases are responsible, and neither was triggered by anything
in this repo.

## 1. hatchling 1.32.0 breaks every `uv run`

Released 2026-08-11 05:03 UTC, hours after #88's CI was last green. It
enforces that `readme` resolves inside the project directory:

```
ValueError: Readme path must be within the project directory: ../../README.md
```

All three sub-packages set `readme = "../../README.md"`, so the editable
build of the workspace fails outright — `uv run python -c "print(1)"` is
enough to reproduce. Nothing runs locally: no pytest, no ruff, no CLI.

None of the three are published (there is no PyPI workflow; the root
package is the only distributable and its `readme = "README.md"` is
already valid), so the field was metadata-only. It is dropped rather
than replaced with a stub README per package.

## 2. ruff 0.16.0 reddens `lint` on every PR

ruff 0.16.0 formats Python code blocks embedded in Markdown, and
`ruff-action`'s `src` input defaults to `${{ github.workspace }}`
independently of the paths passed in `args` — so `CLAUDE.md` silently
entered the scope of `format --check`. It is the only failing file.

Diagnosis credit to @plz12345, who reported this on #85; this PR lands
it standalone so the other open PRs can go green without taking the mlx
bump with them.

Two parts:

- The three snippets are reformatted. Cosmetic only — a blank line after
  an import, `i:i+1` → `i : i + 1`, de-aligned trailing comments.
- The action now takes `version-file: uv.lock`, so CI runs the same ruff
  as `uv run ruff` (0.15.7 today) and a future upgrade arrives through
  the lockfile instead of breaking every open PR the day it ships. This
  matches how the repo already pins its actions by SHA.

The reformatted tree is accepted by **both** 0.15.7 and 0.16.3, so the
pin and the reformat are independent — neither depends on the other
holding.

## Validation

| check | result |
|---|---|
| `uv run python -c "import ltx_core_mlx, ltx_pipelines_mlx"` | OK (fails on `main`) |
| `uv run pytest -m "not slow"` | 625 passed, 1 skipped, 3 failed |
| `ruff 0.15.7 check` / `format --check` over `packages/ tests/ .` | clean |
| `ruff 0.16.3 check` / `format --check` over `packages/ tests/ .` | clean |

The 3 failures are the pre-existing ffmpeg-subprocess tests that close
`stdin` then call `communicate()` on Python 3.11 — the same three
reported independently on #82 and #83, unrelated to this change and not
addressed here.

No source file is touched; the diff is three pyproject lines, one CI
job, and a docs reformat.