### PR TITLE
feat(core): vendor the Gemma-4 text tower and key the encoder off the checkpoint

### DIFF
--- a/packages/ltx-core-mlx/src/ltx_core_mlx/text_encoders/gemma/encoders/encoder_configurator.py
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/text_encoders/gemma/encoders/encoder_configurator.py
@@ -1,0 +1,104 @@
+"""Evidence-based text-encoder selection for the LTX-2.3 / LTX-2.5 packs.
+
+LTX-2.3 packs ship the Gemma 3 12B text encoder as a separate
+``mlx-community`` download (no local weight files in the DiT pack
+itself). LTX-2.5 packs bundle the Gemma 4 unified text tower directly
+in the pack (``text_encoder.safetensors`` + ``text_encoder_config.json``).
+:func:`select_text_encoder` keys off that evidence rather than a version
+string, so any pack that ships the Gemma 4 files gets routed to
+:class:`~ltx_core_mlx.text_encoders.gemma.encoders.gemma4_encoder.Gemma4TextEncoder`,
+and any pack that doesn't keeps using the existing
+:class:`~ltx_core_mlx.text_encoders.gemma.encoders.base_encoder.GemmaLanguageModel`
+path unchanged.
+
+Mirrors upstream's ``_check_gemma_version`` (``configurator.py``) in
+spirit, simplified to what this port's packs actually declare: the real
+LTX-2.5 pack's ``embedded_config.json`` has no ``gemma_source_checkpoint``
+key at all, so the full upstream fallback logic (requiring the key above
+a version floor) has no evidence to key off here. This port only checks
+the *mismatch* case -- when the DiT pack does declare an expected Gemma
+version, it must agree with the tower it is about to select.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Literal
+
+_TEXT_ENCODER_WEIGHTS = "text_encoder.safetensors"
+_TEXT_ENCODER_CONFIG = "text_encoder_config.json"
+_EMBEDDED_CONFIG = "embedded_config.json"
+
+
+def check_gemma_version(model_dir: str | Path) -> None:
+    """Raise if the DiT pack's declared Gemma version disagrees with the tower's.
+
+    Reads ``embedded_config.json``'s top-level ``gemma_source_checkpoint``
+    key (if present) and compares its ``gemma_version`` against the
+    ``gemma_version`` declared at the top level of
+    ``text_encoder_config.json``. Absence of either the file or the key is
+    not an error -- it means the pack makes no claim to check, matching
+    the real LTX-2.5 pack (no ``gemma_source_checkpoint`` in its
+    ``embedded_config.json``).
+
+    Args:
+        model_dir: Path to the pack directory.
+
+    Raises:
+        ValueError: If the pack declares a ``gemma_source_checkpoint``
+            whose ``gemma_version`` disagrees with the tower config's.
+    """
+    model_dir = Path(model_dir)
+    embedded_config_path = model_dir / _EMBEDDED_CONFIG
+    if not embedded_config_path.exists():
+        return
+
+    with open(embedded_config_path) as f:
+        embedded_config = json.load(f)
+
+    gemma_source_checkpoint = embedded_config.get("gemma_source_checkpoint")
+    if gemma_source_checkpoint is None:
+        return
+
+    expected_gemma_version = gemma_source_checkpoint.get("gemma_version")
+
+    text_encoder_config_path = model_dir / _TEXT_ENCODER_CONFIG
+    with open(text_encoder_config_path) as f:
+        text_encoder_config = json.load(f)
+    actual_gemma_version = text_encoder_config.get("gemma_version")
+
+    if expected_gemma_version != actual_gemma_version:
+        raise ValueError(
+            f"Gemma version mismatch: {model_dir}/{_EMBEDDED_CONFIG}'s "
+            f"gemma_source_checkpoint expects gemma_version={expected_gemma_version!r}, "
+            f"but {model_dir}/{_TEXT_ENCODER_CONFIG} has gemma_version={actual_gemma_version!r}."
+        )
+
+
+def select_text_encoder(model_dir: str | Path) -> Literal["gemma3", "gemma4"]:
+    """Select the text-encoder family from the pack's evidence on disk.
+
+    Args:
+        model_dir: Path to the pack directory (the same directory passed
+            to the DiT loader).
+
+    Returns:
+        ``"gemma4"`` iff both ``text_encoder.safetensors`` and
+        ``text_encoder_config.json`` exist directly under ``model_dir``;
+        ``"gemma3"`` otherwise (the LTX-2.3 default: Gemma 3 is loaded
+        from a separate ``mlx-community`` checkpoint, not the DiT pack).
+
+    Raises:
+        ValueError: See :func:`check_gemma_version` -- only reached when
+            the evidence selects ``"gemma4"``.
+    """
+    model_dir = Path(model_dir)
+    has_gemma4_weights = (model_dir / _TEXT_ENCODER_WEIGHTS).exists()
+    has_gemma4_config = (model_dir / _TEXT_ENCODER_CONFIG).exists()
+
+    if not (has_gemma4_weights and has_gemma4_config):
+        return "gemma3"
+
+    check_gemma_version(model_dir)
+    return "gemma4"

--- a/packages/ltx-core-mlx/src/ltx_core_mlx/text_encoders/gemma/encoders/gemma4_encoder.py
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/text_encoders/gemma/encoders/gemma4_encoder.py
@@ -1,0 +1,243 @@
+"""Gemma-4 text tower wrapper exposing the 2.3-era ``GemmaLanguageModel`` contract.
+
+``GemmaFeaturesExtractorV2`` (``feature_extractor.py``) is model-version
+agnostic: it consumes ``(all_hidden_states: list[mx.array], attention_mask:
+mx.array | None)`` -- a plain list of ``num_gemma_layers`` ``(B, T, D)``
+tensors plus a ``(B, T)`` binary mask -- and does not touch the encoder
+object itself. What ties an encoder into the pipeline is the *caller*
+contract exercised by ``PromptEncoder.encode()``
+(``ltx_pipelines_mlx/utils/blocks.py:129`` and the trainer's
+``preprocess.py`` / ``trainer.py``):
+
+    all_hidden_states, attention_mask = text_encoder.encode_all_layers(prompt, max_length=max_length)
+
+``GemmaLanguageModel.encode_all_layers`` (``base_encoder.py:190-203``) is
+the exact method surface this module reproduces for Gemma-4:
+
+* ``tokenize(text, max_length=1024) -> (token_ids, attention_mask)`` --
+  LEFT-padded to ``max_length`` with the tokenizer's native pad token id
+  (this port's divergence, documented at the top of ``base_encoder.py``:
+  upstream right-pads before the connector with an additive mask; we keep
+  LEFT padding + a binary mask end-to-end). ``attention_mask`` is ``1`` on
+  real tokens, ``0`` on padding.
+* ``get_all_hidden_states(token_ids, attention_mask) -> list[mx.array]`` --
+  ``num_gemma_layers`` tensors, one per layer (embeddings + every decoder
+  layer's output for Gemma-3's 49; identically 49 for Gemma-4's tower:
+  scaled embeddings + 48 decoder layers).
+* ``encode_all_layers(text, max_length=1024) -> (list[mx.array], mx.array)``
+  -- tokenize + forward in one call; this is the method
+  ``PromptEncoder.encode()`` actually calls.
+* ``encode(text, max_length=1024) -> mx.array`` -- convenience: just the
+  last hidden state.
+
+HARD REQUIREMENT (Task 3 review, ledger-recorded): HF's
+``output_hidden_states=True`` tuple ties its *last* entry to the
+post-final-norm ``last_hidden_state``
+(``transformers/output_capturing.py:261-263``), and upstream's
+``LTXGemmaTextEncoder.encode`` (see
+``/private/tmp/.../upstream_gemma_base_encoder.py:68-71``) consumes exactly
+that tuple. ``Gemma4TextModel.__call__`` (Task 3) intentionally returns the
+**raw pre-norm** stack (see its docstring) so the tower stays a pure
+port of ``output_hidden_states`` collection; this module is what applies
+``tower.norm`` to the last entry before the stack reaches
+``GemmaFeaturesExtractorV2``. Get this wrong and every 2.5 text embedding
+is silently wrong -- entries 0..47 must stay byte-identical to the raw
+tower output, and entry -1 must equal ``tower.norm(raw[-1])``, not
+``raw[-1]`` itself.
+"""
+
+from __future__ import annotations
+
+import functools
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ltx_core_mlx.text_encoders.gemma.gemma4 import Gemma4TextModel
+
+if TYPE_CHECKING:
+    from transformers import PreTrainedTokenizerBase
+
+# Mirrors GemmaLanguageModel's default (base_encoder.py) and
+# GemmaAssets.TOKENIZER_MAX_LENGTH upstream.
+TOKENIZER_MAX_LENGTH = 1024
+
+
+class Gemma4TextEncoder(nn.Module):
+    """Gemma-4 text tower + tokenizer, exposing the 2.3 encoder's method surface.
+
+    Args:
+        tower: A pre-built :class:`Gemma4TextModel`, or ``None`` to load
+            later via :meth:`load`. Exposed as a constructor arg (rather
+            than only via ``load``) so tests can inject a tiny tower
+            without touching the real 16 GB pack.
+        tokenizer: A pre-built HuggingFace tokenizer, or ``None`` to load
+            later via :meth:`load` / :meth:`load_tokenizer`.
+    """
+
+    def __init__(
+        self,
+        tower: Gemma4TextModel | None = None,
+        tokenizer: PreTrainedTokenizerBase | None = None,
+    ):
+        super().__init__()
+        self._tower = tower
+        self._tokenizer = tokenizer
+
+    @property
+    def tower(self) -> Gemma4TextModel | None:
+        """The underlying :class:`Gemma4TextModel`, or ``None`` if unloaded."""
+        return self._tower
+
+    @property
+    def tokenizer(self) -> PreTrainedTokenizerBase | None:
+        """The underlying HuggingFace tokenizer, or ``None`` if unloaded."""
+        return self._tokenizer
+
+    def load_tokenizer(self, model_dir: str | Path) -> None:
+        """Load the tokenizer from a pack directory's ``tokenizer.json``.
+
+        Uses ``transformers.AutoTokenizer`` (a transitive dependency
+        already pulled in by ``ltx-trainer``; no new project dependency).
+        The pack's ``tokenizer_config.json`` already sets
+        ``padding_side: "left"`` and ``pad_token: "<pad>"``, matching this
+        port's LEFT-pad convention.
+
+        Args:
+            model_dir: Path to the pack directory (containing
+                ``tokenizer.json`` and ``tokenizer_config.json``).
+        """
+        from transformers import AutoTokenizer
+
+        self._tokenizer = AutoTokenizer.from_pretrained(str(model_dir))
+
+    def load(self, model_dir: str | Path) -> None:
+        """Load both the tower and the tokenizer from a pack directory.
+
+        Args:
+            model_dir: Path to the pack directory.
+        """
+        self.load_tokenizer(model_dir)
+        self._tower = Gemma4TextModel.load_from_pack(model_dir)
+
+    def tokenize(self, text: str, max_length: int = TOKENIZER_MAX_LENGTH) -> tuple[mx.array, mx.array]:
+        """Tokenize a text string with left-padding to ``max_length``.
+
+        Mirrors ``GemmaLanguageModel.tokenize`` (``base_encoder.py:52-79``)
+        exactly: strip, encode, keep the *last* ``max_length`` tokens on
+        overflow (left-truncation matches left-padding), left-pad with the
+        tokenizer's native pad token id.
+
+        Args:
+            text: Input text.
+            max_length: Sequence length (padded/truncated to this length).
+
+        Returns:
+            ``(token_ids, attention_mask)``, each shape ``(1, max_length)``.
+            ``attention_mask``: ``1`` for valid tokens, ``0`` for padding.
+        """
+        if self._tokenizer is None:
+            raise RuntimeError("Tokenizer not loaded. Call load() or load_tokenizer() first.")
+
+        tokens = self._tokenizer.encode(text.strip())
+        if len(tokens) > max_length:
+            tokens = tokens[-max_length:]
+
+        pad_length = max_length - len(tokens)
+        pad_token = self._tokenizer.pad_token_id if self._tokenizer.pad_token_id is not None else 0
+        padded_tokens = [pad_token] * pad_length + tokens
+        attention_mask = [0] * pad_length + [1] * len(tokens)
+
+        return mx.array([padded_tokens]), mx.array([attention_mask])
+
+    def get_all_hidden_states(
+        self,
+        token_ids: mx.array,
+        attention_mask: mx.array | None = None,
+    ) -> list[mx.array]:
+        """Run the tower and return all layers' hidden states, last entry post-norm.
+
+        Args:
+            token_ids: ``(B, seq_len)`` token IDs.
+            attention_mask: ``(B, seq_len)`` binary mask (1=valid, 0=padding).
+
+        Returns:
+            ``num_hidden_layers + 1`` ``(B, seq_len, hidden_dim)`` tensors
+            (49 for the real pack). Entries ``0..-2`` are the tower's raw
+            per-layer outputs, unchanged. Entry ``-1`` is
+            ``tower.norm(raw[-1])`` -- the post-final-norm
+            ``last_hidden_state``, matching what upstream's
+            ``output_hidden_states=True`` tuple actually contains (see
+            module docstring).
+        """
+        if self._tower is None:
+            raise RuntimeError("Tower not loaded. Call load() first.")
+
+        raw_states = self._tower(token_ids, attention_mask=attention_mask)
+        hidden_states = list(raw_states)
+        hidden_states[-1] = self._tower.norm(hidden_states[-1])
+        return hidden_states
+
+    def encode(self, text: str, max_length: int = TOKENIZER_MAX_LENGTH) -> mx.array:
+        """Tokenize and extract the final (post-norm) hidden state in one call.
+
+        Args:
+            text: Input text.
+            max_length: Padded sequence length.
+
+        Returns:
+            Hidden states of shape ``(1, max_length, hidden_dim)``.
+        """
+        token_ids, attention_mask = self.tokenize(text, max_length)
+        all_states = self.get_all_hidden_states(token_ids, attention_mask=attention_mask)
+        return all_states[-1]
+
+    def encode_all_layers(self, text: str, max_length: int = TOKENIZER_MAX_LENGTH) -> tuple[list[mx.array], mx.array]:
+        """Tokenize and extract ALL layer hidden states in one call.
+
+        This is the method ``PromptEncoder.encode()``
+        (``ltx_pipelines_mlx/utils/blocks.py:129``) and the trainer call.
+
+        Args:
+            text: Input text.
+            max_length: Padded sequence length.
+
+        Returns:
+            ``(hidden_states, attention_mask)``:
+            - ``hidden_states``: list of ``(1, max_length, hidden_dim)``
+              tensors (49 total), last entry post-final-norm.
+            - ``attention_mask``: ``(1, max_length)`` binary mask.
+        """
+        token_ids, attention_mask = self.tokenize(text, max_length)
+        hidden_states = self.get_all_hidden_states(token_ids, attention_mask=attention_mask)
+        return hidden_states, attention_mask
+
+    @functools.cached_property
+    def default_gemma4_t2v_system_prompt(self) -> str:
+        """Load the default Gemma-4 T2V system prompt."""
+        return _load_system_prompt("gemma4_t2v_system_prompt.txt")
+
+    @functools.cached_property
+    def default_gemma4_i2v_system_prompt(self) -> str:
+        """Load the default Gemma-4 I2V system prompt."""
+        return _load_system_prompt("gemma4_i2v_system_prompt.txt")
+
+
+@functools.lru_cache(maxsize=2)
+def _load_system_prompt(prompt_name: str) -> str:
+    """Load a system prompt file from the prompts directory."""
+    prompt_path = Path(__file__).parent / "prompts" / prompt_name
+    with open(prompt_path) as f:
+        return f.read()
+
+
+def default_gemma4_t2v_system_prompt() -> str:
+    """Standalone accessor mirroring ``default_gemma4_t2v_system_prompt()`` upstream."""
+    return _load_system_prompt("gemma4_t2v_system_prompt.txt")
+
+
+def default_gemma4_i2v_system_prompt() -> str:
+    """Standalone accessor mirroring ``default_gemma4_i2v_system_prompt()`` upstream."""
+    return _load_system_prompt("gemma4_i2v_system_prompt.txt")

--- a/packages/ltx-core-mlx/src/ltx_core_mlx/text_encoders/gemma/encoders/prompts/gemma4_i2v_system_prompt.txt
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/text_encoders/gemma/encoders/prompts/gemma4_i2v_system_prompt.txt
@@ -1,0 +1,27 @@
+You are given a REFERENCE IMAGE (the exact first frame of the video) and a user's short image-to-video request. Write a single, highly detailed audio-visual caption describing the video that BEGINS from this exact reference image and best fulfills that request, in the EXACT style of the training captions used for this video model. The generated video is scored against the user's ORIGINAL request, so preserve every element the user stated; expand faithfully into the full caption style without contradicting or dropping anything they asked for.
+
+FIRST-FRAME / IMAGE GROUNDING (do this first): the opening of your caption must match the reference image exactly — same subject(s), identity, appearance, clothing, setting, lighting, and composition as shown. The video starts on this frame; describe it faithfully, then narrate chronologically as the user's requested action unfolds from it. Never contradict, replace, or invent things not consistent with the image. Single continuous take — no hard cuts.
+
+Match this captioning style precisely:
+
+1. Begin immediately with the action or visual detail. Do NOT use "The scene opens…", "We see…", "There is…".
+
+2. Objective, observable description only. Do not infer emotions or intentions — describe what is visible and audible (e.g. not "he looks sad" but "his eyebrows angle downward and his lips are pressed together").
+
+3. Full visual detail: environment (materials, textures, lighting, colors), character appearance (clothing, posture, facial details), and the spatial positioning of all elements — grounded in and consistent with the reference image. When a human appears, identify them specifically (gendered terms when clearly implied; differentiate multiple people consistently) and describe visible physical attributes — apparent gender presentation, skin tone, estimated age group, hair color/length/style, build, clothing and accessories. Do not infer ethnicity, nationality, religion, or culture.
+
+4. Precise motion and cinematic description. For every shot you MUST include, woven naturally into the prose (never as tags or labels):
+   - Shot type (exactly one: extreme wide shot / wide shot / medium shot / medium close-up / close-up / extreme close-up) — consistent with how the reference image is framed at the start.
+   - Camera motion (always stated; if none, explicitly say the camera remains static). Camera movement is expected and good — match the user if they specified it, otherwise choose the treatment that best presents the requested scene starting from this frame.
+   - Camera viewpoint relative to subject (front-facing / back-facing / side view / over-the-shoulder / top-down / low-angle / high-angle) — matching the reference image's viewpoint at the opening.
+   Express these as flowing prose: "a medium shot frames…, captured from a front-facing angle as the camera slowly pans…". Never as "medium shot, static camera —".
+
+5. Complete soundscape, integrated naturally: any dialogue (quote it exactly, in the original language), tone of voice, background music (type, mood, volume changes), and environmental sounds (footsteps, wind, traffic, animals). If the request implies sound, describe it plausibly.
+
+6. Strict chronological, real-time flow using transitions like "Initially…", "A moment later…", "Simultaneously…". Keep the user's requested motion/action central and in motion throughout.
+
+7. One single continuous paragraph. No bullet points, no section headers, no labels like "Audio:" or "Visual:". Exhaustive and lossless — include background elements, subtle movements, lighting, secondary sounds — detailed enough to reconstruct the scene. Aim for a rich, complete paragraph (roughly 150–220 words).
+
+If the user wrote in another language, produce the English caption of the same content. Output ONLY the caption text — no JSON, no preamble.
+
+AESTHETIC QUALITY (in addition to the above, without breaking the objective caption style or contradicting the reference image): render the described scene with strong visual production value — cinematic, film-grade color and contrast, beautiful natural lighting, crisp fine detail and texture, pleasing composition and depth. Weave these quality descriptors naturally into the same observable prose (e.g. "warm cinematic lighting", "richly saturated film-grade color", "crisp high-resolution detail") — describe how the exact requested scene, starting from this frame, LOOKS at its most visually striking, never adding new objects or actions and never contradicting the first frame. Keep everything else (first-frame grounding, framing triple, soundscape, chronological single paragraph, faithfulness) exactly as specified.

--- a/packages/ltx-core-mlx/src/ltx_core_mlx/text_encoders/gemma/encoders/prompts/gemma4_t2v_system_prompt.txt
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/text_encoders/gemma/encoders/prompts/gemma4_t2v_system_prompt.txt
@@ -1,0 +1,25 @@
+You are given a user's short text-to-video request. Write a single, highly detailed audio-visual caption describing the video that best fulfills that request, in the EXACT style of the training captions used for this video model. The generated video is scored against the user's ORIGINAL request, so preserve every element the user stated; expand faithfully into the full caption style without contradicting or dropping anything they asked for.
+
+Match this captioning style precisely:
+
+1. Begin immediately with the action or visual detail. Do NOT use "The scene opens…", "We see…", "There is…".
+
+2. Objective, observable description only. Do not infer emotions or intentions — describe what is visible and audible (e.g. not "he looks sad" but "his eyebrows angle downward and his lips are pressed together").
+
+3. Full visual detail: environment (materials, textures, lighting, colors), character appearance (clothing, posture, facial details), and the spatial positioning of all elements. When a human appears, identify them specifically (gendered terms when clearly implied; differentiate multiple people consistently) and describe visible physical attributes — apparent gender presentation, skin tone, estimated age group, hair color/length/style, build, clothing and accessories. Do not infer ethnicity, nationality, religion, or culture.
+
+4. Precise motion and cinematic description. For every shot you MUST include, woven naturally into the prose (never as tags or labels):
+   - Shot type (exactly one: extreme wide shot / wide shot / medium shot / medium close-up / close-up / extreme close-up)
+   - Camera motion (always stated; if none, explicitly say the camera remains static). Camera movement is expected and good — match the user if they specified it, otherwise choose the treatment that best presents the requested scene.
+   - Camera viewpoint relative to subject (front-facing / back-facing / side view / over-the-shoulder / top-down / low-angle / high-angle).
+   Express these as flowing prose: "a medium shot frames…, captured from a front-facing angle as the camera slowly pans…". Never as "medium shot, static camera —".
+
+5. Complete soundscape, integrated naturally: any dialogue (quote it exactly, in the original language), tone of voice, background music (type, mood, volume changes), and environmental sounds (footsteps, wind, traffic, animals). If the request implies sound, describe it plausibly.
+
+6. Strict chronological, real-time flow using transitions like "Initially…", "A moment later…", "Simultaneously…". Keep every stated action in motion.
+
+7. One single continuous paragraph. No bullet points, no section headers, no labels like "Audio:" or "Visual:". Exhaustive and lossless — include background elements, subtle movements, lighting, secondary sounds — detailed enough to reconstruct the scene. Aim for a rich, complete paragraph (roughly 150–220 words).
+
+If the user wrote in another language, produce the English caption of the same content. Output ONLY the caption text — no JSON, no preamble.
+
+AESTHETIC QUALITY (in addition to the above, without breaking the objective caption style): render the described scene with strong visual production value — cinematic, film-grade color and contrast, beautiful natural lighting, crisp fine detail and texture, pleasing composition and depth. Weave these quality descriptors naturally into the same observable prose (e.g. "warm cinematic lighting", "richly saturated film-grade color", "crisp high-resolution detail") — describe how the exact requested scene LOOKS at its most visually striking, never adding new objects or actions. Keep everything else (framing triple, soundscape, chronological single paragraph, faithfulness) exactly as specified.

--- a/packages/ltx-core-mlx/src/ltx_core_mlx/text_encoders/gemma/gemma4.py
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/text_encoders/gemma/gemma4.py
@@ -1,0 +1,382 @@
+"""Gemma-4 unified text tower building blocks (norm, rotary, attention, MLP).
+
+Port of HF ``modeling_gemma4_unified.py`` -- ``Gemma4UnifiedRMSNorm``,
+``Gemma4UnifiedTextRotaryEmbedding``, ``Gemma4UnifiedTextAttention`` and
+``Gemma4UnifiedTextMLP`` -- to MLX. The decoder layer and the full tower
+are assembled on top of these in a separate module.
+
+Gemma 4 alternates two attention flavors, and they differ by more than a
+window size:
+
+* ``sliding_attention``: window-``sliding_window`` causal attention,
+  ``num_key_value_heads`` KV heads, ``head_dim`` per head, ``default``
+  rope over ``rope_local_theta``, and a real ``v_proj``.
+* ``full_attention``: plain causal attention, ``num_global_key_value_heads``
+  KV heads (typically 1), ``global_head_dim`` per head, ``proportional``
+  rope over ``rope_global_theta`` with ``partial_rotary_factor``, and --
+  when ``attention_k_eq_v`` -- **no** ``v_proj`` at all: the values are
+  the raw ``k_proj`` output (pre ``k_norm``, un-roped) pushed through a
+  scale-free ``v_norm``.
+
+Two details worth calling out because they diverge from Gemma 3:
+
+* ``Gemma4UnifiedRMSNorm`` applies ``normed * weight``, **not** Gemma 3's
+  ``normed * (1 + weight)``. Reproduced verbatim here.
+* attention ``scaling`` is a hard ``1.0`` (not ``head_dim ** -0.5``); the
+  q/k RMSNorms carry the scale instead.
+"""
+
+from __future__ import annotations
+
+import math
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from .gemma4_config import Gemma4TextConfig
+
+_ROPE_DEFAULT = "default"
+_ROPE_PROPORTIONAL = "proportional"
+
+
+class Gemma4RMSNorm(nn.Module):
+    """RMSNorm as used throughout the Gemma-4 text tower.
+
+    Normalizes in float32 and casts back to the input dtype, mirroring
+    ``Gemma4UnifiedRMSNorm``. The scale is applied as a plain multiply --
+    Gemma 4 does not use Gemma 3's ``(1 + weight)`` convention.
+
+    Args:
+        dim: Feature dimension being normalized (last axis).
+        eps: Epsilon added to the mean square before the inverse sqrt.
+        with_scale: Whether to register a learned ``weight``. The
+            attention ``v_norm`` is scale-free.
+    """
+
+    def __init__(self, dim: int, eps: float = 1e-6, with_scale: bool = True):
+        super().__init__()
+        self.eps = eps
+        self.with_scale = with_scale
+        if with_scale:
+            self.weight = mx.ones((dim,))
+
+    def __call__(self, hidden_states: mx.array) -> mx.array:
+        """Normalize the last axis.
+
+        Args:
+            hidden_states: Tensor whose last axis has size ``dim``.
+
+        Returns:
+            The normalized tensor, in the input dtype.
+        """
+        dtype = hidden_states.dtype
+        x = hidden_states.astype(mx.float32)
+        normed = x * mx.rsqrt(mx.mean(mx.square(x), axis=-1, keepdims=True) + self.eps)
+        if self.with_scale:
+            normed = normed * self.weight.astype(mx.float32)
+        return normed.astype(dtype)
+
+
+class Gemma4RotaryEmbedding(nn.Module):
+    """Rotary tables for one Gemma-4 layer type.
+
+    Covers both parametrizations the tower uses:
+
+    * ``"default"`` -- ``inv_freq[i] = theta ** (-2i / head_dim)`` over the
+      whole head dim.
+    * ``"proportional"`` -- only the first ``int(partial_rotary_factor *
+      head_dim // 2)`` frequencies are populated (with the same
+      ``head_dim`` in the exponent denominator, *not* the rotary sub-dim);
+      the remaining ones are **zero**, which makes those channels
+      identity-rotated (cos 1 / sin 0) while keeping the table full width.
+
+    Args:
+        head_dim: Per-head dimension of the layer.
+        theta: RoPE base frequency.
+        rope_type: ``"default"`` or ``"proportional"``.
+        partial_rotary_factor: Rotary fraction of ``head_dim``; only
+            meaningful for ``"proportional"``.
+
+    Raises:
+        ValueError: On an unknown ``rope_type``, or a ``"default"`` type
+            paired with a non-unit ``partial_rotary_factor``.
+    """
+
+    def __init__(
+        self,
+        head_dim: int,
+        theta: float,
+        rope_type: str = _ROPE_DEFAULT,
+        partial_rotary_factor: float = 1.0,
+    ):
+        super().__init__()
+        if rope_type not in (_ROPE_DEFAULT, _ROPE_PROPORTIONAL):
+            raise ValueError(f"Unsupported rope_type: {rope_type!r}")
+        if rope_type == _ROPE_DEFAULT and partial_rotary_factor != 1.0:
+            raise ValueError(
+                f"rope_type='default' rotates the full head dim, got partial_rotary_factor={partial_rotary_factor}"
+            )
+
+        self.head_dim = head_dim
+        self.theta = theta
+        self.rope_type = rope_type
+        self.partial_rotary_factor = partial_rotary_factor
+
+        half = head_dim // 2
+        rope_angles = int(partial_rotary_factor * head_dim // 2) if rope_type == _ROPE_PROPORTIONAL else half
+        exponents = mx.arange(0, 2 * rope_angles, 2, dtype=mx.float32) / head_dim
+        inv_freq = 1.0 / mx.power(mx.array(theta, dtype=mx.float32), exponents)
+        if rope_angles < half:
+            inv_freq = mx.concatenate([inv_freq, mx.zeros((half - rope_angles,), dtype=mx.float32)])
+        # Buffer, not a parameter: frozen so it is never trained/saved.
+        self._inv_freq = inv_freq
+        self.freeze(keys=["_inv_freq"])
+
+    @property
+    def inv_freq(self) -> mx.array:
+        """The inverse frequency table, shape ``(head_dim // 2,)``."""
+        return self._inv_freq
+
+    @classmethod
+    def from_config(cls, config: Gemma4TextConfig, layer_idx: int) -> Gemma4RotaryEmbedding:
+        """Build the rotary embedding for layer ``layer_idx``.
+
+        Sliding layers use ``default`` rope over ``rope_local_theta``;
+        full layers use ``proportional`` rope over ``rope_global_theta``
+        with the config's ``partial_rotary_factor``.
+
+        Args:
+            config: The parsed text tower config.
+            layer_idx: Zero-based layer index.
+
+        Returns:
+            The rotary embedding for that layer.
+        """
+        if config.layer_is_sliding(layer_idx):
+            return cls(config.head_dim, config.rope_local_theta, rope_type=_ROPE_DEFAULT)
+        return cls(
+            config.global_head_dim,
+            config.rope_global_theta,
+            rope_type=_ROPE_PROPORTIONAL,
+            partial_rotary_factor=config.partial_rotary_factor,
+        )
+
+    def __call__(self, position_ids: mx.array) -> tuple[mx.array, mx.array]:
+        """Compute the cos/sin tables for the given positions.
+
+        Args:
+            position_ids: Integer positions, shape ``(B, T)``.
+
+        Returns:
+            ``(cos, sin)``, each of shape ``(B, T, head_dim)``.
+        """
+        freqs = position_ids.astype(mx.float32)[..., None] * self._inv_freq[None, None, :]
+        emb = mx.concatenate([freqs, freqs], axis=-1)
+        return mx.cos(emb), mx.sin(emb)
+
+
+def rotate_half(x: mx.array) -> mx.array:
+    """Rotate the two halves of the last axis: ``[a, b] -> [-b, a]``.
+
+    Args:
+        x: Tensor with an even-sized last axis.
+
+    Returns:
+        The half-rotated tensor.
+    """
+    half = x.shape[-1] // 2
+    return mx.concatenate([-x[..., half:], x[..., :half]], axis=-1)
+
+
+def apply_rotary_pos_emb(x: mx.array, cos: mx.array, sin: mx.array) -> mx.array:
+    """Apply rotary position embeddings to a ``(B, T, H, D)`` tensor.
+
+    Args:
+        x: Query or key states, shape ``(B, T, H, D)``.
+        cos: Cosine table, shape ``(B, T, D)``.
+        sin: Sine table, shape ``(B, T, D)``.
+
+    Returns:
+        The rotated tensor, same shape as ``x``.
+    """
+    cos = cos[:, :, None, :].astype(x.dtype)
+    sin = sin[:, :, None, :].astype(x.dtype)
+    return (x * cos) + (rotate_half(x) * sin)
+
+
+def build_attention_mask(
+    seq_len: int,
+    sliding_window: int | None = None,
+    padding_mask: mx.array | None = None,
+    dtype: mx.Dtype = mx.float32,
+) -> mx.array:
+    """Build the additive causal (optionally windowed) attention mask.
+
+    Mirrors the HF ``create_causal_mask`` /
+    ``create_sliding_window_causal_mask`` pattern: a key at position
+    ``j`` is visible from query position ``i`` when ``j <= i`` and, on
+    sliding layers, ``j > i - sliding_window``.
+
+    Args:
+        seq_len: Query/key sequence length.
+        sliding_window: Window size for sliding layers, ``None`` for full
+            attention.
+        padding_mask: Optional ``(B, T)`` mask, nonzero on real tokens.
+        dtype: Output dtype.
+
+    Returns:
+        An additive mask of shape ``(1, 1, T, T)`` -- or ``(B, 1, T, T)``
+        when ``padding_mask`` is given -- with ``0`` on visible positions
+        and ``-inf`` on masked ones.
+    """
+    q_idx = mx.arange(seq_len)[:, None]
+    k_idx = mx.arange(seq_len)[None, :]
+    visible = k_idx <= q_idx
+    if sliding_window is not None:
+        visible = mx.logical_and(visible, k_idx > q_idx - sliding_window)
+    visible = visible[None, None, :, :]
+
+    if padding_mask is not None:
+        visible = mx.logical_and(visible, (padding_mask != 0)[:, None, None, :])
+
+    return mx.where(visible, mx.array(0.0, dtype=dtype), mx.array(-mx.inf, dtype=dtype))
+
+
+def repeat_kv(hidden_states: mx.array, n_rep: int) -> mx.array:
+    """Repeat KV heads to match the query head count (GQA).
+
+    Args:
+        hidden_states: ``(B, n_kv_heads, T, D)`` key or value states.
+        n_rep: Repetition factor (``num_key_value_groups``).
+
+    Returns:
+        ``(B, n_kv_heads * n_rep, T, D)``, each KV head repeated
+        contiguously -- equivalent to ``repeat_interleave`` on axis 1.
+    """
+    if n_rep == 1:
+        return hidden_states
+    batch, n_kv_heads, seq_len, head_dim = hidden_states.shape
+    expanded = mx.broadcast_to(hidden_states[:, :, None, :, :], (batch, n_kv_heads, n_rep, seq_len, head_dim))
+    return expanded.reshape(batch, n_kv_heads * n_rep, seq_len, head_dim)
+
+
+class Gemma4Attention(nn.Module):
+    """Gemma-4 multi-head attention, both layer flavors.
+
+    Args:
+        config: The parsed text tower config.
+        layer_idx: Zero-based layer index; selects the flavor via
+            ``config.layer_types``.
+    """
+
+    def __init__(self, config: Gemma4TextConfig, layer_idx: int):
+        super().__init__()
+        self.layer_idx = layer_idx
+        self.is_sliding = config.layer_is_sliding(layer_idx)
+        self.sliding_window = config.sliding_window if self.is_sliding else None
+        self.head_dim = config.layer_head_dim(layer_idx)
+        self.num_heads = config.num_attention_heads
+        self.num_kv_heads = config.layer_num_kv(layer_idx)
+        self.num_key_value_groups = self.num_heads // self.num_kv_heads
+        # K and V are tied only on the full-attention layers.
+        self.k_eq_v = config.attention_k_eq_v and not self.is_sliding
+        self.scaling = 1.0
+
+        self.q_proj = nn.Linear(config.hidden_size, self.num_heads * self.head_dim, bias=False)
+        self.k_proj = nn.Linear(config.hidden_size, self.num_kv_heads * self.head_dim, bias=False)
+        if not self.k_eq_v:
+            self.v_proj = nn.Linear(config.hidden_size, self.num_kv_heads * self.head_dim, bias=False)
+        self.o_proj = nn.Linear(self.num_heads * self.head_dim, config.hidden_size, bias=False)
+
+        self.q_norm = Gemma4RMSNorm(self.head_dim, eps=config.rms_norm_eps)
+        self.k_norm = Gemma4RMSNorm(self.head_dim, eps=config.rms_norm_eps)
+        self.v_norm = Gemma4RMSNorm(self.head_dim, eps=config.rms_norm_eps, with_scale=False)
+
+    def __call__(
+        self,
+        hidden_states: mx.array,
+        cos: mx.array,
+        sin: mx.array,
+        mask: mx.array | None = None,
+    ) -> mx.array:
+        """Run attention over ``hidden_states``.
+
+        Args:
+            hidden_states: ``(B, T, hidden_size)`` layer input (already
+                through ``input_layernorm``).
+            cos: Rotary cosine table, ``(B, T, head_dim)``.
+            sin: Rotary sine table, ``(B, T, head_dim)``.
+            mask: Additive attention mask broadcastable to
+                ``(B, H, T, T)``.
+
+        Returns:
+            ``(B, T, hidden_size)`` attention output.
+        """
+        batch, seq_len, _ = hidden_states.shape
+
+        queries = self.q_proj(hidden_states).reshape(batch, seq_len, self.num_heads, self.head_dim)
+        queries = self.q_norm(queries)
+        queries = apply_rotary_pos_emb(queries, cos, sin)
+        queries = queries.transpose(0, 2, 1, 3)
+
+        keys = self.k_proj(hidden_states).reshape(batch, seq_len, self.num_kv_heads, self.head_dim)
+        # On k_eq_v layers the values are the *raw* k_proj output: pre
+        # k_norm and un-roped, normalized only by the scale-free v_norm.
+        values = (
+            keys
+            if self.k_eq_v
+            else self.v_proj(hidden_states).reshape(batch, seq_len, self.num_kv_heads, self.head_dim)
+        )
+
+        keys = self.k_norm(keys)
+        keys = apply_rotary_pos_emb(keys, cos, sin)
+        keys = keys.transpose(0, 2, 1, 3)
+
+        values = self.v_norm(values).transpose(0, 2, 1, 3)
+
+        keys = repeat_kv(keys, self.num_key_value_groups)
+        values = repeat_kv(values, self.num_key_value_groups)
+
+        attn = mx.fast.scaled_dot_product_attention(queries, keys, values, scale=self.scaling, mask=mask)
+        attn = attn.transpose(0, 2, 1, 3).reshape(batch, seq_len, self.num_heads * self.head_dim)
+        return self.o_proj(attn)
+
+
+class Gemma4MLP(nn.Module):
+    """Gated feed-forward block with the ``gelu_pytorch_tanh`` activation.
+
+    Args:
+        config: The parsed text tower config.
+    """
+
+    def __init__(self, config: Gemma4TextConfig):
+        super().__init__()
+        self.gate_proj = nn.Linear(config.hidden_size, config.intermediate_size, bias=False)
+        self.up_proj = nn.Linear(config.hidden_size, config.intermediate_size, bias=False)
+        self.down_proj = nn.Linear(config.intermediate_size, config.hidden_size, bias=False)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        """Apply the gated MLP.
+
+        Args:
+            x: ``(B, T, hidden_size)`` input.
+
+        Returns:
+            ``(B, T, hidden_size)`` output.
+        """
+        return self.down_proj(gelu_tanh(self.gate_proj(x)) * self.up_proj(x))
+
+
+def gelu_tanh(x: mx.array) -> mx.array:
+    """The ``gelu_pytorch_tanh`` activation.
+
+    ``0.5 * x * (1 + tanh(sqrt(2/pi) * (x + 0.044715 * x**3)))`` --
+    identical to ``torch.nn.functional.gelu(approximate="tanh")``.
+
+    Args:
+        x: Input tensor.
+
+    Returns:
+        The activated tensor.
+    """
+    return 0.5 * x * (1 + mx.tanh(math.sqrt(2.0 / math.pi) * (x + 0.044715 * mx.power(x, 3))))

--- a/packages/ltx-core-mlx/src/ltx_core_mlx/text_encoders/gemma/gemma4.py
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/text_encoders/gemma/gemma4.py
@@ -28,15 +28,54 @@ Two details worth calling out because they diverge from Gemma 3:
 
 from __future__ import annotations
 
+import json
 import math
+import struct
+from pathlib import Path
 
 import mlx.core as mx
 import mlx.nn as nn
+
+from ltx_core_mlx.utils.weights import apply_quantization, load_split_safetensors
 
 from .gemma4_config import Gemma4TextConfig
 
 _ROPE_DEFAULT = "default"
 _ROPE_PROPORTIONAL = "proportional"
+
+_SLIDING_ATTENTION = "sliding_attention"
+_FULL_ATTENTION = "full_attention"
+
+# The pack's text_encoder.safetensors also carries the multimodal (vision +
+# audio/video projector) tensors of the wider Gemma4Unified checkpoint that
+# this text-only port does not load: 9 vision_model tensors, 1 audio
+# projector, 1 multi-modal projector, and the 4 text_embedding_projection
+# tensors (loaded by the connector, not the tower -- see
+# ``text_encoders/gemma/embeddings_connector.py``). Any pack key that is
+# neither under ``text_encoder.model.`` nor in this allowlist is a real
+# format-drift signal and must fail loudly rather than being silently
+# dropped.
+GEMMA4_PACK_IGNORE_ALLOWLIST: frozenset[str] = frozenset(
+    {
+        "text_encoder.audio_projector.embedding_projection.weight",
+        "text_encoder.multi_modal_projector.embedding_projection.weight",
+        "text_encoder.text_embedding_projection.audio_aggregate_embed.bias",
+        "text_encoder.text_embedding_projection.audio_aggregate_embed.weight",
+        "text_encoder.text_embedding_projection.video_aggregate_embed.bias",
+        "text_encoder.text_embedding_projection.video_aggregate_embed.weight",
+        "text_encoder.vision_model.patch_dense.bias",
+        "text_encoder.vision_model.patch_dense.weight",
+        "text_encoder.vision_model.patch_ln1.bias",
+        "text_encoder.vision_model.patch_ln1.weight",
+        "text_encoder.vision_model.patch_ln2.bias",
+        "text_encoder.vision_model.patch_ln2.weight",
+        "text_encoder.vision_model.pos_embedding",
+        "text_encoder.vision_model.pos_norm.bias",
+        "text_encoder.vision_model.pos_norm.weight",
+    }
+)
+
+_TEXT_ENCODER_PACK_PREFIX = "text_encoder.model."
 
 
 class Gemma4RMSNorm(nn.Module):
@@ -238,6 +277,17 @@ def build_attention_mask(
 
     if padding_mask is not None:
         visible = mx.logical_and(visible, (padding_mask != 0)[:, None, None, :])
+        # A padded query position can end up with zero visible keys (e.g.
+        # left-padding: causal + its own key being masked leaves nothing),
+        # which turns that softmax row into all -inf. 0 * NaN then poisons
+        # every downstream position once k_eq_v layers reuse attention
+        # output as the next layer's values. HF's masking utils sidestep
+        # this the same way (``AttentionMaskConverter._unmask_unattended``):
+        # unmask the diagonal on any row left fully masked. The resulting
+        # hidden state at that position is unused by callers regardless.
+        row_all_masked = mx.logical_not(mx.any(visible, axis=-1, keepdims=True))
+        diag = (mx.arange(seq_len)[None, :] == mx.arange(seq_len)[:, None])[None, None, :, :]
+        visible = mx.logical_or(visible, mx.logical_and(row_all_masked, diag))
 
     return mx.where(visible, mx.array(0.0, dtype=dtype), mx.array(-mx.inf, dtype=dtype))
 
@@ -380,3 +430,214 @@ def gelu_tanh(x: mx.array) -> mx.array:
         The activated tensor.
     """
     return 0.5 * x * (1 + mx.tanh(math.sqrt(2.0 / math.pi) * (x + 0.044715 * mx.power(x, 3))))
+
+
+class Gemma4DecoderLayer(nn.Module):
+    """One Gemma-4 decoder layer: pre/post norm sandwich around attn + MLP.
+
+    Unlike Gemma 3's single pre-norm per sublayer, Gemma 4 wraps each
+    sublayer with both an input norm and a post-sublayer norm before the
+    residual add, and finishes with a per-layer scalar gate (``layer_scalar``,
+    a real pack tensor -- not just a constant -- even though its trained
+    value is typically ~1).
+
+    Args:
+        config: The parsed text tower config.
+        layer_idx: Zero-based layer index; selects the attention flavor.
+    """
+
+    def __init__(self, config: Gemma4TextConfig, layer_idx: int):
+        super().__init__()
+        self.self_attn = Gemma4Attention(config, layer_idx)
+        self.mlp = Gemma4MLP(config)
+        self.input_layernorm = Gemma4RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = Gemma4RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.pre_feedforward_layernorm = Gemma4RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_feedforward_layernorm = Gemma4RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.layer_scalar = mx.ones((1,))
+
+    def __call__(
+        self,
+        hidden_states: mx.array,
+        cos: mx.array,
+        sin: mx.array,
+        mask: mx.array | None = None,
+    ) -> mx.array:
+        """Run one decoder layer.
+
+        Args:
+            hidden_states: ``(B, T, hidden_size)`` layer input.
+            cos: Rotary cosine table for this layer's attention flavor.
+            sin: Rotary sine table for this layer's attention flavor.
+            mask: Additive attention mask for this layer's flavor.
+
+        Returns:
+            ``(B, T, hidden_size)`` layer output.
+        """
+        residual = hidden_states
+        attn_out = self.self_attn(self.input_layernorm(hidden_states), cos, sin, mask)
+        hidden_states = residual + self.post_attention_layernorm(attn_out)
+
+        residual = hidden_states
+        mlp_out = self.mlp(self.pre_feedforward_layernorm(hidden_states))
+        hidden_states = residual + self.post_feedforward_layernorm(mlp_out)
+
+        return hidden_states * self.layer_scalar
+
+
+def _safetensors_header_keys(path: Path) -> set[str]:
+    """Read only the JSON header of a safetensors file (no tensor data).
+
+    Args:
+        path: Path to the ``.safetensors`` file.
+
+    Returns:
+        The set of tensor keys in the file.
+    """
+    with open(path, "rb") as f:
+        n = struct.unpack("<Q", f.read(8))[0]
+        header = json.loads(f.read(n))
+    return {k for k in header if k != "__metadata__"}
+
+
+class Gemma4TextModel(nn.Module):
+    """The Gemma-4 unified text tower: scaled embeddings + N decoder layers + final norm.
+
+    Port of ``Gemma4UnifiedTextModel`` (text-only path: no vision/audio
+    inputs, no KV cache, no shared-KV layers -- ruled out by
+    :meth:`Gemma4TextConfig.from_text_encoder_config`).
+
+    Args:
+        config: The parsed text tower config.
+    """
+
+    def __init__(self, config: Gemma4TextConfig):
+        super().__init__()
+        self.config = config
+        self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size)
+        self.embed_scale = math.sqrt(config.hidden_size)
+        self.layers = [Gemma4DecoderLayer(config, i) for i in range(config.num_hidden_layers)]
+        self.norm = Gemma4RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+        # Keyed by layer_types string, not layer index: rotary tables only
+        # depend on the attention flavor. Leading underscore keeps these
+        # out of the MLX parameter tree -- their inv_freq buffers are
+        # derived from config, not loaded from the pack.
+        self._rotary_by_type = {
+            _SLIDING_ATTENTION: Gemma4RotaryEmbedding(
+                config.head_dim, config.rope_local_theta, rope_type=_ROPE_DEFAULT
+            ),
+            _FULL_ATTENTION: Gemma4RotaryEmbedding(
+                config.global_head_dim,
+                config.rope_global_theta,
+                rope_type=_ROPE_PROPORTIONAL,
+                partial_rotary_factor=config.partial_rotary_factor,
+            ),
+        }
+
+    def __call__(
+        self,
+        input_ids: mx.array,
+        attention_mask: mx.array | None = None,
+    ) -> list[mx.array]:
+        """Run the tower and collect every layer's hidden states.
+
+        Args:
+            input_ids: Token ids, shape ``(B, T)``.
+            attention_mask: Optional ``(B, T)`` mask, nonzero on real
+                (non-padding) tokens. This port always left-pads.
+
+        Returns:
+            ``num_hidden_layers + 1`` hidden states, mirroring
+            ``output_hidden_states=True``: the scaled token embeddings,
+            then the raw (pre-final-norm) output of each decoder layer in
+            order. The final RMSNorm is *not* folded into the last entry
+            here -- call ``self.norm`` on it explicitly to get
+            ``last_hidden_state``.
+        """
+        batch, seq_len = input_ids.shape
+        hidden_states = self.embed_tokens(input_ids)
+        hidden_states = hidden_states * mx.array(self.embed_scale, dtype=hidden_states.dtype)
+
+        position_ids = mx.arange(seq_len)[None, :]
+        position_ids = mx.broadcast_to(position_ids, (batch, seq_len))
+
+        rope_tables = {
+            layer_type: self._rotary_by_type[layer_type](position_ids)
+            for layer_type in sorted(set(self.config.layer_types))
+        }
+        masks = {
+            _FULL_ATTENTION: build_attention_mask(
+                seq_len, sliding_window=None, padding_mask=attention_mask, dtype=hidden_states.dtype
+            ),
+            _SLIDING_ATTENTION: build_attention_mask(
+                seq_len,
+                sliding_window=self.config.sliding_window,
+                padding_mask=attention_mask,
+                dtype=hidden_states.dtype,
+            ),
+        }
+
+        hidden_states_list = [hidden_states]
+        for i, layer in enumerate(self.layers):
+            layer_type = self.config.layer_types[i]
+            cos, sin = rope_tables[layer_type]
+            hidden_states = layer(hidden_states, cos, sin, masks[layer_type])
+            hidden_states_list.append(hidden_states)
+
+        return hidden_states_list
+
+    @classmethod
+    def load_from_pack(cls, model_dir: str | Path) -> Gemma4TextModel:
+        """Build and load a Gemma-4 tower from an LTX-2.5 pack directory.
+
+        Reads ``text_encoder_config.json`` to build the config, then loads
+        ``text_encoder.safetensors`` -- everything under the
+        ``text_encoder.model.`` prefix feeds the tower; every other key
+        must be in :data:`GEMMA4_PACK_IGNORE_ALLOWLIST` (the multimodal
+        tensors owned by other components) or this raises. Quantization is
+        applied when ``quantize_config.json`` declares a ``text_encoder``
+        component.
+
+        Args:
+            model_dir: Path to the pack directory.
+
+        Returns:
+            The loaded tower.
+
+        Raises:
+            ValueError: If ``text_encoder.safetensors`` has a key that is
+                neither under the model prefix nor in the ignore allowlist
+                (silent format drift -- see #52's silent-no-op class).
+        """
+        model_dir = Path(model_dir)
+
+        with open(model_dir / "text_encoder_config.json") as f:
+            raw_config = json.load(f)
+        config = Gemma4TextConfig.from_text_encoder_config(raw_config)
+        model = cls(config)
+
+        safetensors_path = model_dir / "text_encoder.safetensors"
+        all_keys = _safetensors_header_keys(safetensors_path)
+        stray = {
+            k for k in all_keys if not k.startswith(_TEXT_ENCODER_PACK_PREFIX) and k not in GEMMA4_PACK_IGNORE_ALLOWLIST
+        }
+        if stray:
+            raise ValueError(
+                f"{safetensors_path.name} has keys outside the text tower's "
+                f"prefix ({_TEXT_ENCODER_PACK_PREFIX!r}) and the ignore "
+                f"allowlist -- refusing to silently drop them: {sorted(stray)[:10]}"
+            )
+
+        weights = load_split_safetensors(safetensors_path, prefix=_TEXT_ENCODER_PACK_PREFIX)
+
+        quantize_config_path = model_dir / "quantize_config.json"
+        if quantize_config_path.exists():
+            with open(quantize_config_path) as f:
+                quant_config = json.load(f)
+            quantization = quant_config.get("quantization", {})
+            if "text_encoder" in quantization.get("components", {}):
+                apply_quantization(model, weights, group_size=quantization.get("group_size", 64))
+
+        model.load_weights(list(weights.items()))
+        return model

--- a/packages/ltx-core-mlx/src/ltx_core_mlx/text_encoders/gemma/gemma4_config.py
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/text_encoders/gemma/gemma4_config.py
@@ -1,0 +1,169 @@
+"""Gemma-4 unified text tower config, parsed from the LTX-2.5 pack.
+
+LTX-2.5 swaps the Gemma 3 12B text encoder for the text tower of
+Gemma4UnifiedForConditionalGeneration (``gemma4_unified_text``). Unlike
+Gemma 3, Gemma 4 alternates two attention flavors per layer
+(``layer_types``), each with its own head_dim / KV head count / RoPE
+theta, and reads them from a nested HF-style config rather than a flat
+dataclass. This module parses only the fields this port's tower needs
+straight out of the pack's ``text_encoder_config.json`` (full JSON, with
+the tower's own fields nested under ``text_config``).
+
+Reference: HF ``configuration_gemma4_unified.py`` (Gemma4TextConfig).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+_TEXT_MODEL_TYPE = "gemma4_unified_text"
+_SLIDING_ATTENTION = "sliding_attention"
+_FULL_ATTENTION = "full_attention"
+
+
+@dataclass
+class Gemma4TextConfig:
+    """Gemma-4 unified text tower configuration.
+
+    Attributes:
+        gemma_version: Version tag from the root of the JSON (e.g.
+            ``"gemma4-12b-ltx-v1"``), or ``None`` if absent.
+        hidden_size: Model (residual stream) width.
+        num_hidden_layers: Number of transformer layers.
+        num_attention_heads: Query head count (uniform across layers).
+        head_dim: Per-head dim for sliding-attention layers.
+        global_head_dim: Per-head dim for full-attention layers.
+        num_key_value_heads: KV head count for sliding-attention layers.
+        num_global_key_value_heads: KV head count for full-attention layers.
+        intermediate_size: MLP hidden width.
+        vocab_size: Token vocabulary size.
+        rms_norm_eps: Epsilon for RMSNorm layers.
+        sliding_window: Sliding-attention window size (tokens).
+        layer_types: Per-layer attention flavor, one of
+            ``"sliding_attention"`` / ``"full_attention"``.
+        attention_k_eq_v: Whether K and V projections are tied (share
+            weights) in attention.
+        rope_local_theta: RoPE base frequency for sliding-attention layers.
+        rope_global_theta: RoPE base frequency for full-attention layers.
+        partial_rotary_factor: Fraction of head_dim that is rotary,
+            applies to full-attention layers only.
+        pad_token_id: Padding token id.
+    """
+
+    gemma_version: str | None
+    hidden_size: int
+    num_hidden_layers: int
+    num_attention_heads: int
+    head_dim: int
+    global_head_dim: int
+    num_key_value_heads: int
+    num_global_key_value_heads: int
+    intermediate_size: int
+    vocab_size: int
+    rms_norm_eps: float
+    sliding_window: int
+    layer_types: tuple[str, ...]
+    attention_k_eq_v: bool
+    rope_local_theta: float
+    rope_global_theta: float
+    partial_rotary_factor: float
+    pad_token_id: int
+
+    @classmethod
+    def from_text_encoder_config(cls, config: dict) -> Gemma4TextConfig:
+        """Parse a Gemma4TextConfig from the pack's full text encoder JSON.
+
+        Args:
+            config: The complete ``text_encoder_config.json`` content
+                (root-level dict). The tower's own fields live under
+                ``config["text_config"]``; ``gemma_version`` is read from
+                the root.
+
+        Returns:
+            The parsed tower configuration.
+
+        Raises:
+            ValueError: If ``text_config.model_type`` is not
+                ``"gemma4_unified_text"``, if ``num_kv_shared_layers`` is
+                nonzero (KV-sharing across layers is not ported), or if
+                ``use_bidirectional_attention == "all"`` (this port always
+                encodes text causally).
+        """
+        text_config = config["text_config"]
+
+        model_type = text_config.get("model_type")
+        if model_type != _TEXT_MODEL_TYPE:
+            raise ValueError(f"Unsupported text_config.model_type: {model_type!r} (expected {_TEXT_MODEL_TYPE!r})")
+
+        num_kv_shared_layers = text_config.get("num_kv_shared_layers", 0)
+        if num_kv_shared_layers != 0:
+            raise ValueError(
+                f"num_kv_shared_layers={num_kv_shared_layers!r} is not supported "
+                "(KV-sharing across layers is not ported)"
+            )
+
+        use_bidirectional_attention = text_config.get("use_bidirectional_attention", "vision")
+        if use_bidirectional_attention == "all":
+            raise ValueError(
+                'use_bidirectional_attention="all" is not supported (this port always encodes text causally)'
+            )
+
+        rope_parameters = text_config["rope_parameters"]
+        full_rope = rope_parameters[_FULL_ATTENTION]
+        sliding_rope = rope_parameters[_SLIDING_ATTENTION]
+
+        return cls(
+            gemma_version=config.get("gemma_version"),
+            hidden_size=text_config["hidden_size"],
+            num_hidden_layers=text_config["num_hidden_layers"],
+            num_attention_heads=text_config["num_attention_heads"],
+            head_dim=text_config["head_dim"],
+            global_head_dim=text_config["global_head_dim"],
+            num_key_value_heads=text_config["num_key_value_heads"],
+            num_global_key_value_heads=text_config["num_global_key_value_heads"],
+            intermediate_size=text_config["intermediate_size"],
+            vocab_size=text_config["vocab_size"],
+            rms_norm_eps=text_config["rms_norm_eps"],
+            sliding_window=text_config["sliding_window"],
+            layer_types=tuple(text_config["layer_types"]),
+            attention_k_eq_v=text_config.get("attention_k_eq_v", False),
+            rope_local_theta=sliding_rope["rope_theta"],
+            rope_global_theta=full_rope["rope_theta"],
+            partial_rotary_factor=full_rope["partial_rotary_factor"],
+            pad_token_id=text_config["pad_token_id"],
+        )
+
+    def layer_is_sliding(self, i: int) -> bool:
+        """Whether layer ``i`` uses sliding-window (local) attention.
+
+        Args:
+            i: Zero-based layer index.
+
+        Returns:
+            True if the layer's type is ``"sliding_attention"``.
+        """
+        return self.layer_types[i] == _SLIDING_ATTENTION
+
+    def layer_head_dim(self, i: int) -> int:
+        """Per-head dimension for layer ``i``, by its attention type.
+
+        Args:
+            i: Zero-based layer index.
+
+        Returns:
+            ``head_dim`` for sliding layers, ``global_head_dim`` for full
+            layers.
+        """
+        return self.head_dim if self.layer_is_sliding(i) else self.global_head_dim
+
+    def layer_num_kv(self, i: int) -> int:
+        """KV head count for layer ``i``, by its attention type.
+
+        Args:
+            i: Zero-based layer index.
+
+        Returns:
+            ``num_key_value_heads`` for sliding layers,
+            ``num_global_key_value_heads`` for full layers.
+        """
+        return self.num_key_value_heads if self.layer_is_sliding(i) else self.num_global_key_value_heads

--- a/packages/ltx-core-mlx/src/ltx_core_mlx/text_encoders/gemma/gemma4_config.py
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/text_encoders/gemma/gemma4_config.py
@@ -17,8 +17,19 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 _TEXT_MODEL_TYPE = "gemma4_unified_text"
+_ROOT_MODEL_TYPE = "gemma4_unified"
 _SLIDING_ATTENTION = "sliding_attention"
 _FULL_ATTENTION = "full_attention"
+
+# Sliding layers use plain (non-scaled) RoPE; full-attention layers use Gemma
+# 4's "proportional" scaling (see gemma4.py's rotary embedding). A pack with
+# these two flipped parses fine under every other check here -- same key set,
+# same types -- and silently computes the wrong rotary tables for every
+# layer, so it needs its own explicit guard.
+_EXPECTED_ROPE_TYPE = {
+    _SLIDING_ATTENTION: "default",
+    _FULL_ATTENTION: "proportional",
+}
 
 
 @dataclass
@@ -83,12 +94,19 @@ class Gemma4TextConfig:
             The parsed tower configuration.
 
         Raises:
-            ValueError: If ``text_config.model_type`` is not
+            ValueError: If the root ``model_type`` is not
+                ``"gemma4_unified"``, if ``text_config.model_type`` is not
                 ``"gemma4_unified_text"``, if ``num_kv_shared_layers`` is
-                nonzero (KV-sharing across layers is not ported), or if
+                nonzero (KV-sharing across layers is not ported), if
                 ``use_bidirectional_attention == "all"`` (this port always
-                encodes text causally).
+                encodes text causally), or if either attention type's
+                ``rope_parameters.*.rope_type`` does not match the expected
+                flavor (sliding: ``"default"``, full: ``"proportional"``).
         """
+        root_model_type = config.get("model_type")
+        if root_model_type != _ROOT_MODEL_TYPE:
+            raise ValueError(f"Unsupported model_type: {root_model_type!r} (expected {_ROOT_MODEL_TYPE!r})")
+
         text_config = config["text_config"]
 
         model_type = text_config.get("model_type")
@@ -111,6 +129,15 @@ class Gemma4TextConfig:
         rope_parameters = text_config["rope_parameters"]
         full_rope = rope_parameters[_FULL_ATTENTION]
         sliding_rope = rope_parameters[_SLIDING_ATTENTION]
+
+        for attention_type, rope_config in ((_SLIDING_ATTENTION, sliding_rope), (_FULL_ATTENTION, full_rope)):
+            expected_rope_type = _EXPECTED_ROPE_TYPE[attention_type]
+            actual_rope_type = rope_config.get("rope_type")
+            if actual_rope_type != expected_rope_type:
+                raise ValueError(
+                    f"Unsupported rope_parameters.{attention_type}.rope_type: {actual_rope_type!r} "
+                    f"(expected {expected_rope_type!r})"
+                )
 
         return cls(
             gemma_version=config.get("gemma_version"),

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/cli.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/cli.py
@@ -1311,6 +1311,29 @@ def _decode_and_save(
     pipe._decode_and_save_video(video_latent, audio_latent, args.output)
 
 
+def _guard_enhance_not_gemma4(gemma_path: str) -> None:
+    """Raise a clear error if ``gemma_path`` is a local LTX-2.5 (Gemma 4) pack.
+
+    ``enhance`` / ``--enhance-prompt`` load via ``GemmaLanguageModel`` (mlx-lm,
+    Gemma 3 only). A Gemma 4 pack path would otherwise reach ``mlx_lm.load()``
+    and fail with an obscure architecture-mismatch error deep in mlx-lm.
+    HuggingFace repo IDs (the common case, e.g. the default
+    ``mlx-community/gemma-3-12b-it-4bit``) never resolve as an existing local
+    path, so this is a no-op for them.
+    """
+    from pathlib import Path
+
+    from ltx_core_mlx.text_encoders.gemma.encoders.encoder_configurator import select_text_encoder
+
+    path = Path(gemma_path)
+    if path.exists() and select_text_encoder(path) == "gemma4":
+        raise NotImplementedError(
+            f"enhance is not supported for LTX-2.5 (Gemma 4) packs yet: {gemma_path!r}. "
+            "Pass a Gemma 3 checkpoint for --gemma (e.g. the default "
+            "mlx-community/gemma-3-12b-it-4bit)."
+        )
+
+
 def _maybe_enhance_prompt(args: argparse.Namespace) -> str:
     """Enhance prompt if --enhance-prompt is set."""
     prompt = args.prompt
@@ -1319,6 +1342,8 @@ def _maybe_enhance_prompt(args: argparse.Namespace) -> str:
 
     from ltx_core_mlx.text_encoders.gemma.encoders.base_encoder import GemmaLanguageModel
     from ltx_core_mlx.utils.memory import aggressive_cleanup
+
+    _guard_enhance_not_gemma4(args.gemma)
 
     if not args.quiet:
         print("Enhancing prompt...")
@@ -1440,6 +1465,8 @@ def _cmd_slice(args: argparse.Namespace) -> None:
 def _cmd_enhance(args: argparse.Namespace) -> None:
     """Enhance a prompt using Gemma."""
     from ltx_core_mlx.text_encoders.gemma.encoders.base_encoder import GemmaLanguageModel
+
+    _guard_enhance_not_gemma4(args.gemma)
 
     print("Loading Gemma...")
     gemma = GemmaLanguageModel()

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/utils/blocks.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/utils/blocks.py
@@ -96,8 +96,11 @@ class PromptEncoder:
 
     def load(self) -> None:
         """Load Gemma + connector if not already loaded."""
+        # Recomputed unconditionally (not just inside the "text encoder unset"
+        # branch below) so a stale _encoder_kind from a prior partial-free
+        # state can never skip the gemma4 projection merge further down.
+        self._encoder_kind = select_text_encoder(self.model_dir)
         if self._text_encoder is None:
-            self._encoder_kind = select_text_encoder(self.model_dir)
             if self._encoder_kind == "gemma4":
                 # LTX-2.5 pack: Gemma 4 unified tower ships in the DiT pack
                 # itself -- pack-local load, no mlx-community download.

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/utils/blocks.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/utils/blocks.py
@@ -92,11 +92,13 @@ class PromptEncoder:
         self.gemma_model_id = gemma_model_id
         self._text_encoder: GemmaLanguageModel | Gemma4TextEncoder | None = None
         self._feature_extractor: GemmaFeaturesExtractorV2 | None = None
+        self._encoder_kind: str | None = None
 
     def load(self) -> None:
         """Load Gemma + connector if not already loaded."""
         if self._text_encoder is None:
-            if select_text_encoder(self.model_dir) == "gemma4":
+            self._encoder_kind = select_text_encoder(self.model_dir)
+            if self._encoder_kind == "gemma4":
                 # LTX-2.5 pack: Gemma 4 unified tower ships in the DiT pack
                 # itself -- pack-local load, no mlx-community download.
                 from ltx_core_mlx.text_encoders.gemma.encoders.gemma4_encoder import Gemma4TextEncoder
@@ -117,6 +119,20 @@ class PromptEncoder:
             double_precision_rope = LTXModelConfig.from_checkpoint_dir(self.model_dir).double_precision_rope
             self._feature_extractor = GemmaFeaturesExtractorV2(double_precision_rope=double_precision_rope)
             connector_weights = load_split_safetensors(self.model_dir / "connector.safetensors", prefix="connector.")
+            if self._encoder_kind == "gemma4":
+                # The 2.5 pack's connector.safetensors carries only the two
+                # Embeddings1DConnector transformer stacks
+                # (video/audio_embeddings_connector); the
+                # text_embedding_projection.{video,audio}_aggregate_embed
+                # tensors that TextEncoderConnector also needs ship inside
+                # text_encoder.safetensors instead (see the allowlist note
+                # in gemma4.py). Pull them in here and merge under the same
+                # key GemmaFeaturesExtractorV2.connector expects.
+                projection_weights = load_split_safetensors(
+                    self.model_dir / "text_encoder.safetensors",
+                    prefix="text_encoder.text_embedding_projection.",
+                )
+                connector_weights.update({f"text_embedding_projection.{k}": v for k, v in projection_weights.items()})
             self._feature_extractor.connector.load_weights(list(connector_weights.items()))
             aggressive_cleanup()
 

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/utils/blocks.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/utils/blocks.py
@@ -42,6 +42,7 @@ from __future__ import annotations
 import sys
 from collections.abc import Callable
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import mlx.core as mx
 
@@ -53,9 +54,13 @@ from ltx_core_mlx.model.video_vae.video_vae import VideoDecoder as _VideoVAEDeco
 from ltx_core_mlx.model.video_vae.video_vae import VideoEncoder as _VideoVAEEncoder
 from ltx_core_mlx.model.video_vae.video_vae import _compute_decode_tiling
 from ltx_core_mlx.text_encoders.gemma.encoders.base_encoder import GemmaLanguageModel
+from ltx_core_mlx.text_encoders.gemma.encoders.encoder_configurator import select_text_encoder
 from ltx_core_mlx.text_encoders.gemma.feature_extractor import GemmaFeaturesExtractorV2
 from ltx_core_mlx.utils.memory import aggressive_cleanup
 from ltx_core_mlx.utils.weights import load_split_safetensors, remap_audio_vae_keys
+
+if TYPE_CHECKING:
+    from ltx_core_mlx.text_encoders.gemma.encoders.gemma4_encoder import Gemma4TextEncoder
 
 _materialize = getattr(mx, "eval")  # noqa: B009 -- security hook flags the literal mx.eval pattern
 
@@ -85,14 +90,22 @@ class PromptEncoder:
     ) -> None:
         self.model_dir = _resolve_model_dir(model_dir)
         self.gemma_model_id = gemma_model_id
-        self._text_encoder: GemmaLanguageModel | None = None
+        self._text_encoder: GemmaLanguageModel | Gemma4TextEncoder | None = None
         self._feature_extractor: GemmaFeaturesExtractorV2 | None = None
 
     def load(self) -> None:
         """Load Gemma + connector if not already loaded."""
         if self._text_encoder is None:
-            self._text_encoder = GemmaLanguageModel()
-            self._text_encoder.load(self.gemma_model_id)
+            if select_text_encoder(self.model_dir) == "gemma4":
+                # LTX-2.5 pack: Gemma 4 unified tower ships in the DiT pack
+                # itself -- pack-local load, no mlx-community download.
+                from ltx_core_mlx.text_encoders.gemma.encoders.gemma4_encoder import Gemma4TextEncoder
+
+                self._text_encoder = Gemma4TextEncoder()
+                self._text_encoder.load(self.model_dir)
+            else:
+                self._text_encoder = GemmaLanguageModel()
+                self._text_encoder.load(self.gemma_model_id)
             aggressive_cleanup()
 
         if self._feature_extractor is None:

--- a/tests/parity_gemma4_reference.py
+++ b/tests/parity_gemma4_reference.py
@@ -24,6 +24,11 @@ forward pass, and dumps:
 * ``mask.<layer_type>`` -- the additive attention masks;
 * ``L<i>.{attn_in,attn_out,mlp_in,mlp_out}`` -- per-layer submodule
   boundaries, so the MLX blocks can be checked in isolation.
+* ``padded.hs.<i>`` / ``padded.hs.final`` / ``padded.input_ids`` /
+  ``padded.attention_mask`` -- a second forward pass over a batch of 2,
+  row 0 left-padded by 3 tokens, exercising the ``padding_mask`` path
+  through ``build_attention_mask`` (unexercised by the all-ones batch=1
+  case above).
 """
 
 from __future__ import annotations
@@ -146,6 +151,41 @@ def main() -> None:
         handle.remove()
 
     store("hs.final", result.last_hidden_state)
+
+    # Padded-batch case (batch=2, row 0 left-padded by PAD_LEN tokens): the
+    # padding_mask path through build_attention_mask is unexercised by the
+    # batch=1 case above, since attention_mask there is all-ones. Reuses the
+    # same per-layer hook mechanism, under a "padded." prefix.
+    PAD_LEN = 3
+    padded_input_ids = torch.randint(0, TINY_CONFIG["vocab_size"], (2, SEQ_LEN), generator=generator)
+    padded_input_ids[0, :PAD_LEN] = TINY_CONFIG["pad_token_id"]
+    padded_attention_mask = torch.ones((2, SEQ_LEN), dtype=torch.long)
+    padded_attention_mask[0, :PAD_LEN] = 0
+
+    padded_handles = []
+    for idx, layer in enumerate(model.layers):
+        padded_handles.append(
+            layer.register_forward_pre_hook(
+                lambda _m, inputs, i=idx: store(f"padded.hs.{i}", inputs[0]),
+            )
+        )
+        padded_handles.append(
+            layer.register_forward_hook(
+                lambda _m, _inputs, output, i=idx: store(
+                    f"padded.hs.{i + 1}", output[0] if isinstance(output, tuple) else output
+                ),
+            )
+        )
+
+    with torch.no_grad():
+        padded_result = model(input_ids=padded_input_ids, attention_mask=padded_attention_mask)
+
+    for handle in padded_handles:
+        handle.remove()
+
+    store("padded.hs.final", padded_result.last_hidden_state)
+    out["padded.input_ids"] = padded_input_ids.numpy()
+    out["padded.attention_mask"] = padded_attention_mask.numpy()
 
     # Rotary tables + masks, recomputed the same way the model does.
     position_ids = torch.arange(SEQ_LEN).unsqueeze(0)

--- a/tests/parity_gemma4_reference.py
+++ b/tests/parity_gemma4_reference.py
@@ -1,0 +1,185 @@
+"""Torch reference harness for the Gemma-4 attention/rotary/norm/MLP parity test.
+
+This is a standalone script, NOT a pytest module: it needs torch +
+transformers, which are not dependencies of this project. Run it in a
+disposable environment to produce the reference npz that
+``tests/test_ltx25_gemma4.py`` compares the MLX blocks against::
+
+    uv run --no-project --with "transformers>=5.10,<6" --with torch --with numpy \
+        python tests/parity_gemma4_reference.py --out /tmp/gemma4_parity.npz
+
+The npz is deliberately NOT committed (it is regenerable and version
+dependent); the parity tests skip when it is absent.
+
+It builds a tiny fixed-seed ``Gemma4UnifiedTextModel`` (2 layers:
+``[sliding_attention, full_attention]``) on CPU in float32, runs one
+forward pass, and dumps:
+
+* ``w.<state_dict key>`` -- every model weight;
+* ``input_ids`` / ``attention_mask`` -- the inputs used;
+* ``hs.<i>`` -- hidden states entering layer ``i`` (``hs.0`` are the
+  scaled token embeddings), ``hs.<n_layers>`` the last layer's output and
+  ``hs.final`` the output of the trailing RMSNorm;
+* ``rope.<layer_type>.{cos,sin}`` -- the per-layer-type rotary tables;
+* ``mask.<layer_type>`` -- the additive attention masks;
+* ``L<i>.{attn_in,attn_out,mlp_in,mlp_out}`` -- per-layer submodule
+  boundaries, so the MLX blocks can be checked in isolation.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import numpy as np
+import torch
+from transformers.models.gemma4_unified.configuration_gemma4_unified import Gemma4UnifiedTextConfig
+from transformers.models.gemma4_unified.modeling_gemma4_unified import Gemma4UnifiedTextModel
+
+SEED = 1234
+
+# Fixed tiny config, mirroring the real pack's *shape* (two attention
+# flavors, k_eq_v on the full layers, proportional partial rope on the
+# global layers) at a size that runs in a second on CPU.
+TINY_CONFIG = {
+    "vocab_size": 128,
+    "hidden_size": 64,
+    "intermediate_size": 128,
+    "num_hidden_layers": 2,
+    "num_attention_heads": 4,
+    "num_key_value_heads": 2,
+    "head_dim": 16,
+    "global_head_dim": 32,
+    "num_global_key_value_heads": 1,
+    "sliding_window": 8,
+    "layer_types": ["sliding_attention", "full_attention"],
+    "attention_k_eq_v": True,
+    "num_kv_shared_layers": 0,
+    "use_double_wide_mlp": False,
+    "rms_norm_eps": 1e-6,
+    "max_position_embeddings": 512,
+    "pad_token_id": 0,
+    "rope_parameters": {
+        "sliding_attention": {"rope_type": "default", "rope_theta": 10_000.0},
+        "full_attention": {
+            "rope_type": "proportional",
+            "rope_theta": 1_000_000.0,
+            "partial_rotary_factor": 0.25,
+        },
+    },
+}
+
+SEQ_LEN = 12
+BATCH = 1
+
+
+def build_config() -> Gemma4UnifiedTextConfig:
+    """Instantiate the fixed tiny reference config."""
+    return Gemma4UnifiedTextConfig(attn_implementation="eager", **TINY_CONFIG)
+
+
+def main() -> None:
+    """Run the reference forward pass and save the npz."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", required=True, help="Destination .npz path")
+    args = parser.parse_args()
+
+    torch.manual_seed(SEED)
+    config = build_config()
+    model = Gemma4UnifiedTextModel(config).to(torch.float32).eval()
+
+    # Randomize every parameter: the default init leaves norms at ones and
+    # would hide scale bugs.
+    generator = torch.Generator().manual_seed(SEED)
+    with torch.no_grad():
+        for param in model.parameters():
+            param.copy_(torch.randn(param.shape, generator=generator, dtype=torch.float32) * 0.1)
+
+    input_ids = torch.randint(0, TINY_CONFIG["vocab_size"], (BATCH, SEQ_LEN), generator=generator)
+    attention_mask = torch.ones((BATCH, SEQ_LEN), dtype=torch.long)
+
+    out: dict[str, np.ndarray] = {}
+
+    def store(name: str, tensor: torch.Tensor) -> None:
+        out[name] = tensor.detach().to(torch.float32).cpu().numpy()
+
+    handles = []
+
+    for idx, layer in enumerate(model.layers):
+        handles.append(
+            layer.register_forward_pre_hook(
+                lambda _m, inputs, i=idx: store(f"hs.{i}", inputs[0]),
+            )
+        )
+        handles.append(
+            layer.register_forward_hook(
+                lambda _m, _inputs, output, i=idx: store(
+                    f"hs.{i + 1}", output[0] if isinstance(output, tuple) else output
+                ),
+            )
+        )
+        handles.append(
+            layer.self_attn.register_forward_pre_hook(
+                lambda _m, _inputs, kwargs, i=idx: store(f"L{i}.attn_in", kwargs["hidden_states"]),
+                with_kwargs=True,
+            )
+        )
+        handles.append(
+            layer.self_attn.register_forward_hook(
+                lambda _m, _inputs, output, i=idx: store(f"L{i}.attn_out", output[0]),
+            )
+        )
+        handles.append(
+            layer.mlp.register_forward_pre_hook(
+                lambda _m, inputs, i=idx: store(f"L{i}.mlp_in", inputs[0]),
+            )
+        )
+        handles.append(
+            layer.mlp.register_forward_hook(
+                lambda _m, _inputs, output, i=idx: store(f"L{i}.mlp_out", output),
+            )
+        )
+
+    with torch.no_grad():
+        result = model(input_ids=input_ids, attention_mask=attention_mask)
+
+    for handle in handles:
+        handle.remove()
+
+    store("hs.final", result.last_hidden_state)
+
+    # Rotary tables + masks, recomputed the same way the model does.
+    position_ids = torch.arange(SEQ_LEN).unsqueeze(0)
+    embeds = model.embed_tokens(input_ids)
+    for layer_type in sorted(set(TINY_CONFIG["layer_types"])):
+        cos, sin = model.rotary_emb(embeds, position_ids, layer_type)
+        store(f"rope.{layer_type}.cos", cos)
+        store(f"rope.{layer_type}.sin", sin)
+        store(f"rope.{layer_type}.inv_freq", getattr(model.rotary_emb, f"{layer_type}_inv_freq"))
+
+    from transformers.masking_utils import create_causal_mask, create_sliding_window_causal_mask
+
+    mask_kwargs = {
+        "config": config,
+        "inputs_embeds": embeds,
+        "attention_mask": attention_mask,
+        "past_key_values": None,
+        "position_ids": position_ids,
+    }
+    store("mask.full_attention", create_causal_mask(**mask_kwargs))
+    store("mask.sliding_attention", create_sliding_window_causal_mask(**mask_kwargs))
+
+    for key, value in model.state_dict().items():
+        store(f"w.{key}", value)
+
+    out["input_ids"] = input_ids.numpy()
+    out["attention_mask"] = attention_mask.numpy()
+
+    np.savez(args.out, **out)
+    print(f"wrote {args.out} with {len(out)} arrays")
+    print(
+        f"last_hidden_state: shape={tuple(result.last_hidden_state.shape)} mean={result.last_hidden_state.mean():.6f}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/parity_gemma4_reference.py
+++ b/tests/parity_gemma4_reference.py
@@ -29,11 +29,19 @@ forward pass, and dumps:
   row 0 left-padded by 3 tokens, exercising the ``padding_mask`` path
   through ``build_attention_mask`` (unexercised by the all-ones batch=1
   case above).
+* ``tokenizer.control_ids`` -- token ids for ``CONTROL_SENTENCE``,
+  produced by ``transformers.AutoTokenizer`` loaded from the real
+  LTX-2.5 pack's ``tokenizer.json`` (not the tiny reference model above --
+  this exercises the *real* Gemma tokenizer, independent of the tiny
+  attention/rotary config). Only written when ``PACK_DIR`` exists locally;
+  ``tests/test_ltx25_gemma4.py`` skips the tokenizer parity test when this
+  key is absent from the npz.
 """
 
 from __future__ import annotations
 
 import argparse
+from pathlib import Path
 
 import numpy as np
 import torch
@@ -41,6 +49,12 @@ from transformers.models.gemma4_unified.configuration_gemma4_unified import Gemm
 from transformers.models.gemma4_unified.modeling_gemma4_unified import Gemma4UnifiedTextModel
 
 SEED = 1234
+
+# Local (non-hub) pack, same convention as tests/conftest.py::_local_pack.
+# Only used for the tokenizer control-sentence dump below -- unrelated to
+# the tiny reference model's config/weights.
+PACK_DIR = Path.home() / "Work/mlx/models/ltx-2.5-mlx-q8"
+CONTROL_SENTENCE = "A lone lighthouse keeper watches the storm roll in over the grey harbor."
 
 # Fixed tiny config, mirroring the real pack's *shape* (two attention
 # flavors, k_eq_v on the full layers, proportional partial rope on the
@@ -213,6 +227,21 @@ def main() -> None:
 
     out["input_ids"] = input_ids.numpy()
     out["attention_mask"] = attention_mask.numpy()
+
+    # Real-pack tokenizer control sentence (independent of the tiny
+    # reference model above): proves our Gemma4TextEncoder.tokenize()
+    # produces identical ids to transformers.AutoTokenizer loaded from the
+    # same pack. Skipped when the pack is not present on this machine --
+    # the pytest side skips the comparison when this key is absent.
+    if PACK_DIR.exists():
+        from transformers import AutoTokenizer
+
+        tokenizer = AutoTokenizer.from_pretrained(str(PACK_DIR))
+        control_ids = tokenizer.encode(CONTROL_SENTENCE.strip())
+        out["tokenizer.control_ids"] = np.array(control_ids, dtype=np.int64)
+        print(f"tokenizer control ids: {len(control_ids)} tokens (pack at {PACK_DIR})")
+    else:
+        print(f"pack dir {PACK_DIR} not found -- skipping tokenizer control-sentence dump")
 
     np.savez(args.out, **out)
     print(f"wrote {args.out} with {len(out)} arrays")

--- a/tests/test_ltx25_gemma4.py
+++ b/tests/test_ltx25_gemma4.py
@@ -7,7 +7,10 @@ parses the real pack when available (``LTX25_Q8_DIR``).
 
 from pathlib import Path
 
+import mlx.core as mx
+import numpy as np
 import pytest
+from mlx.utils import tree_flatten, tree_unflatten
 
 from tests.conftest import LTX25_Q8_DIR
 
@@ -627,3 +630,182 @@ def test_25_gemma4_config_covers_every_pack_tensor():
     assert not missing_in_model, f"pack tensors nobody would load: {missing_in_model[:10]}"
     assert not unfed_params, f"model params the pack does not feed: {unfed_params[:10]}"
     assert len(pack_normalized) == 666
+
+
+# ---------------------------------------------------------------------------
+# Gemma4TextEncoder: system prompts, the post-final-norm stacking contract,
+# and tokenizer LEFT-pad + real-tokenizer parity.
+# ---------------------------------------------------------------------------
+
+_PROMPTS_DIR = (
+    Path(__file__).resolve().parents[1] / "packages/ltx-core-mlx/src/ltx_core_mlx/text_encoders/gemma/encoders/prompts"
+)
+
+# Pinned at port time (2026-08-24) against upstream Lightricks/LTX-2 @ main:
+#   packages/ltx-core/src/ltx_core/text_encoders/gemma/encoders/prompts/gemma4_{t2v,i2v}_system_prompt.txt
+_PROMPT_INTEGRITY = {
+    "gemma4_t2v_system_prompt.txt": {
+        "length": 3769,
+        "sha256": "0cddf69456bcd51e65430f848386295d9ac4d17d5df3ea65d5f3d8a9ad842f3c",
+    },
+    "gemma4_i2v_system_prompt.txt": {
+        "length": 4708,
+        "sha256": "15992bfb757d3bbd83f2d27ad86e450fc4caffa0f7cb7523772a60e346ef3fee",
+    },
+}
+
+
+@pytest.mark.parametrize("prompt_name", sorted(_PROMPT_INTEGRITY))
+def test_gemma4_system_prompt_matches_upstream_verbatim(prompt_name):
+    """The prompt files must be byte-identical to what was fetched from upstream.
+
+    Any future edit (deliberate or accidental) changes the sha and must
+    update this pin explicitly -- these prompts are consumed verbatim as
+    the Gemma-4 system message and are not meant to drift silently.
+    """
+    import hashlib
+
+    path = _PROMPTS_DIR / prompt_name
+    data = path.read_bytes()
+
+    assert len(data) == _PROMPT_INTEGRITY[prompt_name]["length"]
+    assert hashlib.sha256(data).hexdigest() == _PROMPT_INTEGRITY[prompt_name]["sha256"]
+
+
+def test_gemma4_text_encoder_loads_default_system_prompts():
+    from ltx_core_mlx.text_encoders.gemma.encoders.gemma4_encoder import Gemma4TextEncoder
+
+    encoder = Gemma4TextEncoder()
+    t2v = encoder.default_gemma4_t2v_system_prompt
+    i2v = encoder.default_gemma4_i2v_system_prompt
+    assert len(t2v.encode("utf-8")) == _PROMPT_INTEGRITY["gemma4_t2v_system_prompt.txt"]["length"]
+    assert len(i2v.encode("utf-8")) == _PROMPT_INTEGRITY["gemma4_i2v_system_prompt.txt"]["length"]
+
+
+@pytest.mark.slow
+def test_gemma4_get_all_hidden_states_last_entry_is_post_final_norm():
+    """HARD REQUIREMENT (Task 3 ledger): entry -1 of the 49-stack must be
+    ``tower.norm(raw[-1])``, not the raw tower output -- HF's
+    ``output_hidden_states=True`` tuple ties its last entry to the
+    post-final-norm ``last_hidden_state``
+    (``transformers/output_capturing.py:261-263``), and the upstream
+    encoder consumes that tuple as-is (see
+    ``upstream_gemma_base_encoder.py:68-71``).
+
+    Uses the tiny 2-layer config (no real pack needed) with randomly
+    initialized weights, so the norm's effect is guaranteed non-trivial:
+    a bug that forgets to apply ``tower.norm`` would make this test fail,
+    not silently pass.
+    """
+    import numpy as np
+
+    from ltx_core_mlx.text_encoders.gemma.encoders.gemma4_encoder import Gemma4TextEncoder
+    from ltx_core_mlx.text_encoders.gemma.gemma4 import Gemma4TextModel
+    from ltx_core_mlx.text_encoders.gemma.gemma4_config import Gemma4TextConfig
+
+    config = Gemma4TextConfig.from_text_encoder_config(_TINY_PACK_CONFIG)
+    tower = Gemma4TextModel(config)
+
+    # Randomize weights: default init leaves norm weights at zero (Gemma
+    # RMSNorm has no "+1" -- see Task 2 report), which would make
+    # norm(x) == x * rsqrt(mean(x^2)+eps) still differ from raw x, but
+    # randomizing everything makes the mismatch unmistakably large rather
+    # than relying on that one coincidence.
+    mx.random.seed(0)
+    flat = dict(tree_flatten(tower.parameters()))
+    randomized = {k: mx.random.normal(v.shape) * 0.1 for k, v in flat.items()}
+    tower.update(tree_unflatten(list(randomized.items())))
+
+    encoder = Gemma4TextEncoder(tower=tower)
+    input_ids = mx.random.randint(0, config.vocab_size, (1, 6))
+
+    raw_states = tower(input_ids, attention_mask=None)
+    got_states = encoder.get_all_hidden_states(input_ids, attention_mask=None)
+
+    assert len(got_states) == len(raw_states) == config.num_hidden_layers + 1
+
+    # Entries 0..-2: identical to the raw tower output.
+    for i in range(len(raw_states) - 1):
+        diff = float(np.abs(np.array(got_states[i]) - np.array(raw_states[i])).max())
+        assert diff == 0.0, f"entry {i} must be byte-identical to the raw tower output, got diff={diff}"
+
+    # Entry -1: must equal tower.norm(raw[-1]) ...
+    want_final = tower.norm(raw_states[-1])
+    diff = float(np.abs(np.array(got_states[-1]) - np.array(want_final)).max())
+    assert diff == 0.0
+
+    # ... and must NOT equal the raw (pre-norm) last entry -- catches the
+    # #37-class bug of silently forgetting to apply the final norm.
+    raw_vs_got = float(np.abs(np.array(got_states[-1]) - np.array(raw_states[-1])).max())
+    assert raw_vs_got > 1e-3, "entry -1 must differ from the raw pre-norm tower output"
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(LTX25_Q8_DIR is None, reason="local ltx-2.5-mlx-q8 pack not found")
+def test_gemma4_tokenize_left_pads_with_binary_mask():
+    """Our convention: LEFT padding + binary attention mask (divergence
+    from upstream's right-pad-before-connector, documented at the top of
+    ``base_encoder.py`` / the module docstring of ``gemma4_encoder.py``).
+    """
+    from ltx_core_mlx.text_encoders.gemma.encoders.gemma4_encoder import Gemma4TextEncoder
+
+    encoder = Gemma4TextEncoder()
+    encoder.load_tokenizer(LTX25_Q8_DIR)
+
+    max_length = 32
+    token_ids, attention_mask = encoder.tokenize("hello world", max_length=max_length)
+
+    assert token_ids.shape == (1, max_length)
+    assert attention_mask.shape == (1, max_length)
+
+    mask_np = np.array(attention_mask)[0]
+    ids_np = np.array(token_ids)[0]
+
+    # Real tokens are a contiguous suffix (left padding).
+    num_real = int(mask_np.sum())
+    assert num_real > 0
+    assert (mask_np[: max_length - num_real] == 0).all()
+    assert (mask_np[max_length - num_real :] == 1).all()
+
+    # Padding uses the tokenizer's native pad id.
+    pad_id = encoder.tokenizer.pad_token_id
+    assert (ids_np[: max_length - num_real] == pad_id).all()
+
+
+@pytest.mark.slow
+@_needs_parity_npz
+def test_gemma4_tokenizer_matches_pack_reference_ids(ref):
+    """Our tokenize() must produce the same ids as transformers.AutoTokenizer
+    loaded straight from the pack, for the same control sentence -- this is
+    the "tokenizer parity" leg of the harness (Task 4 brief), independent of
+    the tiny-config attention/rotary parity above.
+    """
+    if "tokenizer.control_ids" not in ref:
+        pytest.skip("npz was regenerated without the real pack available (see parity_gemma4_reference.PACK_DIR)")
+    if LTX25_Q8_DIR is None:
+        pytest.skip("local ltx-2.5-mlx-q8 pack not found")
+
+    from ltx_core_mlx.text_encoders.gemma.encoders.gemma4_encoder import Gemma4TextEncoder
+
+    # Must stay byte-identical to parity_gemma4_reference.CONTROL_SENTENCE.
+    # Not imported directly: that module imports torch at module scope
+    # (a --no-project-only dependency), which would break collection of
+    # this test file in the normal project env.
+    CONTROL_SENTENCE = "A lone lighthouse keeper watches the storm roll in over the grey harbor."
+
+    encoder = Gemma4TextEncoder()
+    encoder.load_tokenizer(LTX25_Q8_DIR)
+
+    want_ids = ref["tokenizer.control_ids"].tolist()
+    # Pad wide enough that the control sentence is never truncated, then
+    # strip the left padding back off using the mask -- exercises the real
+    # tokenize() codepath end-to-end rather than calling the raw tokenizer.
+    max_length = len(want_ids) + 64
+    token_ids, attention_mask = encoder.tokenize(CONTROL_SENTENCE, max_length=max_length)
+
+    mask_np = np.array(attention_mask)[0]
+    ids_np = np.array(token_ids)[0]
+    num_real = int(mask_np.sum())
+    got_ids = ids_np[max_length - num_real :].tolist()
+
+    assert got_ids == want_ids

--- a/tests/test_ltx25_gemma4.py
+++ b/tests/test_ltx25_gemma4.py
@@ -5,6 +5,8 @@ the real ``text_encoder_config.json`` pack file, plus a slow test that
 parses the real pack when available (``LTX25_Q8_DIR``).
 """
 
+from pathlib import Path
+
 import pytest
 
 from tests.conftest import LTX25_Q8_DIR
@@ -256,3 +258,198 @@ def test_parses_real_pack_text_encoder_config():
     assert config.rope_global_theta == 1000000.0
     assert config.partial_rotary_factor == 0.25
     assert config.attention_k_eq_v is True
+
+
+# ---------------------------------------------------------------------------
+# Parity against the torch reference (tests/parity_gemma4_reference.py).
+#
+# Generate the npz first (disposable env, torch + transformers):
+#
+#   uv run --no-project --with "transformers>=5.10,<6" --with torch --with numpy \
+#       python tests/parity_gemma4_reference.py --out /tmp/gemma4_parity.npz
+#
+# These tests skip when the npz is absent.
+# ---------------------------------------------------------------------------
+
+PARITY_NPZ = Path("/tmp/gemma4_parity.npz")
+
+_needs_parity_npz = pytest.mark.skipif(
+    not PARITY_NPZ.exists(),
+    reason=f"reference npz not generated at {PARITY_NPZ} (see tests/parity_gemma4_reference.py)",
+)
+
+# Mirrors tests/parity_gemma4_reference.py::TINY_CONFIG, in the pack's
+# JSON shape so Gemma4TextConfig parses it.
+_TINY_PACK_CONFIG = {
+    "gemma_version": "tiny-parity",
+    "text_config": {
+        "model_type": "gemma4_unified_text",
+        "vocab_size": 128,
+        "hidden_size": 64,
+        "intermediate_size": 128,
+        "num_hidden_layers": 2,
+        "num_attention_heads": 4,
+        "num_key_value_heads": 2,
+        "num_global_key_value_heads": 1,
+        "head_dim": 16,
+        "global_head_dim": 32,
+        "sliding_window": 8,
+        "layer_types": ["sliding_attention", "full_attention"],
+        "attention_k_eq_v": True,
+        "num_kv_shared_layers": 0,
+        "rms_norm_eps": 1e-6,
+        "pad_token_id": 0,
+        "use_bidirectional_attention": "vision",
+        "rope_parameters": {
+            "sliding_attention": {"rope_type": "default", "rope_theta": 10000.0},
+            "full_attention": {
+                "rope_type": "proportional",
+                "rope_theta": 1000000.0,
+                "partial_rotary_factor": 0.25,
+            },
+        },
+    },
+}
+
+PARITY_ATOL = 2e-5
+
+
+@pytest.fixture(scope="module")
+def ref():
+    """The torch reference arrays."""
+    import numpy as np
+
+    return dict(np.load(PARITY_NPZ))
+
+
+@pytest.fixture(scope="module")
+def tiny_config():
+    from ltx_core_mlx.text_encoders.gemma.gemma4_config import Gemma4TextConfig
+
+    return Gemma4TextConfig.from_text_encoder_config(_TINY_PACK_CONFIG)
+
+
+def _max_abs_diff(a, b):
+    import mlx.core as mx
+    import numpy as np
+
+    return float(np.abs(np.array(mx.array(a).astype(mx.float32)) - np.asarray(b)).max())
+
+
+@pytest.mark.slow
+@_needs_parity_npz
+def test_rmsnorm_matches_reference(ref):
+    """Gemma4RMSNorm reproduces the reference input_layernorm exactly."""
+    import mlx.core as mx
+
+    from ltx_core_mlx.text_encoders.gemma.gemma4 import Gemma4RMSNorm
+
+    norm = Gemma4RMSNorm(64, eps=1e-6)
+    norm.update({"weight": mx.array(ref["w.layers.0.input_layernorm.weight"])})
+
+    got = norm(mx.array(ref["hs.0"]))
+
+    assert _max_abs_diff(got, ref["L0.attn_in"]) < PARITY_ATOL
+
+
+@pytest.mark.slow
+@_needs_parity_npz
+def test_rmsnorm_without_scale_is_scale_free():
+    """with_scale=False registers no weight and skips the multiply."""
+    import mlx.core as mx
+
+    from ltx_core_mlx.text_encoders.gemma.gemma4 import Gemma4RMSNorm
+
+    norm = Gemma4RMSNorm(4, eps=1e-6, with_scale=False)
+    assert "weight" not in norm.parameters()
+
+    x = mx.array([[3.0, 0.0, 0.0, 0.0]])
+    got = norm(x)
+    assert abs(float(got[0, 0]) - 2.0) < 1e-5
+
+
+@pytest.mark.slow
+@_needs_parity_npz
+@pytest.mark.parametrize("layer_type,layer_idx", [("sliding_attention", 0), ("full_attention", 1)])
+def test_rotary_matches_reference(ref, tiny_config, layer_type, layer_idx):
+    """Both rope parametrizations (default / proportional+partial) match."""
+    import mlx.core as mx
+
+    from ltx_core_mlx.text_encoders.gemma.gemma4 import Gemma4RotaryEmbedding
+
+    rope = Gemma4RotaryEmbedding.from_config(tiny_config, layer_idx)
+
+    # 1 float32 ULP apart from torch: same formula, different rounding order.
+    assert _max_abs_diff(rope.inv_freq, ref[f"rope.{layer_type}.inv_freq"]) < 1e-7
+
+    positions = mx.arange(ref["input_ids"].shape[1])[None]
+    cos, sin = rope(positions)
+
+    assert _max_abs_diff(cos, ref[f"rope.{layer_type}.cos"]) < PARITY_ATOL
+    assert _max_abs_diff(sin, ref[f"rope.{layer_type}.sin"]) < PARITY_ATOL
+
+
+@pytest.mark.slow
+@_needs_parity_npz
+@pytest.mark.parametrize("layer_type,window", [("full_attention", None), ("sliding_attention", 8)])
+def test_attention_mask_matches_reference(ref, layer_type, window):
+    """Causal (and causal+window) masks match the reference mask pattern."""
+    import mlx.core as mx
+    import numpy as np
+
+    from ltx_core_mlx.text_encoders.gemma.gemma4 import build_attention_mask
+
+    seq_len = ref["input_ids"].shape[1]
+    got = np.array(build_attention_mask(seq_len, sliding_window=window))
+    want = ref[f"mask.{layer_type}"]
+
+    assert (got > -1).squeeze().tolist() == (want > -1).squeeze().tolist()
+    assert mx.array(got).dtype == mx.float32
+
+
+@pytest.mark.slow
+@_needs_parity_npz
+@pytest.mark.parametrize("layer_idx", [0, 1])
+def test_attention_matches_reference(ref, tiny_config, layer_idx):
+    """Both attention flavors match the reference block output."""
+    import mlx.core as mx
+
+    from ltx_core_mlx.text_encoders.gemma.gemma4 import (
+        Gemma4Attention,
+        Gemma4RotaryEmbedding,
+        build_attention_mask,
+    )
+
+    attn = Gemma4Attention(tiny_config, layer_idx)
+    prefix = f"w.layers.{layer_idx}.self_attn."
+    weights = {key[len(prefix) :]: mx.array(value) for key, value in ref.items() if key.startswith(prefix)}
+    assert ("v_proj.weight" in weights) is (layer_idx == 0)
+    attn.load_weights(list(weights.items()))
+
+    seq_len = ref["input_ids"].shape[1]
+    rope = Gemma4RotaryEmbedding.from_config(tiny_config, layer_idx)
+    cos, sin = rope(mx.arange(seq_len)[None])
+    window = tiny_config.sliding_window if tiny_config.layer_is_sliding(layer_idx) else None
+    mask = build_attention_mask(seq_len, sliding_window=window)
+
+    got = attn(mx.array(ref[f"L{layer_idx}.attn_in"]), cos, sin, mask)
+
+    assert _max_abs_diff(got, ref[f"L{layer_idx}.attn_out"]) < PARITY_ATOL
+
+
+@pytest.mark.slow
+@_needs_parity_npz
+@pytest.mark.parametrize("layer_idx", [0, 1])
+def test_mlp_matches_reference(ref, tiny_config, layer_idx):
+    """The gated gelu_pytorch_tanh MLP matches the reference block output."""
+    import mlx.core as mx
+
+    from ltx_core_mlx.text_encoders.gemma.gemma4 import Gemma4MLP
+
+    mlp = Gemma4MLP(tiny_config)
+    prefix = f"w.layers.{layer_idx}.mlp."
+    mlp.load_weights([(key[len(prefix) :], mx.array(value)) for key, value in ref.items() if key.startswith(prefix)])
+
+    got = mlp(mx.array(ref[f"L{layer_idx}.mlp_in"]))
+
+    assert _max_abs_diff(got, ref[f"L{layer_idx}.mlp_out"]) < PARITY_ATOL

--- a/tests/test_ltx25_gemma4.py
+++ b/tests/test_ltx25_gemma4.py
@@ -809,3 +809,230 @@ def test_gemma4_tokenizer_matches_pack_reference_ids(ref):
     got_ids = ids_np[max_length - num_real :].tolist()
 
     assert got_ids == want_ids
+
+
+# --- select_text_encoder / check_gemma_version (Task 5: evidence-based configurator) ---
+
+
+def _write_json(path: Path, data: dict) -> None:
+    import json
+
+    with open(path, "w") as f:
+        json.dump(data, f)
+
+
+class TestSelectTextEncoder:
+    """``select_text_encoder`` keys purely off file presence in ``model_dir``."""
+
+    def test_both_files_present_selects_gemma4(self, tmp_path):
+        from ltx_core_mlx.text_encoders.gemma.encoders.encoder_configurator import select_text_encoder
+
+        (tmp_path / "text_encoder.safetensors").touch()
+        _write_json(tmp_path / "text_encoder_config.json", {"gemma_version": "gemma4-12b-ltx-v1"})
+
+        assert select_text_encoder(tmp_path) == "gemma4"
+
+    def test_only_weights_present_selects_gemma3(self, tmp_path):
+        from ltx_core_mlx.text_encoders.gemma.encoders.encoder_configurator import select_text_encoder
+
+        (tmp_path / "text_encoder.safetensors").touch()
+
+        assert select_text_encoder(tmp_path) == "gemma3"
+
+    def test_only_config_present_selects_gemma3(self, tmp_path):
+        from ltx_core_mlx.text_encoders.gemma.encoders.encoder_configurator import select_text_encoder
+
+        _write_json(tmp_path / "text_encoder_config.json", {"gemma_version": "gemma4-12b-ltx-v1"})
+
+        assert select_text_encoder(tmp_path) == "gemma3"
+
+    def test_neither_present_selects_gemma3(self, tmp_path):
+        from ltx_core_mlx.text_encoders.gemma.encoders.encoder_configurator import select_text_encoder
+
+        assert select_text_encoder(tmp_path) == "gemma3"
+
+    @pytest.mark.skipif(LTX25_Q8_DIR is None, reason="local ltx-2.5-mlx-q8 pack not found")
+    def test_real_pack_selects_gemma4_without_raising(self):
+        """The real pack has no ``gemma_source_checkpoint`` in embedded_config.json,
+        so selection must succeed without the version guard raising."""
+        from ltx_core_mlx.text_encoders.gemma.encoders.encoder_configurator import select_text_encoder
+
+        assert select_text_encoder(LTX25_Q8_DIR) == "gemma4"
+
+
+class TestCheckGemmaVersion:
+    """Mirrors upstream ``_check_gemma_version``, scoped to the mismatch case only."""
+
+    def _make_pack(self, tmp_path: Path, *, embedded_config: dict | None, tower_gemma_version: str | None) -> Path:
+        (tmp_path / "text_encoder.safetensors").touch()
+        _write_json(tmp_path / "text_encoder_config.json", {"gemma_version": tower_gemma_version})
+        if embedded_config is not None:
+            _write_json(tmp_path / "embedded_config.json", embedded_config)
+        return tmp_path
+
+    def test_mismatched_version_raises(self, tmp_path):
+        from ltx_core_mlx.text_encoders.gemma.encoders.encoder_configurator import select_text_encoder
+
+        pack = self._make_pack(
+            tmp_path,
+            embedded_config={"gemma_source_checkpoint": {"gemma_version": "gemma4-12b-ltx-v1"}},
+            tower_gemma_version="some-other-version",
+        )
+
+        with pytest.raises(ValueError, match="Gemma version mismatch"):
+            select_text_encoder(pack)
+
+    def test_matching_version_passes(self, tmp_path):
+        from ltx_core_mlx.text_encoders.gemma.encoders.encoder_configurator import select_text_encoder
+
+        pack = self._make_pack(
+            tmp_path,
+            embedded_config={"gemma_source_checkpoint": {"gemma_version": "gemma4-12b-ltx-v1"}},
+            tower_gemma_version="gemma4-12b-ltx-v1",
+        )
+
+        assert select_text_encoder(pack) == "gemma4"
+
+    def test_no_declaration_passes_unchecked(self, tmp_path):
+        """embedded_config.json present but with no gemma_source_checkpoint key at all
+        (the real LTX-2.5 pack's shape) -- no check performed, no raise."""
+        from ltx_core_mlx.text_encoders.gemma.encoders.encoder_configurator import select_text_encoder
+
+        pack = self._make_pack(
+            tmp_path,
+            embedded_config={"transformer": {}, "scheduler": {}},
+            tower_gemma_version="gemma4-12b-ltx-v1",
+        )
+
+        assert select_text_encoder(pack) == "gemma4"
+
+    def test_no_embedded_config_file_passes_unchecked(self, tmp_path):
+        """No embedded_config.json at all -- no check performed, no raise."""
+        from ltx_core_mlx.text_encoders.gemma.encoders.encoder_configurator import select_text_encoder
+
+        pack = self._make_pack(tmp_path, embedded_config=None, tower_gemma_version="gemma4-12b-ltx-v1")
+
+        assert select_text_encoder(pack) == "gemma4"
+
+
+class TestPromptEncoderWiring:
+    """Proves the 2.3 (gemma3) construction site is untouched and the selection is real."""
+
+    def _stub_feature_extractor_deps(self, monkeypatch):
+        """Neutralize the connector-loading half of PromptEncoder.load() so these
+        tests exercise only the text-encoder selection/construction branch."""
+        import types
+
+        from ltx_pipelines_mlx.utils import blocks as blocks_mod
+
+        monkeypatch.setattr(
+            blocks_mod.LTXModelConfig,
+            "from_checkpoint_dir",
+            classmethod(lambda cls, model_dir: types.SimpleNamespace(double_precision_rope=False)),
+        )
+        monkeypatch.setattr(blocks_mod, "load_split_safetensors", lambda path, prefix="": {})
+
+        class _DummyConnector:
+            def load_weights(self, weights):
+                pass
+
+        class _DummyFeatureExtractor:
+            def __init__(self, double_precision_rope: bool) -> None:
+                self.double_precision_rope = double_precision_rope
+                self.connector = _DummyConnector()
+
+        monkeypatch.setattr(blocks_mod, "GemmaFeaturesExtractorV2", _DummyFeatureExtractor)
+        return blocks_mod
+
+    def test_gemma3_path_never_constructs_gemma4_text_encoder(self, tmp_path, monkeypatch):
+        from ltx_core_mlx.text_encoders.gemma.encoders import gemma4_encoder as gemma4_encoder_mod
+        from ltx_pipelines_mlx.utils.blocks import PromptEncoder
+
+        blocks_mod = self._stub_feature_extractor_deps(monkeypatch)
+
+        # tmp_path has neither text_encoder.safetensors nor text_encoder_config.json
+        # -> select_text_encoder(tmp_path) == "gemma3".
+        select_calls = []
+        real_select = blocks_mod.select_text_encoder
+
+        def _spy_select(model_dir):
+            select_calls.append(model_dir)
+            return real_select(model_dir)
+
+        monkeypatch.setattr(blocks_mod, "select_text_encoder", _spy_select)
+
+        class _BlowUpIfConstructed:
+            def __init__(self, *args, **kwargs):
+                raise AssertionError("Gemma4TextEncoder must not be constructed on the gemma3 path")
+
+        monkeypatch.setattr(gemma4_encoder_mod, "Gemma4TextEncoder", _BlowUpIfConstructed)
+
+        class _DummyGemma3:
+            load_called_with = None
+
+            def load(self, gemma_model_id):
+                type(self).load_called_with = gemma_model_id
+
+        monkeypatch.setattr(blocks_mod, "GemmaLanguageModel", _DummyGemma3)
+
+        encoder = PromptEncoder(model_dir=tmp_path, gemma_model_id="mlx-community/gemma-3-12b-it-4bit")
+        encoder.load()
+
+        # (d) select_text_encoder is actually called by the construction site.
+        assert select_calls == [encoder.model_dir]
+        # (c) the gemma3 branch ran -- existing GemmaLanguageModel path used.
+        assert isinstance(encoder._text_encoder, _DummyGemma3)
+        assert _DummyGemma3.load_called_with == "mlx-community/gemma-3-12b-it-4bit"
+
+    def test_gemma4_path_constructs_gemma4_text_encoder(self, tmp_path, monkeypatch):
+        from ltx_pipelines_mlx.utils.blocks import PromptEncoder
+
+        blocks_mod = self._stub_feature_extractor_deps(monkeypatch)
+
+        (tmp_path / "text_encoder.safetensors").touch()
+        _write_json(tmp_path / "text_encoder_config.json", {"gemma_version": "gemma4-12b-ltx-v1"})
+
+        class _DummyGemma4:
+            load_called_with = None
+
+            def load(self, model_dir):
+                type(self).load_called_with = model_dir
+
+        import ltx_core_mlx.text_encoders.gemma.encoders.gemma4_encoder as gemma4_encoder_mod
+
+        monkeypatch.setattr(gemma4_encoder_mod, "Gemma4TextEncoder", _DummyGemma4)
+
+        class _BlowUpIfConstructed:
+            def __init__(self, *args, **kwargs):
+                raise AssertionError("GemmaLanguageModel must not be constructed on the gemma4 path")
+
+        monkeypatch.setattr(blocks_mod, "GemmaLanguageModel", _BlowUpIfConstructed)
+
+        encoder = PromptEncoder(model_dir=tmp_path, gemma_model_id="mlx-community/gemma-3-12b-it-4bit")
+        encoder.load()
+
+        assert isinstance(encoder._text_encoder, _DummyGemma4)
+        assert _DummyGemma4.load_called_with == encoder.model_dir
+
+
+class TestEnhanceGemma4Guard:
+    """``enhance`` must fail clearly, not obscurely, when pointed at a Gemma 4 pack."""
+
+    def test_guard_raises_on_local_gemma4_pack(self, tmp_path):
+        from ltx_pipelines_mlx.cli import _guard_enhance_not_gemma4
+
+        (tmp_path / "text_encoder.safetensors").touch()
+        _write_json(tmp_path / "text_encoder_config.json", {"gemma_version": "gemma4-12b-ltx-v1"})
+
+        with pytest.raises(NotImplementedError, match=r"not supported for LTX-2\.5"):
+            _guard_enhance_not_gemma4(str(tmp_path))
+
+    def test_guard_passes_on_local_gemma3_pack(self, tmp_path):
+        from ltx_pipelines_mlx.cli import _guard_enhance_not_gemma4
+
+        _guard_enhance_not_gemma4(str(tmp_path))  # no raise
+
+    def test_guard_passes_on_nonexistent_path_hf_id(self):
+        from ltx_pipelines_mlx.cli import _guard_enhance_not_gemma4
+
+        _guard_enhance_not_gemma4("mlx-community/gemma-3-12b-it-4bit")  # no raise, path doesn't exist locally

--- a/tests/test_ltx25_gemma4.py
+++ b/tests/test_ltx25_gemma4.py
@@ -6,6 +6,7 @@ parses the real pack when available (``LTX25_Q8_DIR``).
 """
 
 from pathlib import Path
+from typing import ClassVar
 
 import mlx.core as mx
 import numpy as np
@@ -206,6 +207,45 @@ def test_rejects_wrong_model_type():
         Gemma4TextConfig.from_text_encoder_config(bad)
 
 
+def test_rejects_wrong_root_model_type():
+    """Root-level model_type (config["model_type"], sibling of text_config) must
+    also be gemma4_unified -- distinct from text_config.model_type checked above."""
+    import copy
+
+    from ltx_core_mlx.text_encoders.gemma.gemma4_config import Gemma4TextConfig
+
+    bad = copy.deepcopy(_FULL_CONFIG)
+    bad["model_type"] = "gemma3"
+    with pytest.raises(ValueError, match="model_type"):
+        Gemma4TextConfig.from_text_encoder_config(bad)
+
+
+def test_rejects_flipped_sliding_rope_type():
+    """A pack with sliding_attention.rope_type != "default" parses fine under
+    every other check (same keys, same types) and would silently compute wrong
+    rotary tables -- must be caught explicitly."""
+    import copy
+
+    from ltx_core_mlx.text_encoders.gemma.gemma4_config import Gemma4TextConfig
+
+    bad = copy.deepcopy(_FULL_CONFIG)
+    bad["text_config"]["rope_parameters"]["sliding_attention"]["rope_type"] = "proportional"
+    with pytest.raises(ValueError, match=r"rope_parameters\.sliding_attention\.rope_type"):
+        Gemma4TextConfig.from_text_encoder_config(bad)
+
+
+def test_rejects_flipped_full_attention_rope_type():
+    """Mirror of the sliding-side guard, for full_attention.rope_type != "proportional"."""
+    import copy
+
+    from ltx_core_mlx.text_encoders.gemma.gemma4_config import Gemma4TextConfig
+
+    bad = copy.deepcopy(_FULL_CONFIG)
+    bad["text_config"]["rope_parameters"]["full_attention"]["rope_type"] = "default"
+    with pytest.raises(ValueError, match=r"rope_parameters\.full_attention\.rope_type"):
+        Gemma4TextConfig.from_text_encoder_config(bad)
+
+
 def test_defaults_when_fields_absent():
     """use_bidirectional_attention, attention_k_eq_v, num_kv_shared_layers
     default per the HF configuration_gemma4_unified.py reference."""
@@ -285,6 +325,7 @@ _needs_parity_npz = pytest.mark.skipif(
 # JSON shape so Gemma4TextConfig parses it.
 _TINY_PACK_CONFIG = {
     "gemma_version": "tiny-parity",
+    "model_type": "gemma4_unified",
     "text_config": {
         "model_type": "gemma4_unified_text",
         "vocab_size": 128,
@@ -916,11 +957,36 @@ class TestCheckGemmaVersion:
 
 
 class TestPromptEncoderWiring:
-    """Proves the 2.3 (gemma3) construction site is untouched and the selection is real."""
+    """Proves the 2.3 (gemma3) construction site is untouched and the selection is real.
+
+    ``_stub_feature_extractor_deps`` fakes ``load_split_safetensors`` with a
+    prefix-keyed recorder (rather than a blanket ``{}``) so these tests stay
+    load-bearing against the gemma4 ``text_embedding_projection`` merge
+    (commit 8bc5640): a stub that ignores ``prefix`` would go on returning
+    the same ``{}`` even if that merge were reverted, and both spy tests
+    below would stay green while the real load path silently regressed.
+    """
+
+    _CONNECTOR_WEIGHTS: ClassVar[dict[str, str]] = {
+        "connector.video_embeddings_connector.some.weight": "CONNECTOR_TENSOR"
+    }
+    _PROJECTION_WEIGHTS: ClassVar[dict[str, str]] = {
+        "video_aggregate_embed.weight": "VIDEO_AGG_W",
+        "video_aggregate_embed.bias": "VIDEO_AGG_B",
+        "audio_aggregate_embed.weight": "AUDIO_AGG_W",
+        "audio_aggregate_embed.bias": "AUDIO_AGG_B",
+    }
 
     def _stub_feature_extractor_deps(self, monkeypatch):
         """Neutralize the connector-loading half of PromptEncoder.load() so these
-        tests exercise only the text-encoder selection/construction branch."""
+        tests exercise only the text-encoder selection/construction branch --
+        while still recording every ``load_split_safetensors`` call (path, prefix)
+        and returning prefix-appropriate fake weights, so callers can assert on
+        exactly which safetensors files got merged into the connector.
+
+        Returns ``(blocks_mod, load_calls)``: ``load_calls`` accumulates
+        ``(path, prefix)`` tuples in call order.
+        """
         import types
 
         from ltx_pipelines_mlx.utils import blocks as blocks_mod
@@ -930,11 +996,25 @@ class TestPromptEncoderWiring:
             "from_checkpoint_dir",
             classmethod(lambda cls, model_dir: types.SimpleNamespace(double_precision_rope=False)),
         )
-        monkeypatch.setattr(blocks_mod, "load_split_safetensors", lambda path, prefix="": {})
+
+        load_calls: list[tuple[Path, str]] = []
+
+        def _stub_load_split_safetensors(path, prefix=""):
+            load_calls.append((path, prefix))
+            if prefix == "connector.":
+                return dict(self._CONNECTOR_WEIGHTS)
+            if prefix == "text_encoder.text_embedding_projection.":
+                return dict(self._PROJECTION_WEIGHTS)
+            raise AssertionError(f"unexpected load_split_safetensors call: path={path!r} prefix={prefix!r}")
+
+        monkeypatch.setattr(blocks_mod, "load_split_safetensors", _stub_load_split_safetensors)
 
         class _DummyConnector:
+            def __init__(self) -> None:
+                self.load_weights_called_with: dict | None = None
+
             def load_weights(self, weights):
-                pass
+                self.load_weights_called_with = dict(weights)
 
         class _DummyFeatureExtractor:
             def __init__(self, double_precision_rope: bool) -> None:
@@ -942,13 +1022,13 @@ class TestPromptEncoderWiring:
                 self.connector = _DummyConnector()
 
         monkeypatch.setattr(blocks_mod, "GemmaFeaturesExtractorV2", _DummyFeatureExtractor)
-        return blocks_mod
+        return blocks_mod, load_calls
 
     def test_gemma3_path_never_constructs_gemma4_text_encoder(self, tmp_path, monkeypatch):
         from ltx_core_mlx.text_encoders.gemma.encoders import gemma4_encoder as gemma4_encoder_mod
         from ltx_pipelines_mlx.utils.blocks import PromptEncoder
 
-        blocks_mod = self._stub_feature_extractor_deps(monkeypatch)
+        blocks_mod, load_calls = self._stub_feature_extractor_deps(monkeypatch)
 
         # tmp_path has neither text_encoder.safetensors nor text_encoder_config.json
         # -> select_text_encoder(tmp_path) == "gemma3".
@@ -984,10 +1064,16 @@ class TestPromptEncoderWiring:
         assert isinstance(encoder._text_encoder, _DummyGemma3)
         assert _DummyGemma3.load_called_with == "mlx-community/gemma-3-12b-it-4bit"
 
+        # F1: the gemma3 path must call load_split_safetensors exactly once,
+        # for connector.safetensors only -- no text_encoder.safetensors
+        # projection merge (that file doesn't even exist on this path).
+        assert load_calls == [(encoder.model_dir / "connector.safetensors", "connector.")]
+        assert encoder._feature_extractor.connector.load_weights_called_with == self._CONNECTOR_WEIGHTS
+
     def test_gemma4_path_constructs_gemma4_text_encoder(self, tmp_path, monkeypatch):
         from ltx_pipelines_mlx.utils.blocks import PromptEncoder
 
-        blocks_mod = self._stub_feature_extractor_deps(monkeypatch)
+        blocks_mod, load_calls = self._stub_feature_extractor_deps(monkeypatch)
 
         (tmp_path / "text_encoder.safetensors").touch()
         _write_json(tmp_path / "text_encoder_config.json", {"gemma_version": "gemma4-12b-ltx-v1"})
@@ -1013,6 +1099,24 @@ class TestPromptEncoderWiring:
 
         assert isinstance(encoder._text_encoder, _DummyGemma4)
         assert _DummyGemma4.load_called_with == encoder.model_dir
+
+        # F1 (commit 8bc5640 pin): the gemma4 path must merge weights from
+        # TWO files -- connector.safetensors AND the tower's
+        # text_encoder.safetensors under the projection prefix -- in that
+        # order, and hand the connector all of it re-prefixed correctly.
+        assert load_calls == [
+            (encoder.model_dir / "connector.safetensors", "connector."),
+            (encoder.model_dir / "text_encoder.safetensors", "text_encoder.text_embedding_projection."),
+        ]
+
+        merged = encoder._feature_extractor.connector.load_weights_called_with
+        assert merged is not None
+        expected_projection_keys = {f"text_embedding_projection.{k}" for k in self._PROJECTION_WEIGHTS}
+        assert expected_projection_keys <= merged.keys()
+        for k, v in self._PROJECTION_WEIGHTS.items():
+            assert merged[f"text_embedding_projection.{k}"] == v
+        # Original connector.safetensors weights must survive the merge too.
+        assert self._CONNECTOR_WEIGHTS.keys() <= merged.keys()
 
 
 class TestEnhanceGemma4Guard:

--- a/tests/test_ltx25_gemma4.py
+++ b/tests/test_ltx25_gemma4.py
@@ -453,3 +453,177 @@ def test_mlp_matches_reference(ref, tiny_config, layer_idx):
     got = mlp(mx.array(ref[f"L{layer_idx}.mlp_in"]))
 
     assert _max_abs_diff(got, ref[f"L{layer_idx}.mlp_out"]) < PARITY_ATOL
+
+
+# ---------------------------------------------------------------------------
+# Full-tower assembly (Gemma4TextModel): embeddings + N layers + final norm.
+# ---------------------------------------------------------------------------
+
+
+def _load_tiny_tower(ref, tiny_config):
+    """Build a Gemma4TextModel matching the tiny reference config and load
+    its weights from the reference npz's ``w.*`` state dict."""
+    import mlx.core as mx
+
+    from ltx_core_mlx.text_encoders.gemma.gemma4 import Gemma4TextModel
+
+    tower = Gemma4TextModel(tiny_config)
+    weights = [(key[2:], mx.array(value)) for key, value in ref.items() if key.startswith("w.")]
+    tower.load_weights(weights)
+    return tower
+
+
+@pytest.mark.slow
+@_needs_parity_npz
+def test_tower_matches_reference_hidden_states(ref, tiny_config):
+    """embed_tokens (x sqrt(hidden)) + both layers reproduce hs.0/hs.1/hs.2."""
+    import mlx.core as mx
+
+    tower = _load_tiny_tower(ref, tiny_config)
+
+    got = tower(mx.array(ref["input_ids"]))
+
+    assert len(got) == tiny_config.num_hidden_layers + 1 == 3
+    for i, hs in enumerate(got):
+        assert _max_abs_diff(hs, ref[f"hs.{i}"]) < PARITY_ATOL
+
+
+@pytest.mark.slow
+@_needs_parity_npz
+def test_tower_final_norm_matches_reference(ref, tiny_config):
+    """self.norm applied to the last hidden state reproduces hs.final."""
+    import mlx.core as mx
+
+    tower = _load_tiny_tower(ref, tiny_config)
+
+    got = tower(mx.array(ref["input_ids"]))
+    final = tower.norm(got[-1])
+
+    assert _max_abs_diff(final, ref["hs.final"]) < PARITY_ATOL
+
+
+@pytest.mark.slow
+@_needs_parity_npz
+def test_tower_matches_reference_padded_batch(ref, tiny_config):
+    """Left-padded batch (row 0 padded, row 1 not): padding_mask path.
+
+    Padded query positions can legitimately diverge (an all-masked softmax
+    row is undefined in both frameworks), so only real (non-padded) token
+    positions are compared.
+    """
+    import mlx.core as mx
+    import numpy as np
+
+    tower = _load_tiny_tower(ref, tiny_config)
+
+    input_ids = mx.array(ref["padded.input_ids"])
+    attention_mask = mx.array(ref["padded.attention_mask"])
+    valid = np.asarray(ref["padded.attention_mask"]) != 0  # (B, T)
+
+    got = tower(input_ids, attention_mask=attention_mask)
+
+    assert len(got) == tiny_config.num_hidden_layers + 1 == 3
+    for i, hs in enumerate(got):
+        got_np = np.array(mx.array(hs).astype(mx.float32))
+        want_np = ref[f"padded.hs.{i}"]
+        diff = np.abs(got_np - want_np)[valid]
+        assert float(diff.max()) < PARITY_ATOL
+
+    final = tower.norm(got[-1])
+    final_np = np.array(mx.array(final).astype(mx.float32))
+    want_final = ref["padded.hs.final"]
+    diff = np.abs(final_np - want_final)[valid]
+    assert float(diff.max()) < PARITY_ATOL
+
+
+# ---------------------------------------------------------------------------
+# Load contract: the fail-loud allowlist logic, tested against synthetic
+# key sets (fast -- no pack access needed).
+# ---------------------------------------------------------------------------
+
+
+def test_pack_ignore_allowlist_has_exactly_15_entries():
+    from ltx_core_mlx.text_encoders.gemma.gemma4 import GEMMA4_PACK_IGNORE_ALLOWLIST
+
+    assert len(GEMMA4_PACK_IGNORE_ALLOWLIST) == 15
+    assert all(
+        k.startswith("text_encoder.") and not k.startswith("text_encoder.model.") for k in GEMMA4_PACK_IGNORE_ALLOWLIST
+    )
+
+
+def test_load_from_pack_rejects_stray_keys(tmp_path):
+    """A key neither under the model prefix nor in the allowlist must fail loudly."""
+    import json
+    import struct
+
+    from ltx_core_mlx.text_encoders.gemma.gemma4 import Gemma4TextModel
+
+    text_config = _TINY_PACK_CONFIG["text_config"]
+    (tmp_path / "text_encoder_config.json").write_text(json.dumps(_TINY_PACK_CONFIG))
+
+    header = {
+        "text_encoder.model.embed_tokens.weight": {
+            "dtype": "F32",
+            "shape": [text_config["vocab_size"], text_config["hidden_size"]],
+            "data_offsets": [0, 0],
+        },
+        "text_encoder.bogus_new_component.weight": {
+            "dtype": "F32",
+            "shape": [1],
+            "data_offsets": [0, 0],
+        },
+    }
+    header_bytes = json.dumps(header).encode("utf-8")
+    with open(tmp_path / "text_encoder.safetensors", "wb") as f:
+        f.write(struct.pack("<Q", len(header_bytes)))
+        f.write(header_bytes)
+
+    with pytest.raises(ValueError, match=r"text_encoder\.bogus_new_component\.weight"):
+        Gemma4TextModel.load_from_pack(tmp_path)
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(LTX25_Q8_DIR is None, reason="local ltx-2.5-mlx-q8 pack not found")
+def test_25_gemma4_config_covers_every_pack_tensor():
+    """Mirrors tests/test_ltx25_load_contract.py: two-direction key check
+    against the real q8 pack, without materializing the 16 GB of weights.
+
+    ``mx.load`` mmaps without materializing, and ``Gemma4TextModel(config)``
+    only allocates a lazy parameter tree -- shapes are known without
+    evaluating, so this stays cheap even for the real 12B-param tower.
+    """
+    import json
+
+    from mlx.utils import tree_flatten
+
+    from ltx_core_mlx.text_encoders.gemma.gemma4 import (
+        GEMMA4_PACK_IGNORE_ALLOWLIST,
+        Gemma4TextModel,
+        _safetensors_header_keys,
+    )
+    from ltx_core_mlx.text_encoders.gemma.gemma4_config import Gemma4TextConfig
+
+    with open(LTX25_Q8_DIR / "text_encoder_config.json") as f:
+        raw_config = json.load(f)
+    config = Gemma4TextConfig.from_text_encoder_config(raw_config)
+    model = Gemma4TextModel(config)
+
+    model_keys = {f"text_encoder.model.{k}" for k, _ in tree_flatten(model.parameters())}
+
+    pack = _safetensors_header_keys(LTX25_Q8_DIR / "text_encoder.safetensors")
+    pack_model = {k for k in pack if k.startswith("text_encoder.model.")}
+    pack_other = pack - pack_model
+
+    assert pack_other == GEMMA4_PACK_IGNORE_ALLOWLIST
+
+    # Quantized layers save weight/scales/biases separately; normalize back
+    # onto a single ".weight" entry, same convention as the DiT contract.
+    pack_normalized = {
+        k.removesuffix(".scales").removesuffix(".biases") + ".weight" if k.endswith((".scales", ".biases")) else k
+        for k in pack_model
+    }
+    missing_in_model = sorted(pack_normalized - model_keys)
+    unfed_params = sorted(model_keys - pack_normalized)
+    assert not missing_in_model, f"pack tensors nobody would load: {missing_in_model[:10]}"
+    assert not unfed_params, f"model params the pack does not feed: {unfed_params[:10]}"
+    assert len(pack_normalized) == 666

--- a/tests/test_ltx25_gemma4.py
+++ b/tests/test_ltx25_gemma4.py
@@ -1,0 +1,258 @@
+"""Tests for Gemma4TextConfig parsing (LTX-2.5 text tower config).
+
+Covers a truncated-but-representative literal dict mirroring the shape of
+the real ``text_encoder_config.json`` pack file, plus a slow test that
+parses the real pack when available (``LTX25_Q8_DIR``).
+"""
+
+import pytest
+
+from tests.conftest import LTX25_Q8_DIR
+
+# Truncated literal mirroring the real pack's text_encoder_config.json
+# shape (48 layers -> collapsed to a smaller layer_types list here, since
+# Gemma4TextConfig must work off whatever layer_types length the config
+# provides -- num_hidden_layers is read separately).
+_FULL_CONFIG = {
+    "gemma_version": "gemma4-12b-ltx-v1",
+    "model_type": "gemma4_unified",
+    "text_config": {
+        "model_type": "gemma4_unified_text",
+        "attention_k_eq_v": True,
+        "global_head_dim": 512,
+        "head_dim": 256,
+        "hidden_size": 3840,
+        "intermediate_size": 15360,
+        "num_attention_heads": 16,
+        "num_global_key_value_heads": 1,
+        "num_hidden_layers": 48,
+        "num_key_value_heads": 8,
+        "num_kv_shared_layers": 0,
+        "pad_token_id": 0,
+        "rms_norm_eps": 1e-06,
+        "sliding_window": 1024,
+        "use_bidirectional_attention": "vision",
+        "vocab_size": 262144,
+        "layer_types": [
+            "sliding_attention",
+            "sliding_attention",
+            "sliding_attention",
+            "sliding_attention",
+            "sliding_attention",
+            "full_attention",
+            "sliding_attention",
+            "sliding_attention",
+            "sliding_attention",
+            "sliding_attention",
+            "sliding_attention",
+            "full_attention",
+            "sliding_attention",
+            "sliding_attention",
+            "sliding_attention",
+            "sliding_attention",
+            "sliding_attention",
+            "full_attention",
+            "sliding_attention",
+            "sliding_attention",
+            "sliding_attention",
+            "sliding_attention",
+            "sliding_attention",
+            "full_attention",
+            "sliding_attention",
+            "sliding_attention",
+            "sliding_attention",
+            "sliding_attention",
+            "sliding_attention",
+            "full_attention",
+            "sliding_attention",
+            "sliding_attention",
+            "sliding_attention",
+            "sliding_attention",
+            "sliding_attention",
+            "full_attention",
+            "sliding_attention",
+            "sliding_attention",
+            "sliding_attention",
+            "sliding_attention",
+            "sliding_attention",
+            "full_attention",
+            "sliding_attention",
+            "sliding_attention",
+            "sliding_attention",
+            "sliding_attention",
+            "sliding_attention",
+            "full_attention",
+        ],
+        "rope_parameters": {
+            "full_attention": {
+                "partial_rotary_factor": 0.25,
+                "rope_theta": 1000000.0,
+                "rope_type": "proportional",
+            },
+            "sliding_attention": {
+                "rope_theta": 10000.0,
+                "rope_type": "default",
+            },
+        },
+    },
+}
+
+_FULL_ATTENTION_INDICES = [5, 11, 17, 23, 29, 35, 41, 47]
+
+
+def _config_with(**text_config_overrides):
+    import copy
+
+    cfg = copy.deepcopy(_FULL_CONFIG)
+    cfg["text_config"].update(text_config_overrides)
+    return cfg
+
+
+def test_parses_basic_fields():
+    from ltx_core_mlx.text_encoders.gemma.gemma4_config import Gemma4TextConfig
+
+    config = Gemma4TextConfig.from_text_encoder_config(_FULL_CONFIG)
+
+    assert config.gemma_version == "gemma4-12b-ltx-v1"
+    assert config.hidden_size == 3840
+    assert config.num_hidden_layers == 48
+    assert config.num_attention_heads == 16
+    assert config.head_dim == 256
+    assert config.global_head_dim == 512
+    assert config.num_key_value_heads == 8
+    assert config.num_global_key_value_heads == 1
+    assert config.intermediate_size == 15360
+    assert config.vocab_size == 262144
+    assert config.rms_norm_eps == 1e-06
+    assert config.sliding_window == 1024
+    assert config.attention_k_eq_v is True
+    assert config.pad_token_id == 0
+    assert len(config.layer_types) == 48
+    assert isinstance(config.layer_types, tuple)
+
+
+def test_parses_rope_params_per_attention_type():
+    from ltx_core_mlx.text_encoders.gemma.gemma4_config import Gemma4TextConfig
+
+    config = Gemma4TextConfig.from_text_encoder_config(_FULL_CONFIG)
+
+    assert config.rope_local_theta == 10000.0
+    assert config.rope_global_theta == 1000000.0
+    assert config.partial_rotary_factor == 0.25
+
+
+def test_full_attention_layer_indices():
+    from ltx_core_mlx.text_encoders.gemma.gemma4_config import Gemma4TextConfig
+
+    config = Gemma4TextConfig.from_text_encoder_config(_FULL_CONFIG)
+
+    full_indices = [i for i in range(config.num_hidden_layers) if not config.layer_is_sliding(i)]
+    assert full_indices == _FULL_ATTENTION_INDICES
+
+
+def test_layer_is_sliding():
+    from ltx_core_mlx.text_encoders.gemma.gemma4_config import Gemma4TextConfig
+
+    config = Gemma4TextConfig.from_text_encoder_config(_FULL_CONFIG)
+
+    assert config.layer_is_sliding(0) is True
+    assert config.layer_is_sliding(5) is False
+
+
+def test_layer_head_dim_by_type():
+    from ltx_core_mlx.text_encoders.gemma.gemma4_config import Gemma4TextConfig
+
+    config = Gemma4TextConfig.from_text_encoder_config(_FULL_CONFIG)
+
+    assert config.layer_head_dim(0) == 256  # sliding
+    assert config.layer_head_dim(5) == 512  # full
+
+
+def test_layer_num_kv_by_type():
+    from ltx_core_mlx.text_encoders.gemma.gemma4_config import Gemma4TextConfig
+
+    config = Gemma4TextConfig.from_text_encoder_config(_FULL_CONFIG)
+
+    assert config.layer_num_kv(0) == 8  # sliding
+    assert config.layer_num_kv(5) == 1  # full
+
+
+def test_rejects_num_kv_shared_layers_nonzero():
+    from ltx_core_mlx.text_encoders.gemma.gemma4_config import Gemma4TextConfig
+
+    bad = _config_with(num_kv_shared_layers=1)
+    with pytest.raises(ValueError, match="num_kv_shared_layers"):
+        Gemma4TextConfig.from_text_encoder_config(bad)
+
+
+def test_rejects_bidirectional_attention_all():
+    from ltx_core_mlx.text_encoders.gemma.gemma4_config import Gemma4TextConfig
+
+    bad = _config_with(use_bidirectional_attention="all")
+    with pytest.raises(ValueError, match="use_bidirectional_attention"):
+        Gemma4TextConfig.from_text_encoder_config(bad)
+
+
+def test_rejects_wrong_model_type():
+    from ltx_core_mlx.text_encoders.gemma.gemma4_config import Gemma4TextConfig
+
+    bad = _config_with(model_type="gemma3_text")
+    with pytest.raises(ValueError, match="model_type"):
+        Gemma4TextConfig.from_text_encoder_config(bad)
+
+
+def test_defaults_when_fields_absent():
+    """use_bidirectional_attention, attention_k_eq_v, num_kv_shared_layers
+    default per the HF configuration_gemma4_unified.py reference."""
+    import copy
+
+    from ltx_core_mlx.text_encoders.gemma.gemma4_config import Gemma4TextConfig
+
+    cfg = copy.deepcopy(_FULL_CONFIG)
+    del cfg["text_config"]["use_bidirectional_attention"]
+    del cfg["text_config"]["attention_k_eq_v"]
+    del cfg["text_config"]["num_kv_shared_layers"]
+
+    config = Gemma4TextConfig.from_text_encoder_config(cfg)
+
+    assert config.attention_k_eq_v is False
+
+
+def test_gemma_version_missing_is_none():
+    import copy
+
+    from ltx_core_mlx.text_encoders.gemma.gemma4_config import Gemma4TextConfig
+
+    cfg = copy.deepcopy(_FULL_CONFIG)
+    del cfg["gemma_version"]
+
+    config = Gemma4TextConfig.from_text_encoder_config(cfg)
+    assert config.gemma_version is None
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(LTX25_Q8_DIR is None, reason="local ltx-2.5-mlx-q8 pack not found")
+def test_parses_real_pack_text_encoder_config():
+    import json
+
+    from ltx_core_mlx.text_encoders.gemma.gemma4_config import Gemma4TextConfig
+
+    with open(LTX25_Q8_DIR / "text_encoder_config.json") as f:
+        raw = json.load(f)
+
+    config = Gemma4TextConfig.from_text_encoder_config(raw)
+
+    assert config.gemma_version == "gemma4-12b-ltx-v1"
+    assert config.num_hidden_layers == 48
+    full_indices = [i for i in range(config.num_hidden_layers) if not config.layer_is_sliding(i)]
+    assert full_indices == _FULL_ATTENTION_INDICES
+
+    assert config.layer_head_dim(0) == 256
+    assert config.layer_head_dim(5) == 512
+    assert config.layer_num_kv(0) == 8
+    assert config.layer_num_kv(5) == 1
+
+    assert config.rope_local_theta == 10000.0
+    assert config.rope_global_theta == 1000000.0
+    assert config.partial_rotary_factor == 0.25
+    assert config.attention_k_eq_v is True


### PR DESCRIPTION
PR 3/5 of the LTX-2.5 v1 series (spec 2026-08-23). A 2.5 pack's prompt can
now be encoded end-to-end: pack tokenizer → vendored Gemma-4 tower → 49
hidden states → the pack's connector — selected by checkpoint evidence, with
the 2.3/mlx-lm path byte-identical.

## Why a vendored tower

Upstream ltx-core delegates the tower to HF transformers
(`Gemma4UnifiedTextModel`); no mlx-lm release with gemma4 co-installs with
our mlx. The MLX tower is therefore written against the transformers
reference — genuinely new architecture, not Gemma-3 rebadged: 40 sliding
layers (256-dim heads, 8 KV, θ=1e4, window 1024) + 8 global layers (512-dim,
**1 KV**, θ=1e6 "proportional" rope with partial rotary 0.25, and
`k_eq_v`: no v_proj — V is the k_proj output through a scale-free RMSNorm).

## Proven, not assumed

- **Numerical parity vs torch**: a committed harness builds the HF reference
  on a tiny two-layer config (both layer types, k_eq_v) in a throwaway env
  (`uv run --no-project --with "transformers>=5.10,<6" --with torch`) — no
  project dependency added. Measured: blocks 1.31e-6, full tower 3.58e-7
  (budget 2e-5), including a genuinely left-padded batch.
- The harness caught two would-be bugs before they shipped: Gemma-4's
  RMSNorm applies plain `weight` (not Gemma-3's `1+weight`), and MLX's
  `nn.gelu_approx` is a sigmoid approximation (~3e-4) — an exact tanh-GELU
  is used instead.
- The padded-batch requirement caught a real cross-position leak: fully
  masked query rows produced NaN that poisoned valid positions through the
  k_eq_v value path (`0 × NaN`); fixed by mirroring HF's `_unmask_unattended`.
- **Hidden-states contract**: upstream consumes HF's tuple whose last entry
  is tied to the post-final-norm state — our encoder applies `tower.norm()`
  to entry −1 only, pinned by a mutation-verified test (fails if the norm is
  skipped, fails if over-applied). The #37 class, closed by construction.
- **Load contracts, both directions**: tower 666 tensors vs the real q8
  pack with an explicit 15-key ignore-allowlist (multimodal remnants +
  projection); the projection tensors live in `text_encoder.safetensors` in
  2.5 (they were in `connector.safetensors` in 2.3) — the plan predicted
  this trap, validation hit it, and the merge is spy-tested with
  revert-fails evidence.
- **E2E on the 32 GB machine**: q8 tower + connector encode produces
  `(1, 1024, 4096)` / `(1, 1024, 2048)`, bit-deterministic across runs,
  peak 20.18 GB.
- **2.3 untouched**: gemma4 imports are lazy (no transformers load on 2.3
  runs), the gemma3 branch is the pre-existing lines wrapped in `else:`,
  spies prove the wiring both directions, and the 2.3 SHA-gate render
  reproduces `1248862480…` exactly.

## Also

- System prompts `gemma4_{t2v,i2v}` copied verbatim from upstream,
  sha256-pinned. Applying them is a PR 5 decision (symmetric with 2.3).
- Tokenizer loaded from the pack (`tokenizer.json`), ids asserted identical
  to the pack tokenizer run on the torch side.
- `enhance` on a 2.5 pack raises a clear not-supported error instead of
  failing inside mlx-lm.
- Config guards reject silently-wrong packs: flipped rope types, foreign
  model_type, unported knobs (`num_kv_shared_layers`, bidirectional-all).

## Validation

741 non-slow + 19 slow (parity, contracts) passed; ruff clean. Follow-ups
parked in the execution ledger: prompt-relay EOS assertion when validated on
2.5, trainer/preprocess still 2.3-only (trainer slice), dense-mask/repeat_kv
perf (the diagonal unmask fix is load-bearing — not to be optimized away
casually).