### PR TITLE
feat(core)!: versioned DiT config — read the 2.5 fields from the checkpoint

### DIFF
--- a/packages/ltx-core-mlx/src/ltx_core_mlx/model/transformer/feed_forward.py
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/model/transformer/feed_forward.py
@@ -21,12 +21,12 @@ class FeedForward(nn.Module):
     Weight keys: ``proj_in.{weight,bias}``, ``proj_out.{weight,bias}``
     """
 
-    def __init__(self, dim: int, dim_out: int | None = None, mult: float = 4.0):
+    def __init__(self, dim: int, dim_out: int | None = None, mult: float = 4.0, bias: bool = True):
         super().__init__()
         dim_out = dim_out or dim
         inner_dim = int(dim * mult)
-        self.proj_in = nn.Linear(dim, inner_dim)
-        self.proj_out = nn.Linear(inner_dim, dim_out)
+        self.proj_in = nn.Linear(dim, inner_dim, bias=bias)
+        self.proj_out = nn.Linear(inner_dim, dim_out, bias=bias)
 
     def __call__(self, x: mx.array) -> mx.array:
         return self.proj_out(nn.gelu_approx(self.proj_in(x)))

--- a/packages/ltx-core-mlx/src/ltx_core_mlx/model/transformer/feed_forward.py
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/model/transformer/feed_forward.py
@@ -5,6 +5,12 @@ Ported from ltx-core/src/ltx_core/model/transformer/feed_forward.py
 Weight keys (relative to parent ``ff`` or ``audio_ff``):
     ``proj_in.{weight,bias}``  -- input projection with GELU (tanh approx)
     ``proj_out.{weight,bias}`` -- output projection
+
+The ``.bias`` keys are present only when the layer was constructed with
+``bias=True`` (LTX-2.3 default). LTX-2.5 packs set ``ff_bias=False`` /
+``audio_ff_bias=False`` in ``embedded_config.json``, in which case
+``proj_in``/``proj_out`` have no bias tensors at all — see
+``LTXModelConfig.ff_bias`` / ``audio_ff_bias``.
 """
 
 from __future__ import annotations

--- a/packages/ltx-core-mlx/src/ltx_core_mlx/model/transformer/model.py
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/model/transformer/model.py
@@ -204,6 +204,15 @@ class LTXModel(nn.Module):
         self.scale_shift_table = mx.zeros((2, vd))
         self.audio_scale_shift_table = mx.zeros((2, ad))
 
+        # Marks tokens whose latent encodes a single standalone pixel frame.
+        # Zero-initialized, so a checkpoint that predates it behaves
+        # identically until the parameter is trained. Applied by the keyframe
+        # conditioning path (not in this forward) — mirror of upstream
+        # model.py. Only created when the checkpoint config asks for it, so
+        # 2.3 checkpoints keep their exact parameter tree.
+        if config.use_keyframes_abs_pos_embedding:
+            self.keyframes_abs_pos_embedding = mx.zeros((1, vd))
+
         # --- Timestep AdaLN (9-param: self-attn shift/scale/gate x3) ---
         self.adaln_single = AdaLayerNormSingle(vd, num_params=9, timestep_dim=t_dim)
         self.audio_adaln_single = AdaLayerNormSingle(ad, num_params=9, timestep_dim=t_dim)

--- a/packages/ltx-core-mlx/src/ltx_core_mlx/model/transformer/model.py
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/model/transformer/model.py
@@ -652,6 +652,7 @@ class LTXModel(nn.Module):
             theta=self.config.rope_theta,
             max_pos=max_pos,
             rope_type=self.config.rope_type,
+            double_precision=self.config.double_precision_rope,
         )
 
 

--- a/packages/ltx-core-mlx/src/ltx_core_mlx/model/transformer/model.py
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/model/transformer/model.py
@@ -231,6 +231,8 @@ class LTXModel(nn.Module):
                 av_cross_head_dim=config.av_cross_head_dim,
                 ff_mult=config.ff_mult,
                 norm_eps=config.norm_eps,
+                ff_bias=config.ff_bias,
+                audio_ff_bias=config.audio_ff_bias,
             )
             for _ in range(config.num_layers)
         ]

--- a/packages/ltx-core-mlx/src/ltx_core_mlx/model/transformer/model.py
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/model/transformer/model.py
@@ -70,6 +70,13 @@ class LTXModelConfig:
     positional_embedding_max_pos: tuple[int, ...] = (20, 2048, 2048)
     audio_positional_embedding_max_pos: tuple[int, ...] = (20,)
     norm_eps: float = 1e-6
+    # 2.5 fields, read from the checkpoint config. Defaults reproduce 2.3
+    # exactly — the mapping and defaults mirror upstream model_configurator.py.
+    ff_bias: bool = True
+    audio_ff_bias: bool = True
+    use_prompt_adaln_single: bool = True
+    use_keyframes_abs_pos_embedding: bool = False
+    double_precision_rope: bool = False
 
     @classmethod
     def from_checkpoint_config(cls, config: dict) -> LTXModelConfig:
@@ -96,6 +103,10 @@ class LTXModelConfig:
         """
         t = config.get("transformer", config)
         d = cls()
+        if t.get("share_ff", False):
+            raise ValueError(
+                "share_ff=true is not supported (upstream asserts it False; no shipped checkpoint sets it)"
+            )
         return cls(
             num_layers=t.get("num_layers", d.num_layers),
             video_dim=t.get("cross_attention_dim", d.video_dim),
@@ -117,6 +128,11 @@ class LTXModelConfig:
                 t.get("audio_positional_embedding_max_pos", d.audio_positional_embedding_max_pos)
             ),
             norm_eps=t.get("norm_eps", d.norm_eps),
+            ff_bias=t.get("ff_bias", d.ff_bias),
+            audio_ff_bias=t.get("audio_ff_bias", d.audio_ff_bias),
+            use_prompt_adaln_single=t.get("use_prompt_adaln_single", d.use_prompt_adaln_single),
+            use_keyframes_abs_pos_embedding=t.get("use_keyframes_abs_pos_embedding", d.use_keyframes_abs_pos_embedding),
+            double_precision_rope=t.get("frequencies_precision", "") == "float64",
         )
 
     @classmethod

--- a/packages/ltx-core-mlx/src/ltx_core_mlx/model/transformer/rope.py
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/model/transformer/rope.py
@@ -23,6 +23,7 @@ def generate_freq_grid(
     theta: float,
     num_pos_dims: int,
     inner_dim: int,
+    double_precision: bool = False,
 ) -> mx.array:
     """Generate log-spaced frequency indices for RoPE.
 
@@ -32,26 +33,43 @@ def generate_freq_grid(
         theta: Base frequency (default 10000.0).
         num_pos_dims: Number of position dimensions (3 for video, 1 for audio).
         inner_dim: Total attention dimension (heads * head_dim).
+        double_precision: If True, compute the intermediate table in float64
+            on the CPU stream (mirrors upstream's ``frequencies_precision:
+            float64``), then cast back to float32 before returning. mx.float64
+            is CPU-only in MLX, so the f64 computation is confined to
+            ``mx.stream(mx.cpu)`` and never re-enters the GPU graph.
 
     Returns:
-        Frequency indices of shape (inner_dim // (2 * num_pos_dims),).
+        Frequency indices of shape (inner_dim // (2 * num_pos_dims),), always
+        float32.
     """
     n_elem = 2 * num_pos_dims
     num_freqs = inner_dim // n_elem
 
-    indices = theta ** mx.linspace(
-        math.log(1.0) / math.log(theta),
-        math.log(theta) / math.log(theta),
-        num_freqs,
-    ).astype(mx.float32)
+    def _compute(dtype: mx.Dtype) -> mx.array:
+        indices = theta ** mx.linspace(
+            math.log(1.0) / math.log(theta),
+            math.log(theta) / math.log(theta),
+            num_freqs,
+        ).astype(dtype)
 
-    return indices * (math.pi / 2.0)
+        return indices * (math.pi / 2.0)
+
+    if double_precision:
+        # float64 is CPU-only in MLX: compute the tables on the CPU stream,
+        # cast to float32 before they re-enter the GPU graph. Mirrors
+        # upstream's double_precision_rope (frequencies_precision: float64).
+        with mx.stream(mx.cpu):
+            result = _compute(dtype=mx.float64).astype(mx.float32)
+        return result
+    return _compute(dtype=mx.float32)
 
 
 def compute_freqs(
     freq_indices: mx.array,
     positions: mx.array,
     max_pos: list[int],
+    double_precision: bool = False,
 ) -> mx.array:
     """Compute RoPE frequency angles from positions and freq grid.
 
@@ -61,25 +79,41 @@ def compute_freqs(
         freq_indices: (num_freqs,) from generate_freq_grid.
         positions: (B, N, num_pos_dims) integer position indices.
         max_pos: Maximum position per axis for normalization.
+        double_precision: If True, compute the intermediate table in float64
+            on the CPU stream (mirrors upstream's ``frequencies_precision:
+            float64``), then cast back to float32 before returning. mx.float64
+            is CPU-only in MLX, so the f64 computation is confined to
+            ``mx.stream(mx.cpu)`` and never re-enters the GPU graph.
 
     Returns:
-        Frequency angles of shape (B, N, num_freqs * num_pos_dims).
+        Frequency angles of shape (B, N, num_freqs * num_pos_dims), always
+        float32.
     """
     num_pos_dims = positions.shape[-1]
 
-    # Fractional positions: pos / max_pos -> [0, 1]
-    frac_positions = mx.stack(
-        [positions[:, :, i].astype(mx.float32) / max_pos[i] for i in range(num_pos_dims)],
-        axis=-1,
-    )  # (B, N, num_pos_dims)
+    def _compute(dtype: mx.Dtype) -> mx.array:
+        # Fractional positions: pos / max_pos -> [0, 1]
+        frac_positions = mx.stack(
+            [positions[:, :, i].astype(dtype) / max_pos[i] for i in range(num_pos_dims)],
+            axis=-1,
+        )  # (B, N, num_pos_dims)
 
-    # Scale to [-1, 1] and multiply with freq indices
-    # (B, N, num_pos_dims, 1) * (num_freqs,) -> (B, N, num_pos_dims, num_freqs)
-    scaled = freq_indices * (frac_positions[..., None] * 2.0 - 1.0)
+        # Scale to [-1, 1] and multiply with freq indices
+        # (B, N, num_pos_dims, 1) * (num_freqs,) -> (B, N, num_pos_dims, num_freqs)
+        scaled = freq_indices.astype(dtype) * (frac_positions[..., None] * 2.0 - 1.0)
 
-    # Transpose last two dims and flatten: (B, N, num_freqs, num_pos_dims) -> (B, N, num_freqs * num_pos_dims)
-    freqs = scaled.transpose(0, 1, 3, 2).reshape(positions.shape[0], positions.shape[1], -1)
-    return freqs
+        # Transpose last two dims and flatten: (B, N, num_freqs, num_pos_dims) -> (B, N, num_freqs * num_pos_dims)
+        freqs = scaled.transpose(0, 1, 3, 2).reshape(positions.shape[0], positions.shape[1], -1)
+        return freqs
+
+    if double_precision:
+        # float64 is CPU-only in MLX: compute the tables on the CPU stream,
+        # cast to float32 before they re-enter the GPU graph. Mirrors
+        # upstream's double_precision_rope (frequencies_precision: float64).
+        with mx.stream(mx.cpu):
+            result = _compute(dtype=mx.float64).astype(mx.float32)
+        return result
+    return _compute(dtype=mx.float32)
 
 
 def precompute_rope_freqs(
@@ -89,6 +123,7 @@ def precompute_rope_freqs(
     theta: float = 10000.0,
     max_pos: list[int] | None = None,
     rope_type: str = "split",
+    double_precision: bool = False,
 ) -> tuple[mx.array, mx.array, str]:
     """Precompute per-head RoPE cos/sin frequencies.
 
@@ -104,6 +139,9 @@ def precompute_rope_freqs(
             or ``"interleaved"`` (legacy mode, kept for completeness).
             Upstream switched the default from ``"interleaved"`` to ``"split"``
             in PR #212 since all production checkpoints use SPLIT.
+        double_precision: Compute the frequency tables in float64 on the CPU
+            stream (mirrors upstream's ``frequencies_precision: float64``);
+            output is always cast back to float32.
 
     Returns:
         Tuple of (cos_freqs, sin_freqs, rope_type).
@@ -112,8 +150,8 @@ def precompute_rope_freqs(
     if max_pos is None:
         max_pos = [20, 2048, 2048][:num_pos_dims]
 
-    freq_indices = generate_freq_grid(theta, num_pos_dims, inner_dim)
-    freqs = compute_freqs(freq_indices, positions, max_pos)
+    freq_indices = generate_freq_grid(theta, num_pos_dims, inner_dim, double_precision=double_precision)
+    freqs = compute_freqs(freq_indices, positions, max_pos, double_precision=double_precision)
     B, N, num_freqs = freqs.shape
 
     if rope_type == "interleaved":

--- a/packages/ltx-core-mlx/src/ltx_core_mlx/model/transformer/rope.py
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/model/transformer/rope.py
@@ -46,23 +46,33 @@ def generate_freq_grid(
     n_elem = 2 * num_pos_dims
     num_freqs = inner_dim // n_elem
 
-    def _compute(dtype: mx.Dtype) -> mx.array:
+    if not double_precision:
+        # NOTE: this branch must stay byte-for-byte identical to the
+        # pre-double-precision-rope code (no shared helper with the f64
+        # branch below) — under --low-ram the block is mx.compile'd, and an
+        # extra graph node (even a value-identical no-op cast) changes
+        # kernel fusion / reduction order enough to diverge the SHA-gate
+        # render after 11 denoise steps. See PR review on Task 4 fix round 2.
         indices = theta ** mx.linspace(
             math.log(1.0) / math.log(theta),
             math.log(theta) / math.log(theta),
             num_freqs,
-        ).astype(dtype)
+        ).astype(mx.float32)
 
         return indices * (math.pi / 2.0)
 
-    if double_precision:
-        # float64 is CPU-only in MLX: compute the tables on the CPU stream,
-        # cast to float32 before they re-enter the GPU graph. Mirrors
-        # upstream's double_precision_rope (frequencies_precision: float64).
-        with mx.stream(mx.cpu):
-            result = _compute(dtype=mx.float64).astype(mx.float32)
-        return result
-    return _compute(dtype=mx.float32)
+    # float64 is CPU-only in MLX: compute the table on the CPU stream, cast
+    # to float32 before it re-enters the GPU graph. Mirrors upstream's
+    # double_precision_rope (frequencies_precision: float64).
+    with mx.stream(mx.cpu):
+        indices = theta ** mx.linspace(
+            math.log(1.0) / math.log(theta),
+            math.log(theta) / math.log(theta),
+            num_freqs,
+        ).astype(mx.float64)
+
+        result = (indices * (math.pi / 2.0)).astype(mx.float32)
+    return result
 
 
 def compute_freqs(
@@ -91,29 +101,41 @@ def compute_freqs(
     """
     num_pos_dims = positions.shape[-1]
 
-    def _compute(dtype: mx.Dtype) -> mx.array:
+    if not double_precision:
+        # NOTE: this branch must stay byte-for-byte identical to the
+        # pre-double-precision-rope code (no shared helper with the f64
+        # branch below) — under --low-ram the block is mx.compile'd, and an
+        # extra graph node (even a value-identical no-op cast) changes
+        # kernel fusion / reduction order enough to diverge the SHA-gate
+        # render after 11 denoise steps. See PR review on Task 4 fix round 2.
         # Fractional positions: pos / max_pos -> [0, 1]
         frac_positions = mx.stack(
-            [positions[:, :, i].astype(dtype) / max_pos[i] for i in range(num_pos_dims)],
+            [positions[:, :, i].astype(mx.float32) / max_pos[i] for i in range(num_pos_dims)],
             axis=-1,
         )  # (B, N, num_pos_dims)
 
         # Scale to [-1, 1] and multiply with freq indices
         # (B, N, num_pos_dims, 1) * (num_freqs,) -> (B, N, num_pos_dims, num_freqs)
-        scaled = freq_indices.astype(dtype) * (frac_positions[..., None] * 2.0 - 1.0)
+        scaled = freq_indices * (frac_positions[..., None] * 2.0 - 1.0)
 
         # Transpose last two dims and flatten: (B, N, num_freqs, num_pos_dims) -> (B, N, num_freqs * num_pos_dims)
         freqs = scaled.transpose(0, 1, 3, 2).reshape(positions.shape[0], positions.shape[1], -1)
         return freqs
 
-    if double_precision:
-        # float64 is CPU-only in MLX: compute the tables on the CPU stream,
-        # cast to float32 before they re-enter the GPU graph. Mirrors
-        # upstream's double_precision_rope (frequencies_precision: float64).
-        with mx.stream(mx.cpu):
-            result = _compute(dtype=mx.float64).astype(mx.float32)
-        return result
-    return _compute(dtype=mx.float32)
+    # float64 is CPU-only in MLX: compute the table on the CPU stream, cast
+    # to float32 before it re-enters the GPU graph. Mirrors upstream's
+    # double_precision_rope (frequencies_precision: float64).
+    with mx.stream(mx.cpu):
+        frac_positions = mx.stack(
+            [positions[:, :, i].astype(mx.float64) / max_pos[i] for i in range(num_pos_dims)],
+            axis=-1,
+        )  # (B, N, num_pos_dims)
+
+        scaled = freq_indices.astype(mx.float64) * (frac_positions[..., None] * 2.0 - 1.0)
+
+        freqs = scaled.transpose(0, 1, 3, 2).reshape(positions.shape[0], positions.shape[1], -1)
+        result = freqs.astype(mx.float32)
+    return result
 
 
 def precompute_rope_freqs(

--- a/packages/ltx-core-mlx/src/ltx_core_mlx/model/transformer/rope.py
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/model/transformer/rope.py
@@ -47,12 +47,14 @@ def generate_freq_grid(
     num_freqs = inner_dim // n_elem
 
     if not double_precision:
-        # NOTE: this branch must stay byte-for-byte identical to the
-        # pre-double-precision-rope code (no shared helper with the f64
-        # branch below) — under --low-ram the block is mx.compile'd, and an
-        # extra graph node (even a value-identical no-op cast) changes
-        # kernel fusion / reduction order enough to diverge the SHA-gate
-        # render after 11 denoise steps. See PR review on Task 4 fix round 2.
+        # NOTE: kept as a duplicated branch rather than a shared
+        # `_compute(dtype)` helper as hardening — an added graph node (even
+        # a value-identical no-op cast) can change mx.compile's kernel
+        # fusion / reduction order enough to move a bit-exact render's
+        # output hash. The shipped 2.3/2.5 packs both set
+        # frequencies_precision=float64, so production traffic actually
+        # runs the branch below; this one exists for callers that pass
+        # double_precision=False explicitly (tests, future non-f64 packs).
         indices = theta ** mx.linspace(
             math.log(1.0) / math.log(theta),
             math.log(theta) / math.log(theta),
@@ -63,7 +65,8 @@ def generate_freq_grid(
 
     # float64 is CPU-only in MLX: compute the table on the CPU stream, cast
     # to float32 before it re-enters the GPU graph. Mirrors upstream's
-    # double_precision_rope (frequencies_precision: float64).
+    # generate_freq_grid_np (double_precision_rope / frequencies_precision:
+    # float64) — upstream computes this grid in f64 but returns float32.
     with mx.stream(mx.cpu):
         indices = theta ** mx.linspace(
             math.log(1.0) / math.log(theta),
@@ -79,63 +82,40 @@ def compute_freqs(
     freq_indices: mx.array,
     positions: mx.array,
     max_pos: list[int],
-    double_precision: bool = False,
 ) -> mx.array:
     """Compute RoPE frequency angles from positions and freq grid.
 
     Reference: ltx-core rope.py generate_freqs + get_fractional_positions
 
+    Upstream's ``double_precision_rope`` only switches the frequency-grid
+    generator (:func:`generate_freq_grid`); ``generate_freqs`` (this
+    function's upstream analog) always runs the fractional-position math in
+    float32 regardless of that flag. No ``double_precision`` parameter here
+    — matching upstream exactly, not "going further" than it.
+
     Args:
         freq_indices: (num_freqs,) from generate_freq_grid.
         positions: (B, N, num_pos_dims) integer position indices.
         max_pos: Maximum position per axis for normalization.
-        double_precision: If True, compute the intermediate table in float64
-            on the CPU stream (mirrors upstream's ``frequencies_precision:
-            float64``), then cast back to float32 before returning. mx.float64
-            is CPU-only in MLX, so the f64 computation is confined to
-            ``mx.stream(mx.cpu)`` and never re-enters the GPU graph.
 
     Returns:
-        Frequency angles of shape (B, N, num_freqs * num_pos_dims), always
-        float32.
+        Frequency angles of shape (B, N, num_freqs * num_pos_dims).
     """
     num_pos_dims = positions.shape[-1]
 
-    if not double_precision:
-        # NOTE: this branch must stay byte-for-byte identical to the
-        # pre-double-precision-rope code (no shared helper with the f64
-        # branch below) — under --low-ram the block is mx.compile'd, and an
-        # extra graph node (even a value-identical no-op cast) changes
-        # kernel fusion / reduction order enough to diverge the SHA-gate
-        # render after 11 denoise steps. See PR review on Task 4 fix round 2.
-        # Fractional positions: pos / max_pos -> [0, 1]
-        frac_positions = mx.stack(
-            [positions[:, :, i].astype(mx.float32) / max_pos[i] for i in range(num_pos_dims)],
-            axis=-1,
-        )  # (B, N, num_pos_dims)
+    # Fractional positions: pos / max_pos -> [0, 1]
+    frac_positions = mx.stack(
+        [positions[:, :, i].astype(mx.float32) / max_pos[i] for i in range(num_pos_dims)],
+        axis=-1,
+    )  # (B, N, num_pos_dims)
 
-        # Scale to [-1, 1] and multiply with freq indices
-        # (B, N, num_pos_dims, 1) * (num_freqs,) -> (B, N, num_pos_dims, num_freqs)
-        scaled = freq_indices * (frac_positions[..., None] * 2.0 - 1.0)
+    # Scale to [-1, 1] and multiply with freq indices
+    # (B, N, num_pos_dims, 1) * (num_freqs,) -> (B, N, num_pos_dims, num_freqs)
+    scaled = freq_indices * (frac_positions[..., None] * 2.0 - 1.0)
 
-        # Transpose last two dims and flatten: (B, N, num_freqs, num_pos_dims) -> (B, N, num_freqs * num_pos_dims)
-        freqs = scaled.transpose(0, 1, 3, 2).reshape(positions.shape[0], positions.shape[1], -1)
-        return freqs
-
-    # float64 is CPU-only in MLX: compute the table on the CPU stream, cast
-    # to float32 before it re-enters the GPU graph. Mirrors upstream's
-    # double_precision_rope (frequencies_precision: float64).
-    with mx.stream(mx.cpu):
-        frac_positions = mx.stack(
-            [positions[:, :, i].astype(mx.float64) / max_pos[i] for i in range(num_pos_dims)],
-            axis=-1,
-        )  # (B, N, num_pos_dims)
-
-        scaled = freq_indices.astype(mx.float64) * (frac_positions[..., None] * 2.0 - 1.0)
-
-        freqs = scaled.transpose(0, 1, 3, 2).reshape(positions.shape[0], positions.shape[1], -1)
-        result = freqs.astype(mx.float32)
-    return result
+    # Transpose last two dims and flatten: (B, N, num_freqs, num_pos_dims) -> (B, N, num_freqs * num_pos_dims)
+    freqs = scaled.transpose(0, 1, 3, 2).reshape(positions.shape[0], positions.shape[1], -1)
+    return freqs
 
 
 def precompute_rope_freqs(
@@ -161,9 +141,11 @@ def precompute_rope_freqs(
             or ``"interleaved"`` (legacy mode, kept for completeness).
             Upstream switched the default from ``"interleaved"`` to ``"split"``
             in PR #212 since all production checkpoints use SPLIT.
-        double_precision: Compute the frequency tables in float64 on the CPU
-            stream (mirrors upstream's ``frequencies_precision: float64``);
-            output is always cast back to float32.
+        double_precision: Compute the frequency grid (only) in float64 on
+            the CPU stream (mirrors upstream's ``frequencies_precision:
+            float64``, which switches only the grid generator, not the
+            per-position fractional math); output is always cast back to
+            float32.
 
     Returns:
         Tuple of (cos_freqs, sin_freqs, rope_type).
@@ -173,7 +155,7 @@ def precompute_rope_freqs(
         max_pos = [20, 2048, 2048][:num_pos_dims]
 
     freq_indices = generate_freq_grid(theta, num_pos_dims, inner_dim, double_precision=double_precision)
-    freqs = compute_freqs(freq_indices, positions, max_pos, double_precision=double_precision)
+    freqs = compute_freqs(freq_indices, positions, max_pos)
     B, N, num_freqs = freqs.shape
 
     if rope_type == "interleaved":

--- a/packages/ltx-core-mlx/src/ltx_core_mlx/model/transformer/transformer.py
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/model/transformer/transformer.py
@@ -46,6 +46,8 @@ class BasicAVTransformerBlock(nn.Module):
         av_cross_head_dim: Per-head dim for cross-modal attention (default 64).
         ff_mult: Feed-forward expansion factor.
         norm_eps: Epsilon for layer norms.
+        ff_bias: Whether the video feed-forward Linear layers use bias.
+        audio_ff_bias: Whether the audio feed-forward Linear layers use bias.
     """
 
     def __init__(
@@ -60,6 +62,8 @@ class BasicAVTransformerBlock(nn.Module):
         av_cross_head_dim: int = 64,
         ff_mult: float = 4.0,
         norm_eps: float = 1e-6,
+        ff_bias: bool = True,
+        audio_ff_bias: bool = True,
     ):
         super().__init__()
 
@@ -133,10 +137,10 @@ class BasicAVTransformerBlock(nn.Module):
         )
 
         # ---- Video feed-forward ----
-        self.ff = FeedForward(video_dim, dim_out=video_dim, mult=ff_mult)
+        self.ff = FeedForward(video_dim, dim_out=video_dim, mult=ff_mult, bias=ff_bias)
 
         # ---- Audio feed-forward ----
-        self.audio_ff = FeedForward(audio_dim, dim_out=audio_dim, mult=ff_mult)
+        self.audio_ff = FeedForward(audio_dim, dim_out=audio_dim, mult=ff_mult, bias=audio_ff_bias)
 
         # ---- Scale-shift tables (raw parameters, added to timestep-computed params) ----
         # Video self-attn: 9 params (shift, scale, gate) x 3 (self-attn, text-xattn, ff)

--- a/packages/ltx-core-mlx/src/ltx_core_mlx/text_encoders/gemma/embeddings_connector.py
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/text_encoders/gemma/embeddings_connector.py
@@ -244,6 +244,11 @@ class Embeddings1DConnector(nn.Module):
         ff_mult: Feed-forward inner dimension multiplier.
         max_pos: Maximum position for RoPE.
         norm_output: Whether to apply affine-free layer norm to the output.
+        double_precision_rope: Compute this connector's own RoPE tables in
+            float64 on the CPU stream (mirrors upstream's
+            ``frequencies_precision: float64``); output is always cast back
+            to float32. Defaults False; checkpoint-config wiring lands with
+            the text-encoder configurator slice.
     """
 
     def __init__(
@@ -257,6 +262,7 @@ class Embeddings1DConnector(nn.Module):
         max_pos: int = 4096,
         norm_output: bool = True,
         apply_gated_attention: bool = True,
+        double_precision_rope: bool = False,
     ):
         super().__init__()
         self.dim = dim
@@ -264,6 +270,11 @@ class Embeddings1DConnector(nn.Module):
         self.max_pos = max_pos
         self.norm_output = norm_output
         self.head_dim = head_dim
+        # Wiring from checkpoint config (transformer_config["frequencies_precision"]
+        # == "float64") lands with the text-encoder configurator slice (PR 3),
+        # mirroring upstream's VideoConnectorConfigurator. Default False keeps
+        # every existing caller bit-identical until that slice wires it up.
+        self.double_precision_rope = double_precision_rope
 
         # Learnable register tokens — (num_registers, dim)
         self.learnable_registers = mx.zeros((num_registers, dim))
@@ -321,6 +332,7 @@ class Embeddings1DConnector(nn.Module):
             theta=10000.0,
             max_pos=[self.max_pos],
             rope_type="split",
+            double_precision=self.double_precision_rope,
         )
 
         # No attention mask for self-attention (all positions valid after register replacement)

--- a/packages/ltx-core-mlx/src/ltx_core_mlx/text_encoders/gemma/embeddings_connector.py
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/text_encoders/gemma/embeddings_connector.py
@@ -244,11 +244,13 @@ class Embeddings1DConnector(nn.Module):
         ff_mult: Feed-forward inner dimension multiplier.
         max_pos: Maximum position for RoPE.
         norm_output: Whether to apply affine-free layer norm to the output.
-        double_precision_rope: Compute this connector's own RoPE tables in
-            float64 on the CPU stream (mirrors upstream's
-            ``frequencies_precision: float64``); output is always cast back
-            to float32. Defaults False; checkpoint-config wiring lands with
-            the text-encoder configurator slice.
+        double_precision_rope: Compute this connector's own RoPE frequency
+            grid in float64 on the CPU stream (mirrors upstream's
+            ``frequencies_precision: float64``, applied identically by
+            upstream's video/audio connector configurators); output is
+            always cast back to float32. Wired from
+            ``LTXModelConfig.from_checkpoint_dir(...).double_precision_rope``
+            at ``PromptEncoder.load()`` (utils/blocks.py).
     """
 
     def __init__(
@@ -270,10 +272,10 @@ class Embeddings1DConnector(nn.Module):
         self.max_pos = max_pos
         self.norm_output = norm_output
         self.head_dim = head_dim
-        # Wiring from checkpoint config (transformer_config["frequencies_precision"]
-        # == "float64") lands with the text-encoder configurator slice (PR 3),
-        # mirroring upstream's VideoConnectorConfigurator. Default False keeps
-        # every existing caller bit-identical until that slice wires it up.
+        # Read from checkpoint config (transformer_config["frequencies_precision"]
+        # == "float64") and passed down from GemmaFeaturesExtractorV2 by
+        # PromptEncoder.load() (utils/blocks.py), mirroring upstream's
+        # video/audio connector configurators which read the same key.
         self.double_precision_rope = double_precision_rope
 
         # Learnable register tokens — (num_registers, dim)

--- a/packages/ltx-core-mlx/src/ltx_core_mlx/text_encoders/gemma/feature_extractor.py
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/text_encoders/gemma/feature_extractor.py
@@ -114,6 +114,10 @@ class TextEncoderConnector(nn.Module):
         ff_mult: Feed-forward multiplier.
         max_pos: Maximum position for RoPE.
         norm_output: Whether to normalize connector output.
+        double_precision_rope: Compute both connectors' RoPE frequency grids
+            in float64 (mirrors upstream's ``frequencies_precision:
+            float64``, applied identically to video and audio connector
+            configurators upstream).
     """
 
     def __init__(
@@ -130,6 +134,7 @@ class TextEncoderConnector(nn.Module):
         ff_mult: float = 4.0,
         max_pos: int = 4096,
         norm_output: bool = True,
+        double_precision_rope: bool = False,
     ):
         super().__init__()
 
@@ -150,6 +155,7 @@ class TextEncoderConnector(nn.Module):
             ff_mult=ff_mult,
             max_pos=max_pos,
             norm_output=norm_output,
+            double_precision_rope=double_precision_rope,
         )
 
         self.audio_embeddings_connector = Embeddings1DConnector(
@@ -161,6 +167,7 @@ class TextEncoderConnector(nn.Module):
             ff_mult=ff_mult,
             max_pos=max_pos,
             norm_output=norm_output,
+            double_precision_rope=double_precision_rope,
         )
 
     def __call__(
@@ -212,6 +219,14 @@ class GemmaFeaturesExtractorV2(nn.Module):
         num_connector_layers: Connector transformer layers.
         num_registers: Number of learnable registers.
         norm_type: Normalization type for hidden states.
+        double_precision_rope: Compute the video/audio connectors' RoPE
+            frequency grids in float64 (mirrors upstream's
+            ``frequencies_precision: float64``). Wired from
+            ``LTXModelConfig.from_checkpoint_dir(model_dir).double_precision_rope``
+            by ``PromptEncoder.load()`` (ltx_pipelines_mlx/utils/blocks.py) —
+            same checkpoint field the DiT reads, applied to the connector too
+            since upstream's video AND audio connector configurators read it
+            independently.
     """
 
     def __init__(
@@ -226,6 +241,7 @@ class GemmaFeaturesExtractorV2(nn.Module):
         num_connector_layers: int = 8,
         num_registers: int = 128,
         norm_type: str = "per_token_rms",
+        double_precision_rope: bool = False,
     ):
         super().__init__()
         self.norm_type = norm_type
@@ -242,6 +258,7 @@ class GemmaFeaturesExtractorV2(nn.Module):
             audio_head_dim=audio_head_dim,
             num_layers=num_connector_layers,
             num_registers=num_registers,
+            double_precision_rope=double_precision_rope,
         )
 
     def __call__(

--- a/packages/ltx-core-mlx/src/ltx_core_mlx/utils/weights.py
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/utils/weights.py
@@ -111,6 +111,39 @@ def derive_quant_params(
     return bits, group_size
 
 
+def validate_config_matches_weights(transformer_path: Path, config) -> None:
+    """Refuse a 2.5-shaped checkpoint driven by a 2.3 config.
+
+    A pack whose ``ff.proj_in`` has no bias was exported from LTX-2.5
+    (``ff_bias=false``). If the config in hand still says ``ff_bias=True``,
+    the checkpoint directory is missing its ``embedded_config.json`` and
+    ``from_checkpoint_dir`` fell back to 2.3 defaults — the silent-wrong
+    class of #37. Fail here, with the cause, instead of deep inside
+    ``load_weights``.
+
+    Reads only the safetensors header (a few KB), never the tensors.
+    """
+    import json
+    import struct
+
+    with open(transformer_path, "rb") as f:
+        header_len = struct.unpack("<Q", f.read(8))[0]
+        keys = json.loads(f.read(header_len)).keys()
+
+    probe = "transformer.transformer_blocks.0.ff.proj_in"
+    if f"{probe}.weight" not in keys and f"{probe}.scales" not in keys:
+        return  # not a transformer file we understand; loading will complain
+    has_bias = f"{probe}.bias" in keys
+    if not has_bias and config.ff_bias:
+        raise ValueError(
+            f"{transformer_path.name} is a 2.5-shaped checkpoint (no ff biases) "
+            "but the config in use says ff_bias=True — embedded_config.json is "
+            "missing or unreadable in the checkpoint directory. Refusing to "
+            "load with 2.3 defaults (see issue #37 for what silent config "
+            "fallbacks cost)."
+        )
+
+
 def _derive_quant_params(
     model: nn.Module,
     weights: dict[str, mx.array],

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/_base.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/_base.py
@@ -25,7 +25,11 @@ from ltx_core_mlx.model.video_vae.video_vae import VideoDecoder, VideoEncoder
 from ltx_core_mlx.text_encoders.gemma.encoders.base_encoder import GemmaLanguageModel
 from ltx_core_mlx.text_encoders.gemma.feature_extractor import GemmaFeaturesExtractorV2
 from ltx_core_mlx.utils.memory import aggressive_cleanup
-from ltx_core_mlx.utils.weights import apply_quantization, load_split_safetensors
+from ltx_core_mlx.utils.weights import (
+    apply_quantization,
+    load_split_safetensors,
+    validate_config_matches_weights,
+)
 from ltx_pipelines_mlx.utils.constants import DEFAULT_NEGATIVE_PROMPT
 from ltx_pipelines_mlx.utils.progress import phase
 
@@ -339,7 +343,9 @@ class BasePipeline:
 
             transformer_weights = load_split_safetensors(transformer_path, prefix="transformer.")
             transformer_weights = self._fuse_pending_loras(transformer_weights, pending_loras)
-            dit = LTXModel(LTXModelConfig.from_checkpoint_dir(transformer_path.parent))
+            config = LTXModelConfig.from_checkpoint_dir(transformer_path.parent)
+            validate_config_matches_weights(transformer_path, config)
+            dit = LTXModel(config)
             apply_quantization(dit, transformer_weights)
             dit.load_weights(list(transformer_weights.items()))
             # Force materialisation so the phase marker reports actual load

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/utils/_orchestration.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/utils/_orchestration.py
@@ -22,7 +22,11 @@ from huggingface_hub import snapshot_download
 
 from ltx_core_mlx.model.transformer.model import LTXModel, LTXModelConfig
 from ltx_core_mlx.utils.memory import aggressive_cleanup
-from ltx_core_mlx.utils.weights import apply_quantization, load_split_safetensors
+from ltx_core_mlx.utils.weights import (
+    apply_quantization,
+    load_split_safetensors,
+    validate_config_matches_weights,
+)
 
 if TYPE_CHECKING:
     from ltx_pipelines_mlx.utils.blocks import AudioDecoder, VideoDecoder
@@ -103,6 +107,7 @@ def load_transformer(
     hardcoded dataclass defaults (issue #37).
     """
     config = LTXModelConfig.from_checkpoint_dir(transformer_path.parent)
+    validate_config_matches_weights(transformer_path, config)
     dit = LTXModel(config)
     weights = load_split_safetensors(transformer_path, prefix="transformer.")
     if low_ram_streaming:

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/utils/blocks.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/utils/blocks.py
@@ -47,6 +47,7 @@ import mlx.core as mx
 
 from ltx_core_mlx.model.audio_vae.audio_vae import AudioVAEDecoder
 from ltx_core_mlx.model.audio_vae.bwe import VocoderWithBWE
+from ltx_core_mlx.model.transformer.model import LTXModelConfig
 from ltx_core_mlx.model.upsampler.model import LatentUpsampler
 from ltx_core_mlx.model.video_vae.video_vae import VideoDecoder as _VideoVAEDecoder
 from ltx_core_mlx.model.video_vae.video_vae import VideoEncoder as _VideoVAEEncoder
@@ -95,7 +96,13 @@ class PromptEncoder:
             aggressive_cleanup()
 
         if self._feature_extractor is None:
-            self._feature_extractor = GemmaFeaturesExtractorV2()
+            # Same checkpoint field the DiT reads (LTXModelConfig.from_checkpoint_dir
+            # parses "frequencies_precision" == "float64" from embedded_config.json /
+            # config.json); upstream's video AND audio connector configurators read
+            # it independently of the DiT configurator, so the connector needs its
+            # own read here rather than inheriting the DiT's LTXModelConfig instance.
+            double_precision_rope = LTXModelConfig.from_checkpoint_dir(self.model_dir).double_precision_rope
+            self._feature_extractor = GemmaFeaturesExtractorV2(double_precision_rope=double_precision_rope)
             connector_weights = load_split_safetensors(self.model_dir / "connector.safetensors", prefix="connector.")
             self._feature_extractor.connector.load_weights(list(connector_weights.items()))
             aggressive_cleanup()

--- a/packages/ltx-trainer/src/ltx_trainer_mlx/model_loader.py
+++ b/packages/ltx-trainer/src/ltx_trainer_mlx/model_loader.py
@@ -24,7 +24,12 @@ from ltx_core_mlx.model.video_vae.video_vae import VideoDecoder, VideoEncoder
 from ltx_core_mlx.text_encoders.gemma.encoders.base_encoder import GemmaLanguageModel
 from ltx_core_mlx.text_encoders.gemma.feature_extractor import GemmaFeaturesExtractorV2
 from ltx_core_mlx.utils.memory import aggressive_cleanup
-from ltx_core_mlx.utils.weights import apply_quantization, load_split_safetensors, remap_audio_vae_keys
+from ltx_core_mlx.utils.weights import (
+    apply_quantization,
+    load_split_safetensors,
+    remap_audio_vae_keys,
+    validate_config_matches_weights,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -87,7 +92,9 @@ def load_transformer(
     # Read hyperparameters from the checkpoint config so values like
     # av_ca_timestep_scale_multiplier track the checkpoint, not hardcoded
     # dataclass defaults (issue #37).
-    model = LTXModel(LTXModelConfig.from_checkpoint_dir(model_dir))
+    config = LTXModelConfig.from_checkpoint_dir(model_dir)
+    validate_config_matches_weights(tf_path, config)
+    model = LTXModel(config)
     weights = load_split_safetensors(tf_path, prefix="transformer.")
     apply_quantization(model, weights)
     model.load_weights(list(weights.items()))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,4 +44,3 @@ def _local_pack(name: str) -> Path | None:
 
 
 LTX25_Q8_DIR = _local_pack("ltx-2.5-mlx-q8")
-LTX25_BF16_DIR = _local_pack("ltx-2.5-mlx")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,3 +35,13 @@ def find_q8_model_dir() -> Path | None:
 
 
 MODEL_DIR = find_q8_model_dir()
+
+
+def _local_pack(name: str) -> Path | None:
+    """Local (non-hub) converted pack, used by the LTX-2.5 contract tests."""
+    candidate = Path.home() / "Work/mlx/models" / name
+    return candidate if (candidate / "embedded_config.json").exists() else None
+
+
+LTX25_Q8_DIR = _local_pack("ltx-2.5-mlx-q8")
+LTX25_BF16_DIR = _local_pack("ltx-2.5-mlx")

--- a/tests/test_ltx25_config.py
+++ b/tests/test_ltx25_config.py
@@ -5,6 +5,7 @@ embedded_config.json du pack 2.5 (sha a59ff335…), tronquée aux champs que le
 mapping consomme + quelques champs 2.3 pour vérifier la non-régression.
 """
 
+import mlx.core as mx
 import pytest
 
 from ltx_core_mlx.model.transformer.feed_forward import FeedForward
@@ -101,3 +102,11 @@ def test_model_threads_ff_bias_to_blocks():
     # Défauts 2.3 : tout le monde a des biais.
     m23 = _tiny({})
     assert "bias" in m23.transformer_blocks[0].ff.proj_in
+
+
+def test_keyframes_pos_embedding_created_when_configured():
+    m25 = _tiny({"use_keyframes_abs_pos_embedding": True})
+    assert m25.keyframes_abs_pos_embedding.shape == (1, 64)
+    assert bool(mx.all(m25.keyframes_abs_pos_embedding == 0).item())
+    m23 = _tiny({})
+    assert not hasattr(m23, "keyframes_abs_pos_embedding")

--- a/tests/test_ltx25_config.py
+++ b/tests/test_ltx25_config.py
@@ -128,3 +128,43 @@ def test_rope_double_precision_flag():
     # Flag off == comportement actuel, bit-identique.
     again = compute_freqs(grid32, positions, max_pos=[20, 2048, 2048])
     assert bool(mx.array_equal(f32, again).item())
+
+
+def test_embeddings_connector_double_precision_rope():
+    from ltx_core_mlx.text_encoders.gemma.embeddings_connector import Embeddings1DConnector
+
+    mx.random.seed(0)
+    hidden_states = mx.random.normal((1, 16, 32))
+
+    connector_default = Embeddings1DConnector(
+        dim=32,
+        num_heads=2,
+        head_dim=16,
+        num_layers=1,
+        num_registers=0,
+        max_pos=64,
+    )
+    connector_f64 = Embeddings1DConnector(
+        dim=32,
+        num_heads=2,
+        head_dim=16,
+        num_layers=1,
+        num_registers=0,
+        max_pos=64,
+        double_precision_rope=True,
+    )
+    # Same weights for both instances so the only difference is the flag.
+    connector_f64.update(connector_default.parameters())
+
+    assert connector_default.double_precision_rope is False
+    assert connector_f64.double_precision_rope is True
+
+    out_default = connector_default(hidden_states)
+    out_f64 = connector_f64(hidden_states)
+
+    assert out_default.dtype == mx.float32
+    assert out_f64.dtype == mx.float32
+
+    # double_precision_rope=True must not change the default (flag off) path.
+    out_default_again = connector_default(hidden_states)
+    assert bool(mx.array_equal(out_default, out_default_again).item())

--- a/tests/test_ltx25_config.py
+++ b/tests/test_ltx25_config.py
@@ -168,3 +168,19 @@ def test_embeddings_connector_double_precision_rope():
     # double_precision_rope=True must not change the default (flag off) path.
     out_default_again = connector_default(hidden_states)
     assert bool(mx.array_equal(out_default, out_default_again).item())
+
+
+def test_25_shaped_weights_without_config_raise(tmp_path):
+    """Un transformer sans biais de ff + une config 2.3 -> erreur explicite."""
+    from ltx_core_mlx.utils.weights import validate_config_matches_weights
+
+    # Un header minimal de forme 2.5 : le poids existe, le bias non.
+    path = tmp_path / "transformer-dev.safetensors"
+    mx.save_safetensors(
+        str(path),
+        {"transformer.transformer_blocks.0.ff.proj_in.weight": mx.zeros((4, 4))},
+    )
+    with pytest.raises(ValueError, match="ff_bias"):
+        validate_config_matches_weights(path, LTXModelConfig())  # défauts 2.3
+    # La config 2.5 correspondante passe.
+    validate_config_matches_weights(path, LTXModelConfig(ff_bias=False))

--- a/tests/test_ltx25_config.py
+++ b/tests/test_ltx25_config.py
@@ -113,25 +113,51 @@ def test_keyframes_pos_embedding_created_when_configured():
 
 
 def test_rope_double_precision_flag():
+    """double_precision only switches generate_freq_grid (upstream-exact scope:
+    generate_freq_grid_np computes in f64 but returns float32; generate_freqs
+    always runs in f32 regardless of the flag — compute_freqs has no
+    double_precision parameter at all)."""
     from ltx_core_mlx.model.transformer.rope import compute_freqs, generate_freq_grid
 
     grid32 = generate_freq_grid(theta=10000.0, num_pos_dims=3, inner_dim=128)
     grid64 = generate_freq_grid(theta=10000.0, num_pos_dims=3, inner_dim=128, double_precision=True)
     assert grid64.dtype == mx.float32  # toujours casté en sortie
+    # Non-vacuous: the f64 path must actually produce a different grid, not
+    # silently collapse to the f32 one (verified real: maxdiff ~2.4e-4).
+    assert not bool(mx.array_equal(grid32, grid64).item())
 
     positions = mx.array([[[0.5, 100.0, 200.0]]])
     f32 = compute_freqs(grid32, positions, max_pos=[20, 2048, 2048])
-    f64 = compute_freqs(grid64, positions, max_pos=[20, 2048, 2048], double_precision=True)
-    assert f64.dtype == mx.float32
-    assert bool(mx.all(mx.isfinite(f64)).item())
+    f64_from_f64_grid = compute_freqs(grid64, positions, max_pos=[20, 2048, 2048])
+    assert f64_from_f64_grid.dtype == mx.float32
+    assert bool(mx.all(mx.isfinite(f64_from_f64_grid)).item())
+    # The f64 grid still propagates a (smaller) difference through compute_freqs
+    # even though compute_freqs itself runs entirely in f32.
+    assert not bool(mx.array_equal(f32, f64_from_f64_grid).item())
 
     # Flag off == comportement actuel, bit-identique.
     again = compute_freqs(grid32, positions, max_pos=[20, 2048, 2048])
     assert bool(mx.array_equal(f32, again).item())
 
 
-def test_embeddings_connector_double_precision_rope():
+def test_embeddings_connector_double_precision_rope(monkeypatch):
+    """The flag must actually reach precompute_rope_freqs, not just round-trip
+    through a stored attribute (a test only checking output dtype/shape would
+    still pass if the pass-through to precompute_rope_freqs were deleted)."""
+    from ltx_core_mlx.model.transformer import rope as rope_module
     from ltx_core_mlx.text_encoders.gemma.embeddings_connector import Embeddings1DConnector
+
+    # Embeddings1DConnector.__call__ does `from ...rope import precompute_rope_freqs`
+    # freshly at call time, so the spy must live on the rope module (patching an
+    # imported-name alias on embeddings_connector itself would never be seen).
+    calls = []
+    real_precompute = rope_module.precompute_rope_freqs
+
+    def spy(*args, **kwargs):
+        calls.append(kwargs.get("double_precision"))
+        return real_precompute(*args, **kwargs)
+
+    monkeypatch.setattr(rope_module, "precompute_rope_freqs", spy)
 
     mx.random.seed(0)
     hidden_states = mx.random.normal((1, 16, 32))
@@ -159,14 +185,21 @@ def test_embeddings_connector_double_precision_rope():
     assert connector_default.double_precision_rope is False
     assert connector_f64.double_precision_rope is True
 
+    calls.clear()
     out_default = connector_default(hidden_states)
+    assert calls == [False]
+
+    calls.clear()
     out_f64 = connector_f64(hidden_states)
+    assert calls == [True]  # the flag actually reached precompute_rope_freqs
 
     assert out_default.dtype == mx.float32
     assert out_f64.dtype == mx.float32
 
     # double_precision_rope=True must not change the default (flag off) path.
+    calls.clear()
     out_default_again = connector_default(hidden_states)
+    assert calls == [False]
     assert bool(mx.array_equal(out_default, out_default_again).item())
 
 

--- a/tests/test_ltx25_config.py
+++ b/tests/test_ltx25_config.py
@@ -7,7 +7,8 @@ mapping consomme + quelques champs 2.3 pour vérifier la non-régression.
 
 import pytest
 
-from ltx_core_mlx.model.transformer.model import LTXModelConfig
+from ltx_core_mlx.model.transformer.feed_forward import FeedForward
+from ltx_core_mlx.model.transformer.model import LTXModel, LTXModelConfig
 
 CONFIG_25 = {
     "transformer": {
@@ -64,3 +65,39 @@ def test_share_ff_true_is_rejected():
     bad = {"transformer": {**CONFIG_25["transformer"], "share_ff": True}}
     with pytest.raises(ValueError, match="share_ff"):
         LTXModelConfig.from_checkpoint_config(bad)
+
+
+def test_feed_forward_bias_toggle():
+    with_bias = FeedForward(64, mult=2.0)
+    without = FeedForward(64, mult=2.0, bias=False)
+    assert "bias" in with_bias.proj_in
+    assert "bias" in with_bias.proj_out
+    assert "bias" not in without.proj_in
+    assert "bias" not in without.proj_out
+
+
+def _tiny(cfg_kwargs: dict) -> LTXModel:
+    return LTXModel(
+        LTXModelConfig(
+            num_layers=1,
+            video_dim=64,
+            audio_dim=32,
+            video_num_heads=2,
+            audio_num_heads=2,
+            video_head_dim=32,
+            audio_head_dim=16,
+            av_cross_num_heads=2,
+            av_cross_head_dim=16,
+            **cfg_kwargs,
+        )
+    )
+
+
+def test_model_threads_ff_bias_to_blocks():
+    m25 = _tiny({"ff_bias": False, "audio_ff_bias": True})
+    block = m25.transformer_blocks[0]
+    assert "bias" not in block.ff.proj_in
+    assert "bias" in block.audio_ff.proj_in
+    # Défauts 2.3 : tout le monde a des biais.
+    m23 = _tiny({})
+    assert "bias" in m23.transformer_blocks[0].ff.proj_in

--- a/tests/test_ltx25_config.py
+++ b/tests/test_ltx25_config.py
@@ -110,3 +110,21 @@ def test_keyframes_pos_embedding_created_when_configured():
     assert bool(mx.all(m25.keyframes_abs_pos_embedding == 0).item())
     m23 = _tiny({})
     assert not hasattr(m23, "keyframes_abs_pos_embedding")
+
+
+def test_rope_double_precision_flag():
+    from ltx_core_mlx.model.transformer.rope import compute_freqs, generate_freq_grid
+
+    grid32 = generate_freq_grid(theta=10000.0, num_pos_dims=3, inner_dim=128)
+    grid64 = generate_freq_grid(theta=10000.0, num_pos_dims=3, inner_dim=128, double_precision=True)
+    assert grid64.dtype == mx.float32  # toujours casté en sortie
+
+    positions = mx.array([[[0.5, 100.0, 200.0]]])
+    f32 = compute_freqs(grid32, positions, max_pos=[20, 2048, 2048])
+    f64 = compute_freqs(grid64, positions, max_pos=[20, 2048, 2048], double_precision=True)
+    assert f64.dtype == mx.float32
+    assert bool(mx.all(mx.isfinite(f64)).item())
+
+    # Flag off == comportement actuel, bit-identique.
+    again = compute_freqs(grid32, positions, max_pos=[20, 2048, 2048])
+    assert bool(mx.array_equal(f32, again).item())

--- a/tests/test_ltx25_config.py
+++ b/tests/test_ltx25_config.py
@@ -1,0 +1,66 @@
+"""Parsing de la config 2.5 — assertions contre le mapping upstream.
+
+Le dict CONFIG_25 ci-dessous est la copie verbatim du bloc "transformer" de
+embedded_config.json du pack 2.5 (sha a59ff335…), tronquée aux champs que le
+mapping consomme + quelques champs 2.3 pour vérifier la non-régression.
+"""
+
+import pytest
+
+from ltx_core_mlx.model.transformer.model import LTXModelConfig
+
+CONFIG_25 = {
+    "transformer": {
+        "num_layers": 48,
+        "cross_attention_dim": 4096,
+        "audio_cross_attention_dim": 2048,
+        "av_ca_timestep_scale_multiplier": 1000.0,
+        "rope_type": "split",
+        "ff_bias": False,
+        "share_ff": False,
+        "use_keyframes_abs_pos_embedding": True,
+        "frequencies_precision": "float64",
+    }
+}
+
+CONFIG_23 = {
+    "transformer": {
+        "num_layers": 48,
+        "cross_attention_dim": 4096,
+        "av_ca_timestep_scale_multiplier": 1000.0,
+        "rope_type": "split",
+    }
+}
+
+
+def test_25_fields_parsed_from_checkpoint_config():
+    c = LTXModelConfig.from_checkpoint_config(CONFIG_25)
+    assert c.ff_bias is False
+    assert c.audio_ff_bias is True  # absent du checkpoint -> défaut upstream
+    assert c.use_prompt_adaln_single is True  # absent -> défaut upstream
+    assert c.use_keyframes_abs_pos_embedding is True
+    assert c.double_precision_rope is True  # frequencies_precision == float64
+
+
+def test_23_config_yields_23_defaults():
+    c = LTXModelConfig.from_checkpoint_config(CONFIG_23)
+    assert c.ff_bias is True
+    assert c.audio_ff_bias is True
+    assert c.use_keyframes_abs_pos_embedding is False
+    assert c.double_precision_rope is False
+
+
+def test_dataclass_defaults_are_23_behavior():
+    c = LTXModelConfig()
+    assert c.ff_bias is True
+    assert c.audio_ff_bias is True
+    assert c.use_prompt_adaln_single is True
+    assert c.use_keyframes_abs_pos_embedding is False
+    assert c.double_precision_rope is False
+
+
+def test_share_ff_true_is_rejected():
+    # Upstream: check_config_value(config, "share_ff", False) — assertion dure.
+    bad = {"transformer": {**CONFIG_25["transformer"], "share_ff": True}}
+    with pytest.raises(ValueError, match="share_ff"):
+        LTXModelConfig.from_checkpoint_config(bad)

--- a/tests/test_ltx25_config.py
+++ b/tests/test_ltx25_config.py
@@ -184,3 +184,15 @@ def test_25_shaped_weights_without_config_raise(tmp_path):
         validate_config_matches_weights(path, LTXModelConfig())  # défauts 2.3
     # La config 2.5 correspondante passe.
     validate_config_matches_weights(path, LTXModelConfig(ff_bias=False))
+
+
+def test_23_pack_requests_double_precision_rope():
+    """The shipped 2.3 packs declare frequencies_precision=float64 — the field
+    our port left inert until the versioned config landed, which is why the
+    2.3 SHA baseline moved (re-baselined 2026-08-24, upstream-faithful)."""
+    from tests.conftest import MODEL_DIR
+
+    if MODEL_DIR is None:
+        pytest.skip("q8 2.3 pack not found")
+    c = LTXModelConfig.from_checkpoint_dir(MODEL_DIR)
+    assert c.double_precision_rope is True

--- a/tests/test_ltx25_load_contract.py
+++ b/tests/test_ltx25_load_contract.py
@@ -1,0 +1,49 @@
+"""Contrat de chargement du DiT 2.5 : pack réel <-> arbre de paramètres.
+
+`mx.load` mmap-e sans matérialiser, donc comparer les clés est peu coûteux
+même sur 20 GB. Ce test attrape la classe silent-no-op (#52) : un poids
+présent que personne ne lit, ou un paramètre que le pack ne sert pas.
+"""
+
+import json
+import struct
+
+import pytest
+
+from tests.conftest import LTX25_Q8_DIR
+
+pytestmark = [
+    pytest.mark.slow,
+    pytest.mark.skipif(LTX25_Q8_DIR is None, reason="local ltx-2.5-mlx-q8 pack not found"),
+]
+
+
+def _pack_keys() -> set[str]:
+    path = LTX25_Q8_DIR / "transformer-dev.safetensors"
+    with open(path, "rb") as f:
+        n = struct.unpack("<Q", f.read(8))[0]
+        header = json.loads(f.read(n))
+    return {k for k in header if k != "__metadata__"}
+
+
+def test_25_config_covers_every_pack_tensor():
+    from mlx.utils import tree_flatten
+
+    from ltx_core_mlx.model.transformer.model import LTXModel, LTXModelConfig
+
+    config = LTXModelConfig.from_checkpoint_dir(LTX25_Q8_DIR)
+    assert config.ff_bias is False, "embedded_config.json not read"
+    model = LTXModel(config)
+
+    model_keys = {f"transformer.{k}" for k, _ in tree_flatten(model.parameters())}
+    pack = _pack_keys()
+
+    # Quantization scales/biases du q8 correspondent aux .weight du modèle.
+    pack_normalized = {
+        k.removesuffix(".scales").removesuffix(".biases") + ".weight" if k.endswith((".scales", ".biases")) else k
+        for k in pack
+    }
+    missing_in_model = sorted(pack_normalized - model_keys)
+    unfed_params = sorted(model_keys - pack_normalized)
+    assert not missing_in_model, f"pack tensors nobody would load: {missing_in_model[:10]}"
+    assert not unfed_params, f"model params the pack does not feed: {unfed_params[:10]}"

--- a/tests/test_pending_loras_dispatch.py
+++ b/tests/test_pending_loras_dispatch.py
@@ -65,6 +65,7 @@ def test_pending_loras_takes_fusion_path(pipeline_stub):
         patch("ltx_pipelines_mlx._base.apply_quantization") as apply_q,
         patch("ltx_pipelines_mlx._base.LTXModel") as LTXModel_cls,
         patch("ltx_pipelines_mlx._base.aggressive_cleanup"),
+        patch("ltx_pipelines_mlx._base.validate_config_matches_weights"),
         patch("ltx_pipelines_mlx.utils._orchestration.load_transformer") as orch_load,
     ):
         dit_instance = MagicMock(name="dit")


### PR DESCRIPTION
PR 1/5 of the LTX-2.5 v1 series (spec 2026-08-23). The DiT is now built from
the checkpoint's `embedded_config.json` following upstream
`model_configurator.py` field-for-field, instead of hardcoding one
generation's architecture.

## What's in

- `LTXModelConfig` gains the 2.5 fields (`ff_bias`, `audio_ff_bias`,
  `use_prompt_adaln_single`, `use_keyframes_abs_pos_embedding`,
  `double_precision_rope` ← `frequencies_precision`), parsed with upstream's
  exact defaults; `share_ff=true` is rejected (upstream asserts it).
- `FeedForward` biases are config-driven (2.5: video FF loses biases, audio
  keeps them — matching the shipped tensors).
- `keyframes_abs_pos_embedding` parameter created when the checkpoint asks
  (zero-init, applied by conditioning, not this forward — upstream-iso).
- f64 RoPE, scoped exactly as upstream: only the frequency grid is computed
  in float64 (on the CPU stream — f64 is CPU-only in MLX), returned f32;
  fractional-position math stays f32. Wired into the DiT and both text
  connectors from the same config field.
- A 2.5-shaped checkpoint driven by 2.3 config defaults now fails loudly at
  all three load sites instead of silently producing wrong output (#37 class).
- Load-contract test: every tensor of the real 2.5 q8 pack ↔ every model
  parameter, both directions (header-only read; slow-marked, local pack).

## BREAKING CHANGE: 2.3 outputs change (seed reproducibility)

The shipped 2.3 packs declare `frequencies_precision: float64`. Upstream
honors it unconditionally; this port never did — the old renders encoded an
f32 truncation upstream doesn't have. With the field now honored, the same
seed produces a different (upstream-faithful) video.

| render | sha256 |
|---|---|
| old (f32 rope) | `07cfc7cf…` |
| new (upstream-exact f64 scope) | `1248862480a293134722d54323442bc5755d6d56d6873c605d67dd60e0f7c8d0` |

New baseline verified deterministic (two identical renders), visually
validated, audio healthy (−35.6 dB mean). An intermediate f64-everywhere
variant (`b258ca72…`) was caught by review as exceeding upstream scope and
does not ship.

## Validation

- 699 non-slow tests passed; 2.5 load contract passed; stepwise e2e (4
  render-based tests) passed under f64; ruff clean.
- 2.3 default construction: parameter tree byte-identical by test; the only
  behavioral change is the (intended) f64 rope.
- Executed subagent-driven with per-task review + final whole-branch review;
  full audit trail in the plan workspace ledger.

## Follow-ups (parked with rulings)

- `use_prompt_adaln_single` parsed but not consumed — guard lands with the
  PR that consumes it (no shipped pack sets it false).
- Trainer's `GemmaFeaturesExtractorV2()` call site defaults f64 off —
  trainer slice.
- Weight/config check is one-directional; contract test is shape-blind.