### PR TITLE
fix(tests): stop weight-gated tests from silently skipping, and unbreak them

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,19 +7,31 @@ _Q8_CANDIDATES = [
     _HUB_DIR / "models--dgrauet--ltx-2.3-mlx-q8" / "snapshots",
 ]
 
+# A snapshot without this file cannot serve the weight-gated tests.
+_REQUIRED_WEIGHT = "transformer-distilled.safetensors"
+
 
 def find_q8_model_dir() -> Path | None:
-    """Find the latest q8 model snapshot directory."""
+    """Find a complete q8 model snapshot, or None if none is usable.
+
+    The hub keeps one snapshot directory per revision, and a revision only
+    symlinks the files that were fetched at it -- so a cache can hold a dozen
+    partial snapshots (a lone ``config.json``, say) beside the complete ones.
+    Any download that resolves a new revision adds another.
+
+    Every candidate is therefore checked and the most recently modified
+    *complete* one wins. Picking by name alone silently selects a partial
+    snapshot as soon as one sorts last, which skips every weight-gated test
+    while the suite still exits 0.
+    """
+    complete: list[Path] = []
     for candidate in _Q8_CANDIDATES:
         if not candidate.exists():
             continue
-        snapshots = sorted(candidate.iterdir())
-        if not snapshots:
-            continue
-        model_dir = snapshots[-1]
-        if (model_dir / "transformer-distilled.safetensors").exists():
-            return model_dir
-    return None
+        complete += [d for d in candidate.iterdir() if (d / _REQUIRED_WEIGHT).exists()]
+    if not complete:
+        return None
+    return max(complete, key=lambda d: d.stat().st_mtime)
 
 
 MODEL_DIR = find_q8_model_dir()

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -226,9 +226,10 @@ class TestFullGeneration:
                 for i in range(num_frames_out):
                     frame = np.array(frames[i])
                     proc.stdin.write(frame.tobytes())
-                proc.stdin.close()
             except BrokenPipeError:
                 pass
+            # communicate() closes stdin itself; closing it here first makes its
+            # flush raise ValueError on Python 3.11.
             _, stderr = proc.communicate()
             if proc.returncode != 0:
                 print(f"  ffmpeg warning: {stderr.decode()[-200:]}")

--- a/tests/test_generate_real_prompt.py
+++ b/tests/test_generate_real_prompt.py
@@ -237,9 +237,10 @@ class TestRealPromptGeneration:
             try:
                 for i in range(num_frames_out):
                     proc.stdin.write(np.array(frames[i]).tobytes())
-                proc.stdin.close()
             except BrokenPipeError:
                 pass
+            # communicate() closes stdin itself; closing it here first makes its
+            # flush raise ValueError on Python 3.11.
             proc.communicate()
 
         print(f"\n  Output: {output_dir}")

--- a/tests/test_generate_with_rope.py
+++ b/tests/test_generate_with_rope.py
@@ -208,9 +208,10 @@ class TestGenerateWithRoPE:
             try:
                 for i in range(num_frames_out):
                     proc.stdin.write(np.array(frames[i]).tobytes())
-                proc.stdin.close()
             except BrokenPipeError:
                 pass
+            # communicate() closes stdin itself; closing it here first makes its
+            # flush raise ValueError on Python 3.11.
             proc.communicate()
 
         print(f"\n  Output: {output_dir}")


### PR DESCRIPTION
The tests that exercise real weights have not been running, and the suite
exited 0 while they didn't. Two bugs, stacked.

## 1. Snapshot discovery picks a partial snapshot

`tests/conftest.py::find_q8_model_dir` took `sorted(snapshots)[-1]`.

The hub keeps one snapshot directory per revision and only symlinks the
files fetched at that revision, so a cache accumulates partial snapshots
beside the complete ones. On this machine:

```
YES  files=22  6671a757…
YES  files=21  03da129b…
YES  files=19  4cb4bb0f…   (+2 more complete)
no   files=1   22bc6e21…
no   files=3   df68cfa6…   <- sorted()[-1] picks this one
 …10 partial in total
```

`df68cfa6…` holds three files and no `transformer-distilled.safetensors`,
so `MODEL_DIR` is `None` and every weight-gated test skips — silently,
exit code 0.

Any download that resolves a new revision can flip this. It is why the
local pass count drifted during a single session: `625 passed, 3 failed`
one hour, `607 passed, 22 skipped` the next, with no source change
between them. I noted the discrepancy at the time and did not chase it;
this was the cause.

All candidates are now checked for the weight file they actually need,
and the most recently modified complete one wins.

## 2. The three tests it re-exposed were broken

With discovery fixed, three tests fail on:

```
ValueError: flush of closed file
```

They do `proc.stdin.close()` and then `proc.communicate()`, which closes
stdin again and raises on Python 3.11. The explicit close is redundant —
`communicate()` does it — so it is dropped, with a comment so it does not
come back.

These are the same three failures reported independently on #82 and #83
and treated as "pre-existing" ever since. They were only ever visible in
the window where `MODEL_DIR` happened to resolve, which is why they were
never chased down.

Fixing (1) without (2) would just convert a silent skip into a red suite,
so both are here.

## Validation

| | before | after |
|---|---|---|
| `pytest -m "not slow"` (weights present) | 664 passed, **3 failed** | **667 passed**, 1 skipped |
| `MODEL_DIR` resolves | `None` | the 22-file snapshot |
| `ruff check` / `format --check` | clean | clean |

**CI is unaffected in either direction** — the GitHub runners have no
weights, so `MODEL_DIR` is `None` there by design and these tests skip.
This changes what the suite does on a developer machine that has the
weights, which is precisely where it was lying.

No source file is touched; the diff is `tests/` only.