### PR TITLE
feat(core): port the euler-ancestral sampler and the 2.5 sigma tables

### DIFF
--- a/packages/ltx-core-mlx/src/ltx_core_mlx/components/__init__.py
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/components/__init__.py
@@ -1,5 +1,11 @@
 """Diffusion components: guiders, schedulers, patchifiers, diffusion steps."""
 
+from ltx_core_mlx.components.diffusion_steps import (
+    EulerAncestralDiffusionStep,
+    EulerCfgPpDiffusionStep,
+    EulerDiffusionStep,
+    Res2sDiffusionStep,
+)
 from ltx_core_mlx.components.guiders import (
     MultiModalGuider,
     MultiModalGuiderFactory,
@@ -14,9 +20,13 @@ from ltx_core_mlx.components.patchifiers import (
 
 __all__ = [
     "AudioPatchifier",
+    "EulerAncestralDiffusionStep",
+    "EulerCfgPpDiffusionStep",
+    "EulerDiffusionStep",
     "MultiModalGuider",
     "MultiModalGuiderFactory",
     "MultiModalGuiderParams",
+    "Res2sDiffusionStep",
     "VideoLatentPatchifier",
     "compute_video_latent_shape",
     "create_multimodal_guider_factory",

--- a/packages/ltx-core-mlx/src/ltx_core_mlx/components/diffusion_steps.py
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/components/diffusion_steps.py
@@ -74,6 +74,57 @@ class EulerDiffusionStep:
         return (sample.astype(mx.float32) + velocity.astype(mx.float32) * dt).astype(out_dtype)
 
 
+class EulerAncestralDiffusionStep:
+    """Ancestral (SDE) Euler step for rectified-flow models.
+
+    Each step advances deterministically to an intermediate noise level
+    ``sigma_down <= sigma_next`` and then renoises back up to ``sigma_next``,
+    rescaling the signal component by ``alpha_next / alpha_down`` so the
+    transition stays variance-preserving. ``eta`` interpolates between a plain
+    Euler step (``eta=0``) and a fully ancestral step (``eta=1``).
+
+    This is the rectified-flow parameterization (``alpha = 1 - sigma``). It
+    deliberately does **not** reuse :func:`_get_ancestral_step`: that helper
+    implements the DDIM/variance-exploding coefficients, which agree with
+    this step only at ``eta=0``. Mirror of upstream diffusion_steps.py.
+    """
+
+    def __init__(self, eta: float = 1.0, s_noise: float = 1.0) -> None:
+        self.eta = eta
+        self.s_noise = s_noise
+
+    def step(
+        self,
+        sample: mx.array,
+        denoised_sample: mx.array,
+        sigmas: mx.array,
+        step_index: int,
+        noise: mx.array | None = None,
+    ) -> mx.array:
+        sigma = float(sigmas[step_index])
+        sigma_next = float(sigmas[step_index + 1])
+        if sigma_next == 0:
+            return denoised_sample.astype(sample.dtype)
+        if self.eta > 0 and noise is None:
+            raise ValueError("EulerAncestralDiffusionStep requires a noise tensor when eta > 0")
+
+        x = sample.astype(mx.float32)
+        denoised = denoised_sample.astype(mx.float32)
+
+        downstep_ratio = 1.0 + (sigma_next / sigma - 1.0) * self.eta
+        sigma_down = sigma_next * downstep_ratio
+
+        sigma_down_ratio = sigma_down / sigma
+        x_next = sigma_down_ratio * x + (1.0 - sigma_down_ratio) * denoised
+
+        if self.eta > 0:
+            alpha_next = 1.0 - sigma_next
+            alpha_down = 1.0 - sigma_down
+            renoise_coeff = max(sigma_next**2 - sigma_down**2 * alpha_next**2 / alpha_down**2, 0.0) ** 0.5
+            x_next = (alpha_next / alpha_down) * x_next + noise.astype(mx.float32) * self.s_noise * renoise_coeff
+        return x_next.astype(sample.dtype)
+
+
 class Res2sDiffusionStep:
     """Second-order res_2s step with SDE noise injection.
 
@@ -204,6 +255,7 @@ class EulerCfgPpDiffusionStep:
 
 __all__ = [
     "DiffusionStepProtocol",
+    "EulerAncestralDiffusionStep",
     "EulerCfgPpDiffusionStep",
     "EulerDiffusionStep",
     "Res2sDiffusionStep",

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/scheduler.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/scheduler.py
@@ -35,6 +35,8 @@ def ltx2_schedule(
 
 __all__ = [
     "DISTILLED_SIGMAS",
+    "LTX_2_5_DISTILLED_SIGMAS",
+    "LTX_2_5_STAGE_2_DISTILLED_SIGMAS",
     "STAGE_2_SIGMAS",
     "get_sigma_schedule",
     "ltx2_schedule",
@@ -58,6 +60,31 @@ DISTILLED_SIGMAS: list[float] = [
 # Sigma schedule for stage 2 refinement (two-stage pipeline).
 # 4 values = 3 steps.
 STAGE_2_SIGMAS: list[float] = [
+    0.909375,
+    0.725,
+    0.421875,
+    0.0,
+]
+
+# Predefined sigma schedule for LTX-2.5 8-step distilled model.
+# Upstream reuses the name DISTILLED_SIGMAS; we diverge on surface (LTX_2_5_ prefix)
+# to keep both model tables in scope without ambiguity.
+# 9 values = 8 steps (iterate consecutive pairs: sigmas[i], sigmas[i+1]).
+LTX_2_5_DISTILLED_SIGMAS: list[float] = [
+    1.0,
+    0.99375,
+    0.9875,
+    0.98125,
+    0.975,
+    0.909375,
+    0.725,
+    0.421875,
+    0.0,
+]
+
+# Sigma schedule for LTX-2.5 stage 2 refinement (two-stage pipeline).
+# 4 values = 3 steps.
+LTX_2_5_STAGE_2_DISTILLED_SIGMAS: list[float] = [
     0.909375,
     0.725,
     0.421875,

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/utils/samplers.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/utils/samplers.py
@@ -12,6 +12,7 @@ import mlx.core as mx
 from mlx_arsenal.diffusion import euler_step
 from tqdm import tqdm
 
+from ltx_core_mlx.components.diffusion_steps import EulerAncestralDiffusionStep
 from ltx_core_mlx.components.guiders import MultiModalGuiderFactory
 from ltx_core_mlx.conditioning.types.latent_cond import LatentState, apply_denoise_mask
 from ltx_core_mlx.guidance.perturbations import (
@@ -181,6 +182,176 @@ def denoise_loop(
         # Euler step
         video_x = euler_step(video_x, video_x0, sigma, sigma_next)
         audio_x = euler_step(audio_x, audio_x0, sigma, sigma_next)
+
+        # Force computation for memory efficiency
+        mx.async_eval(video_x, audio_x)
+
+    aggressive_cleanup()
+
+    return DenoiseOutput(video_latent=video_x, audio_latent=audio_x)
+
+
+# --- Ancestral (SDE) Euler sampler ---
+
+
+def euler_ancestral_denoising_loop(
+    sigmas: list[float] | None,
+    video_state: LatentState,
+    audio_state: LatentState,
+    stepper: EulerAncestralDiffusionStep,
+    transformer: X0Model,
+    video_text_embeds: mx.array,
+    audio_text_embeds: mx.array,
+    *,
+    noise_seed: int,
+    video_positions: mx.array | None = None,
+    audio_positions: mx.array | None = None,
+    video_attention_mask: mx.array | None = None,
+    audio_attention_mask: mx.array | None = None,
+    video_cross_attention_mask: mx.array | None = None,
+    show_progress: bool = True,
+    on_step: OnStepFn | None = None,
+) -> DenoiseOutput:
+    """Run the ancestral (SDE) Euler denoising loop for joint audio+video.
+
+    Structurally identical to :func:`denoise_loop` (per-token timesteps,
+    ``X0Model`` call contract, ``apply_denoise_mask`` blending) but advances
+    the sample with :class:`EulerAncestralDiffusionStep` instead of a plain
+    Euler step. Mirrors upstream ``ltx_pipelines.utils.samplers.
+    euler_ancestral_denoising_loop`` / ``_ancestral_euler_denoising_loop``.
+
+    Noise semantics (upstream-iso):
+      - ``mx.random.seed(noise_seed)`` is set once before the loop (MLX
+        translation of the single upstream generator); each step draws the
+        video noise first, then the audio noise, so the random sequence
+        stays consistent across modalities.
+      - Noise is drawn raw: ``mx.random.normal(shape).astype(mx.float32)`` —
+        no channel-wise normalization (that variant is reserved for res2s).
+      - ``draw_noise = stepper.eta > 0``.
+      - Stepping happens in float32. On a terminal sigma (``sigma_next ==
+        0``) the latent short-circuits to the (already mask-blended) x0
+        prediction. Otherwise the stepper advances the sample and, only when
+        ``draw_noise``, the conditioning mask is re-applied *after* the
+        noise injection (``apply_denoise_mask(x_next, clean_latent,
+        denoise_mask)``) before casting back to the model dtype.
+
+    Args:
+        sigmas: Sigma schedule (defaults to ``DISTILLED_SIGMAS``). Already
+            includes the terminal ``0.0``.
+        video_state: Video latent state.
+        audio_state: Audio latent state.
+        stepper: ``EulerAncestralDiffusionStep`` instance carrying ``eta``
+            and ``s_noise``.
+        transformer: ``X0Model`` wrapping the LTX transformer.
+        video_text_embeds: Text embeddings for video conditioning.
+        audio_text_embeds: Text embeddings for audio conditioning.
+        noise_seed: Seed for the ancestral noise draws.
+        video_positions: Positional embeddings for video.
+        audio_positions: Positional embeddings for audio.
+        video_attention_mask: Attention mask for video.
+        audio_attention_mask: Attention mask for audio.
+        video_cross_attention_mask: Optional video->text cross-attention mask.
+        show_progress: Whether to show tqdm progress bar.
+        on_step: Optional per-step preview hook, see :func:`denoise_loop`.
+
+    Returns:
+        DenoiseOutput with final video and audio latents.
+    """
+    if sigmas is None:
+        sigmas = DISTILLED_SIGMAS
+
+    # Resolve positions: explicit params override, then fall back to state
+    if video_positions is None and video_state.positions is not None:
+        video_positions = video_state.positions
+    if audio_positions is None and audio_state.positions is not None:
+        audio_positions = audio_state.positions
+
+    # Resolve attention masks from state
+    if video_attention_mask is None and video_state.attention_mask is not None:
+        video_attention_mask = video_state.attention_mask
+    if audio_attention_mask is None and audio_state.attention_mask is not None:
+        audio_attention_mask = audio_state.attention_mask
+
+    video_x = video_state.latent
+    audio_x = audio_state.latent
+    video_dtype = video_x.dtype
+    audio_dtype = audio_x.dtype
+
+    steps = list(zip(sigmas[:-1], sigmas[1:]))
+    iterator = tqdm(steps, desc="Denoising (ancestral)", disable=not show_progress)
+
+    video_uniform = _is_uniform_mask(video_state.denoise_mask)
+    audio_uniform = _is_uniform_mask(audio_state.denoise_mask)
+
+    draw_noise = stepper.eta > 0
+    mx.random.seed(noise_seed)
+
+    for step_idx, (sigma, sigma_next) in enumerate(iterator):
+        sigma_arr = mx.array([sigma], dtype=mx.bfloat16)
+        B = video_x.shape[0]
+
+        call_kwargs: dict = dict(
+            video_latent=video_x,
+            audio_latent=audio_x,
+            sigma=mx.broadcast_to(sigma_arr, (B,)),
+            video_text_embeds=video_text_embeds,
+            audio_text_embeds=audio_text_embeds,
+            video_positions=video_positions,
+            audio_positions=audio_positions,
+            video_attention_mask=video_attention_mask,
+            audio_attention_mask=audio_attention_mask,
+        )
+        if video_cross_attention_mask is not None:
+            call_kwargs["video_cross_attention_mask"] = video_cross_attention_mask
+
+        # Pass per-token timesteps when mask is not uniform
+        if not video_uniform:
+            call_kwargs["video_timesteps"] = _compute_per_token_timesteps(sigma, video_state.denoise_mask)
+        if not audio_uniform:
+            call_kwargs["audio_timesteps"] = _compute_per_token_timesteps(sigma, audio_state.denoise_mask)
+
+        # Predict x0
+        video_x0, audio_x0 = transformer(**call_kwargs)
+
+        # Apply denoise mask: blend with clean latent
+        video_x0 = apply_denoise_mask(video_x0, video_state.clean_latent, video_state.denoise_mask)
+        audio_x0 = apply_denoise_mask(audio_x0, audio_state.clean_latent, audio_state.denoise_mask)
+
+        if on_step is not None:
+            on_step(step_idx, len(steps), video_x0, sigma)
+
+        if sigma_next == 0:
+            # Terminal step: short-circuit to the (already mask-blended) x0 prediction.
+            video_x = video_x0.astype(video_dtype)
+            audio_x = audio_x0.astype(audio_dtype)
+        else:
+            # Video draw first, then audio, from the same seeded generator.
+            video_noise = mx.random.normal(video_x.shape).astype(mx.float32) if draw_noise else None
+            audio_noise = mx.random.normal(audio_x.shape).astype(mx.float32) if draw_noise else None
+
+            video_x_next = stepper.step(
+                sample=video_x.astype(mx.float32),
+                denoised_sample=video_x0,
+                sigmas=sigmas,
+                step_index=step_idx,
+                noise=video_noise,
+            )
+            audio_x_next = stepper.step(
+                sample=audio_x.astype(mx.float32),
+                denoised_sample=audio_x0,
+                sigmas=sigmas,
+                step_index=step_idx,
+                noise=audio_noise,
+            )
+
+            if draw_noise:
+                # Re-apply the conditioning mask AFTER noise injection: the point
+                # that breaks I2V if forgotten (preserved tokens must not get renoised).
+                video_x_next = apply_denoise_mask(video_x_next, video_state.clean_latent, video_state.denoise_mask)
+                audio_x_next = apply_denoise_mask(audio_x_next, audio_state.clean_latent, audio_state.denoise_mask)
+
+            video_x = video_x_next.astype(video_dtype)
+            audio_x = audio_x_next.astype(audio_dtype)
 
         # Force computation for memory efficiency
         mx.async_eval(video_x, audio_x)

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/utils/samplers.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/utils/samplers.py
@@ -320,7 +320,8 @@ def euler_ancestral_denoising_loop(
         if on_step is not None:
             on_step(step_idx, len(steps), video_x0, sigma)
 
-        if sigma_next == 0:
+        terminal_step = sigma_next == 0
+        if terminal_step:
             # Terminal step: short-circuit to the (already mask-blended) x0 prediction.
             video_x = video_x0.astype(video_dtype)
             audio_x = audio_x0.astype(audio_dtype)
@@ -355,6 +356,9 @@ def euler_ancestral_denoising_loop(
 
         # Force computation for memory efficiency
         mx.async_eval(video_x, audio_x)
+
+        if terminal_step:
+            break
 
     aggressive_cleanup()
 

--- a/tests/test_ltx25_ancestral.py
+++ b/tests/test_ltx25_ancestral.py
@@ -210,22 +210,40 @@ def test_loop_determinism_and_seed_sensitivity():
 
 
 def test_preserved_tokens_stay_clean_after_renoise():
-    # denoise_mask=0 on a block of tokens: after the full loop (eta=1), those
+    # denoise_mask=0 on a block of tokens: after the loop (eta=1), those
     # tokens must equal clean_latent exactly — the mask is re-applied AFTER
     # the noise injection. This is the exact point that breaks I2V if forgotten.
+    #
+    # The primary schedule deliberately does NOT end at sigma=0: with a
+    # terminal sigma, the loop's last iteration takes the short-circuit
+    # branch (latent = already-mask-blended x0), which passes even if the
+    # post-noise apply_denoise_mask block is deleted — making the assertion
+    # vacuous. A non-terminal schedule forces the final state through the
+    # renoise + re-mask path, so the assertion can only pass through that
+    # block (verified by neutering it locally: the assertion then fails).
     video_state, audio_state, transformer = _stub_transformer_and_states(denoise_mask_prefix_zero=3)
-    sigmas = [1.0, 0.6, 0.3, 0.0]
+    expected = video_state.clean_latent[:, :3, :]
 
+    non_terminal_sigmas = [1.0, 0.6, 0.3]
     out = euler_ancestral_denoising_loop(
-        sigmas,
+        non_terminal_sigmas,
         stepper=EulerAncestralDiffusionStep(eta=1.0),
         noise_seed=123,
         **_common_loop_kwargs(video_state, audio_state, transformer),
     )
-
     preserved = out.video_latent[:, :3, :]
-    expected = video_state.clean_latent[:, :3, :]
     assert mx.array_equal(preserved, expected).item()
+
+    # Terminal schedule covers the short-circuit path separately.
+    terminal_sigmas = [1.0, 0.6, 0.3, 0.0]
+    out_terminal = euler_ancestral_denoising_loop(
+        terminal_sigmas,
+        stepper=EulerAncestralDiffusionStep(eta=1.0),
+        noise_seed=123,
+        **_common_loop_kwargs(video_state, audio_state, transformer),
+    )
+    preserved_terminal = out_terminal.video_latent[:, :3, :]
+    assert mx.array_equal(preserved_terminal, expected).item()
 
 
 def test_25_sigma_tables():

--- a/tests/test_ltx25_ancestral.py
+++ b/tests/test_ltx25_ancestral.py
@@ -12,6 +12,8 @@ from ltx_core_mlx.components.diffusion_steps import (
     EulerAncestralDiffusionStep,
     EulerDiffusionStep,
 )
+from ltx_core_mlx.conditioning.types.latent_cond import LatentState
+from ltx_pipelines_mlx.utils.samplers import denoise_loop, euler_ancestral_denoising_loop
 
 
 def _reference_step(x, x0, sigma, sigma_next, eta, s_noise, noise):
@@ -96,3 +98,131 @@ def test_s_noise_zero_still_rescales():
     )
     want = _reference_step(x, x0, 0.9, 0.6, 1.0, 0.0, [0.0, 0.0])
     assert mx.allclose(got, mx.array(want), atol=1e-6, rtol=1e-6).item()
+
+
+# ---------------------------------------------------------------------------
+# euler_ancestral_denoising_loop
+# ---------------------------------------------------------------------------
+
+VIDEO_TOKENS = 8
+AUDIO_TOKENS = 4
+CHANNELS = 4
+
+
+class _StubX0Model:
+    """Deterministic X0Model stub: x0 = 0.5 * latent, for both modalities."""
+
+    def __call__(self, *, video_latent, audio_latent, **_kwargs):
+        return 0.5 * video_latent, 0.5 * audio_latent
+
+
+def _stub_transformer_and_states(
+    denoise_mask_prefix_zero: int = 0,
+    clean_value: float = 3.0,
+):
+    """A minimal video+audio LatentState pair and a deterministic X0Model stub.
+
+    ``denoise_mask_prefix_zero`` zeros out that many leading video tokens in
+    the denoise mask (preserved/conditioning tokens); the rest stay at 1.0
+    (fully denoised). ``clean_value`` is the clean_latent fill value for the
+    preserved tokens, chosen far from the noisy/init latent so a leaked
+    renoise is trivially detectable.
+    """
+    video_latent = mx.random.normal((1, VIDEO_TOKENS, CHANNELS)).astype(mx.bfloat16)
+    audio_latent = mx.random.normal((1, AUDIO_TOKENS, CHANNELS)).astype(mx.bfloat16)
+
+    video_mask = mx.ones((1, VIDEO_TOKENS, 1), dtype=mx.bfloat16)
+    if denoise_mask_prefix_zero:
+        prefix = mx.zeros((1, denoise_mask_prefix_zero, 1), dtype=mx.bfloat16)
+        rest = mx.ones((1, VIDEO_TOKENS - denoise_mask_prefix_zero, 1), dtype=mx.bfloat16)
+        video_mask = mx.concatenate([prefix, rest], axis=1)
+
+    video_clean = mx.full((1, VIDEO_TOKENS, CHANNELS), clean_value, dtype=mx.bfloat16)
+    audio_clean = mx.zeros((1, AUDIO_TOKENS, CHANNELS), dtype=mx.bfloat16)
+
+    video_state = LatentState(latent=video_latent, clean_latent=video_clean, denoise_mask=video_mask)
+    audio_state = LatentState(
+        latent=audio_latent, clean_latent=audio_clean, denoise_mask=mx.ones((1, AUDIO_TOKENS, 1), dtype=mx.bfloat16)
+    )
+    return video_state, audio_state, _StubX0Model()
+
+
+def _common_loop_kwargs(video_state, audio_state, transformer):
+    return dict(
+        video_state=video_state,
+        audio_state=audio_state,
+        transformer=transformer,
+        video_text_embeds=mx.zeros((1, 2, CHANNELS)),
+        audio_text_embeds=mx.zeros((1, 2, CHANNELS)),
+        show_progress=False,
+    )
+
+
+def test_loop_eta_zero_matches_denoise_loop():
+    # eta=0 => no noise is drawn; the trajectory must coincide with
+    # denoise_loop on the same stub (allclose — FP evaluation order may differ).
+    video_state, audio_state, transformer = _stub_transformer_and_states()
+    sigmas = [1.0, 0.6, 0.3, 0.0]
+
+    ancestral_out = euler_ancestral_denoising_loop(
+        sigmas,
+        stepper=EulerAncestralDiffusionStep(eta=0.0),
+        noise_seed=0,
+        **_common_loop_kwargs(video_state, audio_state, transformer),
+    )
+    euler_out = denoise_loop(
+        model=transformer,
+        video_state=video_state,
+        audio_state=audio_state,
+        video_text_embeds=mx.zeros((1, 2, CHANNELS)),
+        audio_text_embeds=mx.zeros((1, 2, CHANNELS)),
+        sigmas=sigmas,
+        show_progress=False,
+    )
+
+    assert mx.allclose(
+        ancestral_out.video_latent.astype(mx.float32), euler_out.video_latent.astype(mx.float32), atol=1e-2, rtol=1e-2
+    ).item()
+    assert mx.allclose(
+        ancestral_out.audio_latent.astype(mx.float32), euler_out.audio_latent.astype(mx.float32), atol=1e-2, rtol=1e-2
+    ).item()
+
+
+def test_loop_determinism_and_seed_sensitivity():
+    # Same seed -> bit-identical outputs; different seed -> different outputs.
+    sigmas = [1.0, 0.6, 0.3, 0.0]
+    stepper = EulerAncestralDiffusionStep(eta=1.0)
+
+    video_state, audio_state, transformer = _stub_transformer_and_states()
+    out_a = euler_ancestral_denoising_loop(
+        sigmas, stepper=stepper, noise_seed=42, **_common_loop_kwargs(video_state, audio_state, transformer)
+    )
+    out_b = euler_ancestral_denoising_loop(
+        sigmas, stepper=stepper, noise_seed=42, **_common_loop_kwargs(video_state, audio_state, transformer)
+    )
+    assert mx.array_equal(out_a.video_latent, out_b.video_latent).item()
+    assert mx.array_equal(out_a.audio_latent, out_b.audio_latent).item()
+
+    out_c = euler_ancestral_denoising_loop(
+        sigmas, stepper=stepper, noise_seed=7, **_common_loop_kwargs(video_state, audio_state, transformer)
+    )
+    assert not mx.array_equal(out_a.video_latent, out_c.video_latent).item()
+
+
+def test_preserved_tokens_stay_clean_after_renoise():
+    # denoise_mask=0 on a block of tokens: after the full loop (eta=1), those
+    # tokens must equal clean_latent exactly — the mask is re-applied AFTER
+    # the noise injection. This is the exact point that breaks I2V if forgotten.
+    video_state, audio_state, transformer = _stub_transformer_and_states(denoise_mask_prefix_zero=3)
+    sigmas = [1.0, 0.6, 0.3, 0.0]
+
+    out = euler_ancestral_denoising_loop(
+        sigmas,
+        stepper=EulerAncestralDiffusionStep(eta=1.0),
+        noise_seed=123,
+        **_common_loop_kwargs(video_state, audio_state, transformer),
+    )
+
+    preserved = out.video_latent[:, :3, :]
+    expected = video_state.clean_latent[:, :3, :]
+    assert mx.array_equal(preserved, expected).item()

--- a/tests/test_ltx25_ancestral.py
+++ b/tests/test_ltx25_ancestral.py
@@ -226,3 +226,21 @@ def test_preserved_tokens_stay_clean_after_renoise():
     preserved = out.video_latent[:, :3, :]
     expected = video_state.clean_latent[:, :3, :]
     assert mx.array_equal(preserved, expected).item()
+
+
+def test_25_sigma_tables():
+    from ltx_pipelines_mlx.scheduler import (
+        DISTILLED_SIGMAS,
+        LTX_2_5_DISTILLED_SIGMAS,
+        LTX_2_5_STAGE_2_DISTILLED_SIGMAS,
+        STAGE_2_SIGMAS,
+    )
+
+    assert LTX_2_5_DISTILLED_SIGMAS == [1.0, 0.99375, 0.9875, 0.98125, 0.975, 0.909375, 0.725, 0.421875, 0.0]
+    assert LTX_2_5_STAGE_2_DISTILLED_SIGMAS == [0.909375, 0.725, 0.421875, 0.0]
+    # Le 0.0 terminal est porteur (bug de troncature témoin) et l'invariant
+    # de sous-schedule est le même qu'en 2.3.
+    assert LTX_2_5_DISTILLED_SIGMAS[-1] == 0.0
+    assert LTX_2_5_DISTILLED_SIGMAS[-4:] == LTX_2_5_STAGE_2_DISTILLED_SIGMAS
+    # Les tables 2.3 ne bougent pas d'un octet.
+    assert DISTILLED_SIGMAS[-4:] == STAGE_2_SIGMAS

--- a/tests/test_ltx25_ancestral.py
+++ b/tests/test_ltx25_ancestral.py
@@ -1,0 +1,98 @@
+"""EulerAncestralDiffusionStep — asserté contre les formules upstream.
+
+Les valeurs de référence sont recalculées dans le test avec l'arithmétique
+Python float (indépendante de MLX), reproduisant upstream
+diffusion_steps.py:43-107 ligne à ligne.
+"""
+
+import mlx.core as mx
+import pytest
+
+from ltx_core_mlx.components.diffusion_steps import (
+    EulerAncestralDiffusionStep,
+    EulerDiffusionStep,
+)
+
+
+def _reference_step(x, x0, sigma, sigma_next, eta, s_noise, noise):
+    """Transcription float-Python des formules upstream (rectified flow)."""
+    downstep_ratio = 1.0 + (sigma_next / sigma - 1.0) * eta
+    sigma_down = sigma_next * downstep_ratio
+    r = sigma_down / sigma
+    out = [r * xi + (1.0 - r) * x0i for xi, x0i in zip(x, x0)]
+    if eta > 0:
+        alpha_next = 1.0 - sigma_next
+        alpha_down = 1.0 - sigma_down
+        coeff = max(sigma_next**2 - sigma_down**2 * alpha_next**2 / alpha_down**2, 0.0) ** 0.5
+        out = [(alpha_next / alpha_down) * o + n * s_noise * coeff for o, n in zip(out, noise)]
+    return out
+
+
+def test_matches_upstream_formulas_elementwise():
+    x = [0.8, -1.2, 0.3, 2.0]
+    x0 = [0.1, -0.4, 0.05, 1.1]
+    noise = [0.5, -0.5, 1.0, -1.0]
+    sigmas = mx.array([0.9, 0.6, 0.0])
+    step = EulerAncestralDiffusionStep(eta=1.0, s_noise=1.0)
+    got = step.step(
+        sample=mx.array(x, dtype=mx.float32),
+        denoised_sample=mx.array(x0, dtype=mx.float32),
+        sigmas=sigmas,
+        step_index=0,
+        noise=mx.array(noise, dtype=mx.float32),
+    )
+    want = _reference_step(x, x0, 0.9, 0.6, 1.0, 1.0, noise)
+    assert mx.allclose(got, mx.array(want), atol=1e-6, rtol=1e-6).item()
+
+
+def test_eta_zero_reduces_to_euler():
+    # Algébriquement identique au pas d'Euler (formes interpolation vs
+    # vélocité) — égal à tolérance FP, pas bit-exact.
+    x = mx.random.normal((64,)).astype(mx.float32)
+    x0 = mx.random.normal((64,)).astype(mx.float32)
+    sigmas = mx.array([0.9, 0.6, 0.0])
+    anc = EulerAncestralDiffusionStep(eta=0.0).step(sample=x, denoised_sample=x0, sigmas=sigmas, step_index=0)
+    eul = EulerDiffusionStep().step(sample=x, denoised_sample=x0, sigmas=sigmas, step_index=0)
+    assert mx.allclose(anc, eul, atol=1e-5, rtol=1e-5).item()
+
+
+def test_terminal_sigma_returns_denoised():
+    x = mx.random.normal((8,)).astype(mx.bfloat16)
+    x0 = mx.random.normal((8,)).astype(mx.float32)
+    sigmas = mx.array([0.42, 0.0])
+    got = EulerAncestralDiffusionStep(eta=1.0).step(
+        sample=x,
+        denoised_sample=x0,
+        sigmas=sigmas,
+        step_index=0,
+        noise=mx.zeros((8,), dtype=mx.float32),
+    )
+    assert got.dtype == x.dtype  # cast au dtype de sample
+    assert mx.allclose(got, x0.astype(x.dtype)).item()
+
+
+def test_eta_positive_requires_noise():
+    with pytest.raises(ValueError, match="noise"):
+        EulerAncestralDiffusionStep(eta=1.0).step(
+            sample=mx.zeros((4,)),
+            denoised_sample=mx.zeros((4,)),
+            sigmas=mx.array([0.9, 0.6]),
+            step_index=0,
+        )
+
+
+def test_s_noise_zero_still_rescales():
+    # draw_noise est gated sur eta seul : à s_noise=0 le rescale
+    # alpha_next/alpha_down s'applique quand même (docstring upstream).
+    x = [1.0, -1.0]
+    x0 = [0.2, 0.4]
+    sigmas = mx.array([0.9, 0.6, 0.0])
+    got = EulerAncestralDiffusionStep(eta=1.0, s_noise=0.0).step(
+        sample=mx.array(x, dtype=mx.float32),
+        denoised_sample=mx.array(x0, dtype=mx.float32),
+        sigmas=sigmas,
+        step_index=0,
+        noise=mx.zeros((2,), dtype=mx.float32),
+    )
+    want = _reference_step(x, x0, 0.9, 0.6, 1.0, 0.0, [0.0, 0.0])
+    assert mx.allclose(got, mx.array(want), atol=1e-6, rtol=1e-6).item()


### PR DESCRIPTION
PR 2/5 of the LTX-2.5 v1 series (spec 2026-08-23). Purely additive: the
sampler, its denoising loop, and the 2.5 sigma tables land unused — nothing
outside tests references them until PR 5 wires the distilled pipeline.

## What's in

- `EulerAncestralDiffusionStep(eta, s_noise)` in `components/diffusion_steps.py`,
  the rectified-flow ancestral step (`alpha = 1 − sigma`), asserted
  element-wise against upstream's formulas via an independent pure-Python
  reference in the tests. Deliberately does not reuse the ported DDIM helper
  `_get_ancestral_step` — the two agree only at `eta=0` (upstream's own
  warning, now pinned by test).
- `euler_ancestral_denoising_loop` in `utils/samplers.py`, mirroring
  upstream's driver semantics: RNG seeded once, video noise drawn before
  audio each step, raw Gaussian noise (not res2s's channelwise-normalized
  variant), `draw_noise` gated on `eta` alone, float32 stepping, terminal
  short-circuit with upstream's `break`, and the conditioning mask re-applied
  **after** noise injection — the property that keeps I2V anchors clean under
  SDE renoising, covered by a mutation-verified test (deleting the re-mask
  block makes it fail).
- `LTX_2_5_DISTILLED_SIGMAS` / `LTX_2_5_STAGE_2_DISTILLED_SIGMAS` in
  `scheduler.py`, digit-for-digit from upstream **including the terminal
  0.0**, with the `[-4:]` sub-schedule invariant pinned. 2.3 tables untouched
  (upstream reuses the `DISTILLED_SIGMAS` name; the `LTX_2_5_` prefix is a
  documented surface divergence).

## Validation

- 708 non-slow tests passed (9 new); ruff clean.
- Additivity proven by grep: the only references to the new symbols are
  definitions, exports, and their tests.
- No render gate needed — nothing here is reachable from the CLI.

## Noted for PR 5 (wiring), parked in the execution ledger

- `ANCESTRAL_ETA` / `ANCESTRAL_S_NOISE` / the +10000 noise-seed offset live
  in upstream's `distilled.py` and land with the pipeline wiring, not here.
- Loop seams: `model_dtype` parameter and optional-modality support may be
  wanted at wiring time; both follow the existing `denoise_loop` idiom today.