### PR TITLE
ci: lint the pull request title instead of every commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    # `edited` matters: commitlint checks the PR title, and without it a title
+    # fixed after a red run never re-runs, leaving the check stuck red until an
+    # unrelated commit is pushed. The other three are the default set, which
+    # naming any type at all would otherwise drop.
+    types: [opened, synchronize, reopened, edited]
 
 jobs:
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,10 +66,35 @@ jobs:
         continue-on-error: true
       - run: uv run pytest tests/ -v -m "not slow" --tb=short
 
+  # Lints the pull request TITLE, not the individual commits.
+  #
+  # Squash is the only merge method, and `squash_merge_commit_title` is
+  # PR_TITLE, so the PR title is the subject that lands on main and the one
+  # release-please reads to pick a version bump. The commits inside a PR are
+  # discarded by the squash, so requiring conventional-commit subjects on them
+  # asked contributors to reword messages that never reach the history the rule
+  # exists to protect -- see the #83 thread.
+  #
+  # The push branch is a backstop: on main the squashed subject is the PR title,
+  # so linting it catches anything that reached main another way.
   commitlint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 0
-      - uses: wagoid/commitlint-github-action@b948419dd99f3fd78a6548d48f94e3df7f6bf3ed  # v6.2.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
+        with:
+          node-version: "22"
+      - name: Install commitlint
+        run: npm install --no-save @commitlint/cli @commitlint/config-conventional
+      - name: Lint the pull request title
+        if: github.event_name == 'pull_request'
+        # Via env, never interpolated into the script: a PR title is
+        # attacker-controlled text and would otherwise be a command injection.
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: printf '%s\n' "$PR_TITLE" | npx commitlint
+      - name: Lint the pushed commit
+        if: github.event_name == 'push'
+        run: npx commitlint --from HEAD~1 --to HEAD

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,10 @@
+# `commitlint` runs at the commit-msg stage, so `pre-commit install` wires it up
+# without a second --hook-type flag. This is a convenience for people who have
+# the hooks installed, not a gate: git hooks live in .git/hooks, which no clone
+# carries, so nothing can impose them on a contributor. The enforced check is
+# the PR title in CI.
+default_install_hook_types: [pre-commit, commit-msg]
+
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.11.12
@@ -15,3 +22,9 @@ repos:
     rev: v8.30.0
     hooks:
       - id: gitleaks
+  - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
+    rev: v9.26.0
+    hooks:
+      - id: commitlint
+        stages: [commit-msg]
+        additional_dependencies: ["@commitlint/config-conventional"]


### PR DESCRIPTION
`commitlint` has been rejecting merges over commit messages that never
reach `main`. #83 is blocked on it right now: five perfectly good commits
whose only fault is a missing `fix(media):` prefix, on a PR that will be
squashed into a single subject taken from the PR title.

## Why not just require contributors to comply

Because you cannot. Git hooks live in `.git/hooks`, which no clone carries
— by design, or cloning a repo would execute arbitrary code. There is no
mechanism to impose a `commit-msg` hook on someone who forks and pushes.
Asking after the fact, as we did on #83, is the only option the current
setup leaves, and it costs a round trip every time.

So this changes what is enforced rather than who is asked.

## What lands on main

With squash as the merge method and `squash_merge_commit_title: PR_TITLE`,
the PR title *is* the subject that lands and the one release-please reads
to pick a version bump. That is the string worth validating.

The `commitlint` job now lints the PR title on pull_request events, piped
through the existing `commitlint.config.mjs` so the rules stay in one
place. On push to `main` it lints the squashed commit as a backstop,
catching anything that arrived another way.

The PR title is attacker-controlled text, so it is passed via `env:` and
never interpolated into the shell — otherwise this would be a command
injection.

## Also here

- `types: [opened, synchronize, reopened, edited]` on the `pull_request`
  trigger. Without `edited`, fixing a rejected title never re-runs
  anything and the check stays red until an unrelated commit is pushed.
  I found this by doing exactly that on this PR — see below.
- A `commit-msg` commitlint hook in `.pre-commit-config.yaml`, with
  `default_install_hook_types` so `pre-commit install` wires it up. This
  is a convenience for people who have the hooks installed, not a gate,
  and the comment in the file says so.

## Validated by making it fail first

A gate that has never rejected anything is not known to gate. This PR was
opened with the title **"Lint PR titles instead of commits"**:

```
commitlint   fail   12s
  Lint the pull request title
  ✖   subject may not be empty [subject-empty]
  ✖   type may not be empty [type-empty]
  ✖   found 2 problems, 0 warnings
```

Right job, right reason. The title was then corrected to the current one,
with no code change, and the run went green — which is also how the
missing `edited` type surfaced, since the first correction re-ran nothing
at all.

Local `commit-msg` hook, same treatment: a non-conventional message is
rejected and no commit is created; a conventional one commits normally.

## Settings this depends on

`squash_merge_commit_title` must be `PR_TITLE`, not `COMMIT_OR_PR_TITLE`.
Under the latter, a **single-commit** PR takes its subject from the commit
rather than the PR title, so the linted string and the landed string could
differ. Merge-commit and rebase should be off for the same reason: they
put raw commit subjects on `main` without passing this check.

Both are repo settings rather than files; they are being applied alongside
this merge.