### PR TITLE
feat(pipelines): wire the distilled pipeline for LTX-2.5 packs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -942,7 +942,7 @@ that path. 2.3 packs are byte-identical to before.
 - Stage 1: `euler_ancestral_denoising_loop` (`EulerAncestralDiffusionStep(eta=ANCESTRAL_ETA, s_noise=ANCESTRAL_S_NOISE)`, 8 steps) on `LTX_2_5_DISTILLED_SIGMAS`.
 - Stage 2: stays the deterministic Euler loop (`STAGE_2` renoise) on `LTX_2_5_STAGE_2_DISTILLED_SIGMAS`, matching upstream: *"Stage 2 is always deterministic — its 3-step refinement schedule is too short to remove freshly injected noise."*
 - Ancestral noise is seeded from `seed + ANCESTRAL_NOISE_SEED_OFFSET` (10000) to decorrelate from the initial-latent draw.
-- Stage 2 upscaler resolves to `spatial_upscaler_x2_v1_0.safetensors` (vs `x1_1` on 2.3), hard error if absent (#42 style).
+- Stage 2 upscaler resolves to `spatial_upscaler_x2_v1_0.safetensors` (vs `v1_1` on 2.3), falling back to the 2.3 stems; hard error only when none exists (#42 style).
 
 ### v1 limits (2.5 packs, `generate --distilled` only)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -926,6 +926,48 @@ End-to-end run on M2 Pro 32 GB, dev model + HDR LoRA fused, q8:
 
 ---
 
+## LTX-2.5 (Early Support)
+
+`generate --distilled --model <2.5-pack-dir>` runs end-to-end on a local
+LTX-2.5 pack. No new CLI flag — generation is auto-detected from the pack's
+`embedded_config.json` (`ff_bias is False` ⇔ 2.5) via
+`is_ltx25_pack()`/`LTXModelConfig.from_checkpoint_dir()`, resolved once in
+`DistilledPipeline.__init__` as `self._is_25`. The pack carries its own
+Gemma-4 text encoder (`text_encoder.safetensors` + `text_encoder_config.json`,
+selected by `select_text_encoder()`) — no `mlx-community` Gemma 3 download on
+that path. 2.3 packs are byte-identical to before.
+
+### Sampler
+
+- Stage 1: `euler_ancestral_denoising_loop` (`EulerAncestralDiffusionStep(eta=ANCESTRAL_ETA, s_noise=ANCESTRAL_S_NOISE)`, 8 steps) on `LTX_2_5_DISTILLED_SIGMAS`.
+- Stage 2: stays the deterministic Euler loop (`STAGE_2` renoise) on `LTX_2_5_STAGE_2_DISTILLED_SIGMAS`, matching upstream: *"Stage 2 is always deterministic — its 3-step refinement schedule is too short to remove freshly injected noise."*
+- Ancestral noise is seeded from `seed + ANCESTRAL_NOISE_SEED_OFFSET` (10000) to decorrelate from the initial-latent draw.
+- Stage 2 upscaler resolves to `spatial_upscaler_x2_v1_0.safetensors` (vs `x1_1` on 2.3), hard error if absent (#42 style).
+
+### v1 limits (2.5 packs, `generate --distilled` only)
+
+| Feature | Status |
+|---|---|
+| `--two-stage` / `--two-stages-hq` (dev model + CFG) | not yet supported |
+| `a2v`, `keyframe`, `ic-lora`, `hdr-ic-lora`, `retake`, `extend`, `lipdub` | not yet supported |
+| `enhance` / `--enhance-prompt` | raises `NotImplementedError` (`_guard_enhance_not_gemma4`) — Gemma 3 only |
+| `--enable-teacache` | raises `ValueError` — 2.3 polynomial isn't calibrated for 2.5 |
+| Modality tiling, Prompt Relay | validated on 2.3 only |
+| Diffusion (`DiffVAEMode`) VAE decoder | not loaded — conv `vae_decoder_conv` used (see Weight Format) |
+
+Further 2.5 pipelines (two-stage, a2v, keyframe, ic-lora, ...) land in
+subsequent releases behind the same pack-evidence detection.
+
+### Key Files
+
+- `packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/distilled.py` — `DistilledPipeline` (2.3/2.5 dispatch), `ANCESTRAL_*` constants.
+- `packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/utils/generation.py` — `is_ltx25_pack()`.
+- `packages/ltx-core-mlx/src/ltx_core_mlx/text_encoders/gemma/encoders/encoder_configurator.py` — `select_text_encoder()`, `check_gemma_version()`.
+- `packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ti2vid_two_stages.py` — `_resolve_upsampler_path()` (`_is_25` class attribute, default `False`).
+- `tests/test_ltx25_distilled.py` — routing, sigma-table, TeaCache-guard, upsampler-resolution tests.
+
+---
+
 ## Metal Watchdog Mitigation
 
 The macOS GPU watchdog (`kIOGPUCommandBufferCallbackErrorImpactingInteractivity`, ~10 s per Metal command buffer) trips when:

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Pure MLX port of [LTX-2](https://github.com/Lightricks/LTX-2) for Apple Silicon.
 
 ## Features
 
+- **LTX-2.5 (early support)** — `generate --distilled --model <2.5-pack-dir>`; auto-detected from the pack, no new flag. See [LTX-2.5 section](#ltx-25-early-support) for what's supported in v1.
 - **Text-to-Video** — generate video + stereo 48kHz audio from a text prompt
 - **Image-to-Video** — animate a reference image
 - **Audio-to-Video** — generate video conditioned on an audio track
@@ -114,6 +115,37 @@ ltx-2-mlx generate -p "1080p scene" --two-stages-hq --low-ram \
 # Model info
 ltx-2-mlx info --model dgrauet/ltx-2.3-mlx-q8
 ```
+
+## LTX-2.5 (early support)
+
+```bash
+ltx-2-mlx generate --distilled --model /path/to/ltx-2.5-mlx-q8 \
+    --prompt "a heavy wooden door creaks slowly open" -o out.mp4
+```
+
+The 2.5 generation is **auto-detected from the model pack** (no new CLI
+flag) — a local directory is required, since the pack bundles its own
+Gemma-4 text encoder (`text_encoder.safetensors`); no `mlx-community`
+Gemma download happens on this path. `--image` (I2V) works the same as on
+2.3.
+
+Sampling: stage 1 runs euler-ancestral (8 steps, SDE noise injection);
+stage 2 stays deterministic euler (3 steps) — upstream's rationale is that
+stage 2's short 3-step refinement schedule is too short to remove freshly
+injected noise.
+
+**v1 limits on 2.5 packs** (`generate --distilled` only):
+
+| Feature | Status |
+|---|---|
+| `--two-stage` / `--two-stages-hq` (dev + CFG) | not yet supported |
+| `a2v`, `keyframe`, `ic-lora`, `hdr-ic-lora`, `retake`, `extend`, `lipdub` | not yet supported |
+| `enhance` / `--enhance-prompt` | raises a clear error (Gemma 3-only) |
+| `--enable-teacache` | raises a clear error (not calibrated for 2.5) |
+| Modality tiling, Prompt Relay | validated on 2.3 only |
+| Diffusion (`DiffVAEMode`) VAE decoder | not loaded — conv decoder used |
+
+Further 2.5 pipelines land in subsequent releases.
 
 ### Python API
 

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/distilled.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/distilled.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import mlx.core as mx
 
+from ltx_core_mlx.components.diffusion_steps import EulerAncestralDiffusionStep
 from ltx_core_mlx.components.patchifiers import (
     compute_video_latent_shape,
     snap_output_dimensions,
@@ -35,11 +36,17 @@ from ltx_core_mlx.utils.positions import (
     compute_video_positions,
 )
 
-from .scheduler import DISTILLED_SIGMAS, STAGE_2_SIGMAS
+from .scheduler import (
+    DISTILLED_SIGMAS,
+    LTX_2_5_DISTILLED_SIGMAS,
+    LTX_2_5_STAGE_2_DISTILLED_SIGMAS,
+    STAGE_2_SIGMAS,
+)
 from .ti2vid_two_stages import TI2VidTwoStagesPipeline
+from .utils.generation import is_ltx25_pack
 from .utils.helpers import create_noised_state
 from .utils.progress import phase
-from .utils.samplers import denoise_loop
+from .utils.samplers import denoise_loop, euler_ancestral_denoising_loop
 
 _materialize = getattr(mx, "eval")  # noqa: B009 -- security hook flags mx.eval pattern
 
@@ -67,6 +74,11 @@ class DistilledPipeline(TI2VidTwoStagesPipeline):
     - Run simple ``denoise_loop`` with ``DISTILLED_SIGMAS`` for stage 1.
     - Run the same distilled transformer for stage 2 with ``STAGE_2_SIGMAS``.
 
+    On an LTX-2.5 pack (detected once at construction via
+    :func:`~ltx_pipelines_mlx.utils.generation.is_ltx25_pack`) both stages
+    instead run the ancestral (SDE) Euler loop on the ``LTX_2_5_*`` sigma
+    tables, and stage 2 resolves the ``spatial_upscaler_x2_v1_0`` upscaler.
+
     Args:
         model_dir: Path to model weights or HuggingFace repo ID. Must
             contain the distilled checkpoint (e.g. ``dgrauet/ltx-2.3-mlx-q8``
@@ -92,6 +104,12 @@ class DistilledPipeline(TI2VidTwoStagesPipeline):
             low_ram_streaming=low_ram_streaming,
             tile_count=tile_count,
         )
+        # Resolved once, here, because ``super().__init__`` has just turned
+        # ``model_dir`` into a concrete local path (downloading the HF repo if
+        # needed) — the same point where every other model-dir-derived fact
+        # (prompt encoder, conditioners, decoder blocks) is bound. Reading the
+        # checkpoint config later, per stage, would re-open it on every call.
+        self._is_25 = is_ltx25_pack(self.model_dir)
 
     def load(self) -> None:
         """Load distilled DiT + VAE encoder + upsampler (skip decoders).
@@ -119,6 +137,63 @@ class DistilledPipeline(TI2VidTwoStagesPipeline):
 
         self._loaded = True
 
+    def _run_denoise_loop(
+        self,
+        *,
+        model,
+        video_state,
+        audio_state,
+        video_text_embeds: mx.array,
+        audio_text_embeds: mx.array,
+        sigmas: list[float],
+        video_cross_attention_mask: mx.array | None,
+        on_step,
+        seed: int,
+    ):
+        """Dispatch one stage onto the deterministic (2.3) or ancestral (2.5) loop.
+
+        LTX-2.5 distilled checkpoints are trained for the ancestral (SDE) Euler
+        sampler; 2.3 checkpoints keep the deterministic loop they were shipped
+        with. Upstream makes the same choice through ``DiffusionStage``'s
+        ``stepper`` / ``loop`` overrides (``_stage_1_sampler_kwargs``).
+
+        Divergence from upstream: upstream applies the ancestral override to
+        stage 1 only (``_stage_1_sampler_kwargs``) and keeps stage 2's 3-step
+        refinement on the deterministic sampler. Here both stages of a 2.5 pack
+        run ancestral; the terminal sigma still short-circuits to the x0
+        prediction, so stage 2 does not end on injected noise.
+
+        The two loops differ only in the model keyword (``model=`` vs upstream's
+        ``transformer=``) and in the ancestral extras (``stepper`` /
+        ``noise_seed``): positions and attention masks are resolved from the
+        :class:`LatentState` by both, so the call structure is otherwise the
+        one already used at the 2.3 call sites.
+        """
+        if not self._is_25:
+            return denoise_loop(
+                model=model,
+                video_state=video_state,
+                audio_state=audio_state,
+                video_text_embeds=video_text_embeds,
+                audio_text_embeds=audio_text_embeds,
+                sigmas=sigmas,
+                video_cross_attention_mask=video_cross_attention_mask,
+                on_step=on_step,
+            )
+
+        return euler_ancestral_denoising_loop(
+            transformer=model,
+            video_state=video_state,
+            audio_state=audio_state,
+            video_text_embeds=video_text_embeds,
+            audio_text_embeds=audio_text_embeds,
+            sigmas=sigmas,
+            stepper=EulerAncestralDiffusionStep(eta=ANCESTRAL_ETA, s_noise=ANCESTRAL_S_NOISE),
+            noise_seed=seed + ANCESTRAL_NOISE_SEED_OFFSET,
+            video_cross_attention_mask=video_cross_attention_mask,
+            on_step=on_step,
+        )
+
     def generate_two_stage(  # type: ignore[override]
         self,
         prompt: str,
@@ -133,6 +208,7 @@ class DistilledPipeline(TI2VidTwoStagesPipeline):
         image: str | None = None,
         images=None,
         prompt_relay=None,
+        enable_teacache: bool = False,
         **_unused_kwargs,
     ) -> tuple[mx.array, mx.array]:
         """Generate video using the distilled two-stage pipeline.
@@ -146,13 +222,29 @@ class DistilledPipeline(TI2VidTwoStagesPipeline):
             stage1_steps: Stage 1 steps (default: full DISTILLED_SIGMAS = 8).
             stage2_steps: Stage 2 steps (default: full STAGE_2_SIGMAS = 3).
             image: Optional reference image for I2V conditioning.
+            enable_teacache: Accepted for signature compatibility with
+                :meth:`TI2VidTwoStagesPipeline.generate_two_stage`. Ignored on
+                LTX-2.3 packs (the 8-step distilled flow has never used
+                TeaCache); rejected on LTX-2.5 packs.
             **_unused_kwargs: Accepted (and ignored) for signature compatibility
-                with :meth:`TI2VidTwoStagesPipeline.generate_two_stage`. CFG / STG /
-                TeaCache flags don't apply to the distilled flow.
+                with :meth:`TI2VidTwoStagesPipeline.generate_two_stage`. CFG / STG
+                flags don't apply to the distilled flow.
 
         Returns:
             Tuple of (video_latent, audio_latent) at full resolution.
+
+        Raises:
+            ValueError: when ``enable_teacache`` is requested on an LTX-2.5 pack.
         """
+        if enable_teacache and self._is_25:
+            raise ValueError(
+                "TeaCache is not calibrated for LTX-2.5 packs: the polynomial "
+                "coefficients and threshold were fitted on the LTX-2.3 dev "
+                "model with the deterministic Euler sampler, and the 2.5 "
+                "distilled path runs an ancestral (SDE) sampler whose per-step "
+                "residual deltas differ. Re-run without --enable-teacache."
+            )
+
         # --- Prompt Relay setup (temporal prompt gating on video cross-attn) ---
         encode_prompt, relay_token_ranges = self._prompt_relay_setup(prompt, prompt_relay)
 
@@ -230,7 +322,8 @@ class DistilledPipeline(TI2VidTwoStagesPipeline):
             legacy_scalar_blend=True,
         )
 
-        sigmas_1 = DISTILLED_SIGMAS[: stage1_steps + 1] if stage1_steps else DISTILLED_SIGMAS
+        stage1_table = LTX_2_5_DISTILLED_SIGMAS if self._is_25 else DISTILLED_SIGMAS
+        sigmas_1 = stage1_table[: stage1_steps + 1] if stage1_steps else stage1_table
 
         stage1_dit = self.dit
         if self._tile_count is not None:
@@ -242,7 +335,7 @@ class DistilledPipeline(TI2VidTwoStagesPipeline):
         x0_model = X0Model(stage1_dit)
 
         self._pre_denoise_flush(video_state, audio_state)
-        output_1 = denoise_loop(
+        output_1 = self._run_denoise_loop(
             model=x0_model,
             video_state=video_state,
             audio_state=audio_state,
@@ -251,6 +344,7 @@ class DistilledPipeline(TI2VidTwoStagesPipeline):
             sigmas=sigmas_1,
             video_cross_attention_mask=relay_mask(F, H_half, W_half, video_state.latent.shape[1]),
             on_step=self._stepwise_hook(F, H_half, W_half, stage=1),
+            seed=seed,
         )
         if self.low_memory:
             aggressive_cleanup()
@@ -292,7 +386,11 @@ class DistilledPipeline(TI2VidTwoStagesPipeline):
 
         # --- Stage 2: full resolution refine (no LoRA swap — already distilled) ---
         video_tokens, _ = self.video_patchifier.patchify(video_upscaled)
-        sigmas_2 = STAGE_2_SIGMAS[: stage2_steps + 1] if stage2_steps else STAGE_2_SIGMAS
+        stage2_table = LTX_2_5_STAGE_2_DISTILLED_SIGMAS if self._is_25 else STAGE_2_SIGMAS
+        sigmas_2 = stage2_table[: stage2_steps + 1] if stage2_steps else stage2_table
+        # Upstream renoises the upscaled stage-1 latent at ``stage_2_sigmas[0]``
+        # (``ModalitySpec(noise_scale=stage_2_sigmas[0].item())``); our
+        # ``create_noised_state(sigma=...)`` below is that same mechanism.
         start_sigma = sigmas_2[0]
 
         video_positions_2 = compute_video_positions(F, H_full, W_full, frame_rate=frame_rate)
@@ -327,7 +425,7 @@ class DistilledPipeline(TI2VidTwoStagesPipeline):
             stage2_x0_model = X0Model(TiledLTXModel(self.dit, tiler_2))
 
         self._pre_denoise_flush(video_state_2, audio_state_2)
-        output_2 = denoise_loop(
+        output_2 = self._run_denoise_loop(
             model=stage2_x0_model,
             video_state=video_state_2,
             audio_state=audio_state_2,
@@ -336,6 +434,7 @@ class DistilledPipeline(TI2VidTwoStagesPipeline):
             sigmas=sigmas_2,
             video_cross_attention_mask=relay_mask(F, H_full, W_full, video_state_2.latent.shape[1]),
             on_step=self._stepwise_hook(F, H_full, W_full, stage=2),
+            seed=seed,
         )
         if self.low_memory:
             aggressive_cleanup()

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/distilled.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/distilled.py
@@ -75,9 +75,10 @@ class DistilledPipeline(TI2VidTwoStagesPipeline):
     - Run the same distilled transformer for stage 2 with ``STAGE_2_SIGMAS``.
 
     On an LTX-2.5 pack (detected once at construction via
-    :func:`~ltx_pipelines_mlx.utils.generation.is_ltx25_pack`) both stages
-    instead run the ancestral (SDE) Euler loop on the ``LTX_2_5_*`` sigma
-    tables, and stage 2 resolves the ``spatial_upscaler_x2_v1_0`` upscaler.
+    :func:`~ltx_pipelines_mlx.utils.generation.is_ltx25_pack`) both stages run
+    on the ``LTX_2_5_*`` sigma tables, stage 1 switches to the ancestral (SDE)
+    Euler loop (stage 2 stays deterministic, as upstream), and stage 2 resolves
+    the ``spatial_upscaler_x2_v1_0`` upscaler.
 
     Args:
         model_dir: Path to model weights or HuggingFace repo ID. Must
@@ -149,19 +150,23 @@ class DistilledPipeline(TI2VidTwoStagesPipeline):
         video_cross_attention_mask: mx.array | None,
         on_step,
         seed: int,
+        ancestral: bool,
     ):
-        """Dispatch one stage onto the deterministic (2.3) or ancestral (2.5) loop.
+        """Dispatch one stage onto the deterministic or ancestral (SDE) loop.
 
         LTX-2.5 distilled checkpoints are trained for the ancestral (SDE) Euler
         sampler; 2.3 checkpoints keep the deterministic loop they were shipped
         with. Upstream makes the same choice through ``DiffusionStage``'s
-        ``stepper`` / ``loop`` overrides (``_stage_1_sampler_kwargs``).
+        ``stepper`` / ``loop`` overrides, and scopes them to stage 1 only
+        (``_stage_1_sampler_kwargs``) — quoting upstream ``distilled.py``:
 
-        Divergence from upstream: upstream applies the ancestral override to
-        stage 1 only (``_stage_1_sampler_kwargs``) and keeps stage 2's 3-step
-        refinement on the deterministic sampler. Here both stages of a 2.5 pack
-        run ancestral; the terminal sigma still short-circuits to the x0
-        prediction, so stage 2 does not end on injected noise.
+            Stage 1 samples with the ancestral (SDE) Euler sampler or the
+            deterministic one according to ``self.use_ancestral_sampler``.
+            Stage 2 is always deterministic -- its 3-step refinement schedule
+            is too short to remove freshly injected noise.
+
+        Hence ``ancestral`` is passed per stage rather than read off
+        ``self._is_25``: only stage 1 of a 2.5 pack sets it.
 
         The two loops differ only in the model keyword (``model=`` vs upstream's
         ``transformer=``) and in the ancestral extras (``stepper`` /
@@ -169,7 +174,7 @@ class DistilledPipeline(TI2VidTwoStagesPipeline):
         :class:`LatentState` by both, so the call structure is otherwise the
         one already used at the 2.3 call sites.
         """
-        if not self._is_25:
+        if not ancestral:
             return denoise_loop(
                 model=model,
                 video_state=video_state,
@@ -345,6 +350,7 @@ class DistilledPipeline(TI2VidTwoStagesPipeline):
             video_cross_attention_mask=relay_mask(F, H_half, W_half, video_state.latent.shape[1]),
             on_step=self._stepwise_hook(F, H_half, W_half, stage=1),
             seed=seed,
+            ancestral=self._is_25,
         )
         if self.low_memory:
             aggressive_cleanup()
@@ -435,6 +441,8 @@ class DistilledPipeline(TI2VidTwoStagesPipeline):
             video_cross_attention_mask=relay_mask(F, H_full, W_full, video_state_2.latent.shape[1]),
             on_step=self._stepwise_hook(F, H_full, W_full, stage=2),
             seed=seed,
+            # Deterministic on every pack, 2.5 included (see _run_denoise_loop).
+            ancestral=False,
         )
         if self.low_memory:
             aggressive_cleanup()

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/distilled.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/distilled.py
@@ -43,6 +43,18 @@ from .utils.samplers import denoise_loop
 
 _materialize = getattr(mx, "eval")  # noqa: B009 -- security hook flags mx.eval pattern
 
+# Ancestral-sampler defaults for LTX-2.5 distilled packs (upstream
+# distilled.py). eta=1.0 / s_noise=1.0 reproduce upstream's default
+# EulerAncestralDiffusionStep configuration verbatim.
+ANCESTRAL_ETA = 1.0
+ANCESTRAL_S_NOISE = 1.0
+# The loop's noise generator is seeded from the pipeline seed plus this
+# offset. Without it the loop's first draw would be bit-identical to the
+# initial latent noise: GaussianNoiser and the loop's plain-noise draw both
+# pull mx.random.normal at the same shape/dtype from a freshly seeded
+# generator, so reusing the raw seed would correlate the two draws.
+ANCESTRAL_NOISE_SEED_OFFSET = 10000
+
 
 class DistilledPipeline(TI2VidTwoStagesPipeline):
     """Distilled two-stage T2V/I2V pipeline (half-res → upscale → full-res refine).

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ic_lora.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ic_lora.py
@@ -150,7 +150,11 @@ class ICLoraPipeline(BasePipeline):
             config_path = model_dir / f"{name}_config.json"
             weights_path = model_dir / f"{name}.safetensors"
             if config_path.exists():
-                config = json.loads(config_path.read_text()).get("config", {})
+                raw_config = json.loads(config_path.read_text())
+                # Old format nests fields under a "config" key; newer
+                # conversions (e.g. LTX-2.5) emit the fields flat at the
+                # top level.
+                config = raw_config.get("config", raw_config)
                 self.upsampler = LatentUpsampler.from_config(config)
             else:
                 self.upsampler = LatentUpsampler()

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ti2vid_two_stages.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ti2vid_two_stages.py
@@ -110,6 +110,12 @@ class TI2VidTwoStagesPipeline(BasePipeline):
         distilled_lora_strength: LoRA fusion strength (default 1.0).
     """
 
+    #: Whether the checkpoint is an LTX-2.5 weight pack. Resolved once per
+    #: pipeline instance by the subclasses that support 2.5 packs (currently
+    #: :class:`~ltx_pipelines_mlx.distilled.DistilledPipeline`); the class
+    #: default keeps every other two-stage pipeline on the 2.3 behaviour.
+    _is_25: bool = False
+
     def __init__(
         self,
         model_dir: str,
@@ -229,8 +235,13 @@ class TI2VidTwoStagesPipeline(BasePipeline):
         object.__setattr__(self.dit, "_lora_sources", existing)
         aggressive_cleanup()
 
-    def _load_upsampler(self) -> None:
-        """Load the spatial upsampler from config and weights.
+    def _resolve_upsampler_path(self) -> Path:
+        """Return the spatial-upscaler weights file to load for stage 2.
+
+        LTX-2.5 packs ship ``spatial_upscaler_x2_v1_0.safetensors``; the 2.3
+        packs ship ``spatial_upscaler_x2_v1_1.safetensors`` (or the older
+        ``ltx-2.3-spatial-upscaler-x2`` name). The 2.5 name is only consulted
+        on 2.5 packs, so the 2.3 resolution order is untouched.
 
         Raises:
             FileNotFoundError: when no upsampler weights file is present in the
@@ -240,27 +251,42 @@ class TI2VidTwoStagesPipeline(BasePipeline):
                 with no other error. A missing file must therefore fail loud
                 rather than silently degrade.
         """
-        import json
+        stems = ["ltx-2.3-spatial-upscaler-x2", "spatial_upscaler_x2_v1_1"]
+        if self._is_25:
+            stems.insert(0, "spatial_upscaler_x2_v1_0")
 
         # Try new v1.1+ naming, then old naming
         weights_path = self.model_dir / "spatial_upscaler_x2_v1_1.safetensors"
-        for stem in ["ltx-2.3-spatial-upscaler-x2", "spatial_upscaler_x2_v1_1"]:
+        for stem in stems:
             resolved = self._resolve_safetensors(self.model_dir, stem)
             if resolved.exists():
                 weights_path = resolved
                 break
 
         if not weights_path.exists():
+            expected = "spatial_upscaler_x2_v1_0.safetensors" if self._is_25 else "spatial_upscaler_x2_v1_1.safetensors"
             raise FileNotFoundError(
                 f"Spatial upsampler weights not found in {self.model_dir} "
-                "(looked for spatial_upscaler_x2_v1_1.safetensors and "
-                "ltx-2.3-spatial-upscaler-x2*.safetensors). The two-stage and "
+                f"(looked for {', '.join(f'{s}*.safetensors' for s in stems)}). "
+                "The two-stage and "
                 "distilled pipelines require it for stage-2 upscaling; without "
                 "it the latent is upscaled by an untrained module and the "
                 "output degrades into a periodic 'mosaic' grid. Download it, "
                 "e.g.: hf download dgrauet/ltx-2.3-mlx-q8 "
-                f"spatial_upscaler_x2_v1_1.safetensors --local-dir {self.model_dir}"
+                f"{expected} --local-dir {self.model_dir}"
             )
+        return weights_path
+
+    def _load_upsampler(self) -> None:
+        """Load the spatial upsampler from config and weights.
+
+        Raises:
+            FileNotFoundError: propagated from :meth:`_resolve_upsampler_path`
+                when no upsampler weights file is present in the model dir.
+        """
+        import json
+
+        weights_path = self._resolve_upsampler_path()
 
         config_path = self.model_dir / f"{weights_path.stem}_config.json"
         if config_path.exists():

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ti2vid_two_stages.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ti2vid_two_stages.py
@@ -290,7 +290,10 @@ class TI2VidTwoStagesPipeline(BasePipeline):
 
         config_path = self.model_dir / f"{weights_path.stem}_config.json"
         if config_path.exists():
-            config = json.loads(config_path.read_text()).get("config", {})
+            raw_config = json.loads(config_path.read_text())
+            # Old format nests fields under a "config" key; newer conversions
+            # (e.g. LTX-2.5) emit the fields flat at the top level.
+            config = raw_config.get("config", raw_config)
             self.upsampler = LatentUpsampler.from_config(config)
         else:
             self.upsampler = LatentUpsampler()

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/utils/blocks.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/utils/blocks.py
@@ -420,7 +420,10 @@ class VideoUpsampler:
         weights_path = self.model_dir / f"{self.name}.safetensors"
 
         if config_path.exists():
-            config = json.loads(config_path.read_text()).get("config", {})
+            raw_config = json.loads(config_path.read_text())
+            # Old format nests fields under a "config" key; newer conversions
+            # (e.g. LTX-2.5) emit the fields flat at the top level.
+            config = raw_config.get("config", raw_config)
             self._upsampler = LatentUpsampler.from_config(config)
         else:
             self._upsampler = LatentUpsampler()

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/utils/generation.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/utils/generation.py
@@ -1,0 +1,38 @@
+"""Checkpoint-shape detection helpers shared across generation pipelines.
+
+LTX-2.5 packs are distinguished from LTX-2.3 packs by their transformer
+config, not by a file naming convention -- ``is_ltx25_pack`` reads the same
+``embedded_config.json`` / ``config.json`` that :class:`LTXModelConfig`
+already parses at load time, so the detection stays in sync with the
+loader by construction instead of duplicating the field mapping.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ltx_core_mlx.model.transformer.model import LTXModelConfig
+
+
+def is_ltx25_pack(model_dir: str | Path) -> bool:
+    """Detect whether a checkpoint directory holds an LTX-2.5 weight pack.
+
+    LTX-2.5 checkpoints ship ``ff_bias=false`` in their transformer config
+    (2.3 checkpoints omit the field, which defaults to ``True``). This is
+    the same signal :class:`LTXModelConfig.from_checkpoint_config` uses to
+    decide whether the feed-forward layers carry a bias term, so reusing it
+    here keeps pack detection isomorphic with the loader instead of
+    re-deriving a second heuristic.
+
+    Args:
+        model_dir: Directory containing the checkpoint's config files
+            (``embedded_config.json`` or ``config.json``).
+
+    Returns:
+        ``True`` if the checkpoint config declares ``ff_bias=false``
+        (LTX-2.5), ``False`` otherwise -- including when no config file is
+        found, in which case :meth:`LTXModelConfig.from_checkpoint_dir`
+        warns on stderr and falls back to the LTX-2.3-shaped defaults
+        (``ff_bias=True``).
+    """
+    return LTXModelConfig.from_checkpoint_dir(model_dir).ff_bias is False

--- a/tests/test_ltx25_distilled.py
+++ b/tests/test_ltx25_distilled.py
@@ -60,3 +60,208 @@ def test_is_ltx25_pack_false_when_no_config_present(tmp_path):
     # defaults, where ff_bias=True (2.3-shaped) -> is_ltx25_pack is False.
     # Must not raise.
     assert is_ltx25_pack(tmp_path) is False
+
+
+# --------------------------------------------------------------------------
+# Task 2: 2.5 routing inside DistilledPipeline.generate_two_stage
+# --------------------------------------------------------------------------
+#
+# The routing tests drive the real ``generate_two_stage`` at toy resolution
+# (128x128x9 -> 2x2x2 latent tokens) with the heavyweight collaborators
+# stubbed: text encoder, DiT, VAE encoder, upsampler and both denoising
+# loops. Everything else (dimension snapping, patchify/unpatchify, position
+# computation, ``create_noised_state``) runs for real, so the assertions pin
+# the actual call structure rather than a mock of it.
+
+import mlx.core as mx  # noqa: E402
+
+from ltx_pipelines_mlx import distilled as distilled_mod  # noqa: E402
+from ltx_pipelines_mlx.distilled import DistilledPipeline  # noqa: E402
+from ltx_pipelines_mlx.scheduler import (  # noqa: E402
+    DISTILLED_SIGMAS,
+    LTX_2_5_DISTILLED_SIGMAS,
+    LTX_2_5_STAGE_2_DISTILLED_SIGMAS,
+    STAGE_2_SIGMAS,
+)
+from ltx_pipelines_mlx.utils.samplers import DenoiseOutput  # noqa: E402
+
+
+def _write_pack_config(tmp_path, *, ltx25: bool):
+    """Write a minimal transformer config marking the dir as a 2.5 / 2.3 pack."""
+    transformer: dict = {"num_layers": 48}
+    if ltx25:
+        transformer["ff_bias"] = False
+    (tmp_path / "embedded_config.json").write_text(json.dumps({"transformer": transformer}))
+    return tmp_path
+
+
+class _LoopSpy:
+    """Stand-in for a denoising loop: records kwargs, echoes the input latents."""
+
+    def __init__(self):
+        self.calls: list[dict] = []
+
+    def __call__(self, **kwargs):
+        self.calls.append(kwargs)
+        return DenoiseOutput(
+            video_latent=kwargs["video_state"].latent,
+            audio_latent=kwargs["audio_state"].latent,
+        )
+
+
+class _FakeVaeEncoder:
+    """Identity latent (de)normalization — the upscale path only needs shapes."""
+
+    def denormalize_latent(self, x):
+        return x
+
+    def normalize_latent(self, x):
+        return x
+
+
+def _fake_upsampler(x):
+    """2x nearest-neighbour spatial upscale on a (B, C, F, H, W) latent."""
+    return mx.repeat(mx.repeat(x, 2, axis=3), 2, axis=4)
+
+
+def _make_stubbed_pipeline(tmp_path, monkeypatch, *, ltx25: bool):
+    """Build a DistilledPipeline over a synthetic pack with stubbed collaborators."""
+    _write_pack_config(tmp_path, ltx25=ltx25)
+    pipe = DistilledPipeline(str(tmp_path), low_memory=False)
+
+    pipe._load_text_encoder = lambda: None  # type: ignore[method-assign]
+    pipe._encode_text = lambda prompt: (  # type: ignore[method-assign]
+        mx.zeros((1, 8, 4096), dtype=mx.bfloat16),
+        mx.zeros((1, 8, 2048), dtype=mx.bfloat16),
+    )
+    pipe.load = lambda: None  # type: ignore[method-assign]
+    pipe.dit = object()  # type: ignore[assignment]
+    pipe.vae_encoder = _FakeVaeEncoder()  # type: ignore[assignment]
+    pipe.upsampler = _fake_upsampler  # type: ignore[assignment]
+
+    monkeypatch.setattr(distilled_mod, "X0Model", lambda dit: dit)
+
+    euler = _LoopSpy()
+    ancestral = _LoopSpy()
+    monkeypatch.setattr(distilled_mod, "denoise_loop", euler)
+    monkeypatch.setattr(distilled_mod, "euler_ancestral_denoising_loop", ancestral)
+
+    noised_calls: list[dict] = []
+    real_create_noised_state = distilled_mod.create_noised_state
+
+    def spy_create_noised_state(**kwargs):
+        noised_calls.append(kwargs)
+        return real_create_noised_state(**kwargs)
+
+    monkeypatch.setattr(distilled_mod, "create_noised_state", spy_create_noised_state)
+
+    return pipe, euler, ancestral, noised_calls
+
+
+def _run(pipe, **overrides):
+    kwargs = dict(prompt="a fox", height=128, width=128, num_frames=9, frame_rate=24.0, seed=7)
+    kwargs.update(overrides)
+    return pipe.generate_two_stage(**kwargs)
+
+
+def test_25_pack_routes_stage1_and_stage2_through_ancestral_loop(tmp_path, monkeypatch):
+    pipe, euler, ancestral, _ = _make_stubbed_pipeline(tmp_path, monkeypatch, ltx25=True)
+
+    _run(pipe)
+
+    assert euler.calls == []
+    assert len(ancestral.calls) == 2
+    assert ancestral.calls[0]["sigmas"] == LTX_2_5_DISTILLED_SIGMAS
+    assert ancestral.calls[1]["sigmas"] == LTX_2_5_STAGE_2_DISTILLED_SIGMAS
+    for call in ancestral.calls:
+        assert call["noise_seed"] == 7 + ANCESTRAL_NOISE_SEED_OFFSET
+        stepper = call["stepper"]
+        assert stepper.eta == ANCESTRAL_ETA
+        assert stepper.s_noise == ANCESTRAL_S_NOISE
+
+
+def test_25_pack_stage2_renoises_at_first_stage2_sigma(tmp_path, monkeypatch):
+    pipe, _, _, noised_calls = _make_stubbed_pipeline(tmp_path, monkeypatch, ltx25=True)
+
+    _run(pipe)
+
+    # 4 calls: stage-1 video/audio (sigma 1.0), stage-2 video/audio.
+    assert [c["sigma"] for c in noised_calls[:2]] == [1.0, 1.0]
+    assert [c["sigma"] for c in noised_calls[2:]] == [
+        LTX_2_5_STAGE_2_DISTILLED_SIGMAS[0],
+        LTX_2_5_STAGE_2_DISTILLED_SIGMAS[0],
+    ]
+
+
+def test_23_pack_keeps_the_deterministic_euler_loop(tmp_path, monkeypatch):
+    pipe, euler, ancestral, noised_calls = _make_stubbed_pipeline(tmp_path, monkeypatch, ltx25=False)
+
+    _run(pipe)
+
+    assert ancestral.calls == []
+    assert len(euler.calls) == 2
+    assert euler.calls[0]["sigmas"] == DISTILLED_SIGMAS
+    assert euler.calls[1]["sigmas"] == STAGE_2_SIGMAS
+    for call in euler.calls:
+        assert "stepper" not in call
+        assert "noise_seed" not in call
+    assert [c["sigma"] for c in noised_calls[2:]] == [STAGE_2_SIGMAS[0], STAGE_2_SIGMAS[0]]
+
+
+def test_stage_step_truncation_applies_to_the_25_tables(tmp_path, monkeypatch):
+    pipe, _, ancestral, _ = _make_stubbed_pipeline(tmp_path, monkeypatch, ltx25=True)
+
+    _run(pipe, stage1_steps=3, stage2_steps=2)
+
+    assert ancestral.calls[0]["sigmas"] == LTX_2_5_DISTILLED_SIGMAS[:4]
+    assert ancestral.calls[1]["sigmas"] == LTX_2_5_STAGE_2_DISTILLED_SIGMAS[:3]
+
+
+def test_teacache_rejected_on_25_pack(tmp_path, monkeypatch):
+    pipe, euler, ancestral, _ = _make_stubbed_pipeline(tmp_path, monkeypatch, ltx25=True)
+
+    with pytest.raises(ValueError, match=r"TeaCache is not calibrated for LTX-2\.5"):
+        _run(pipe, enable_teacache=True)
+
+    # Guard fires before any denoising work.
+    assert euler.calls == []
+    assert ancestral.calls == []
+
+
+def test_teacache_flag_still_ignored_on_23_pack(tmp_path, monkeypatch):
+    pipe, euler, _, _ = _make_stubbed_pipeline(tmp_path, monkeypatch, ltx25=False)
+
+    _run(pipe, enable_teacache=True)
+
+    assert len(euler.calls) == 2
+
+
+# --- upsampler resolution ---------------------------------------------------
+
+
+def _upsampler_pipeline(tmp_path, *, ltx25: bool, files: list[str]):
+    _write_pack_config(tmp_path, ltx25=ltx25)
+    for name in files:
+        (tmp_path / name).touch()
+    return DistilledPipeline(str(tmp_path), low_memory=False)
+
+
+def test_upsampler_resolves_v1_0_on_25_pack(tmp_path):
+    pipe = _upsampler_pipeline(tmp_path, ltx25=True, files=["spatial_upscaler_x2_v1_0.safetensors"])
+    assert pipe._resolve_upsampler_path().name == "spatial_upscaler_x2_v1_0.safetensors"
+
+
+def test_upsampler_falls_back_to_v1_1(tmp_path):
+    pipe = _upsampler_pipeline(tmp_path, ltx25=True, files=["spatial_upscaler_x2_v1_1.safetensors"])
+    assert pipe._resolve_upsampler_path().name == "spatial_upscaler_x2_v1_1.safetensors"
+
+
+def test_upsampler_keeps_v1_1_on_23_pack(tmp_path):
+    pipe = _upsampler_pipeline(tmp_path, ltx25=False, files=["spatial_upscaler_x2_v1_1.safetensors"])
+    assert pipe._resolve_upsampler_path().name == "spatial_upscaler_x2_v1_1.safetensors"
+
+
+def test_upsampler_missing_raises_file_not_found(tmp_path):
+    pipe = _upsampler_pipeline(tmp_path, ltx25=True, files=[])
+    with pytest.raises(FileNotFoundError, match="Spatial upsampler weights not found"):
+        pipe._resolve_upsampler_path()

--- a/tests/test_ltx25_distilled.py
+++ b/tests/test_ltx25_distilled.py
@@ -171,7 +171,9 @@ def test_25_pack_routes_stage1_through_ancestral_loop(tmp_path, monkeypatch):
 
     assert len(ancestral.calls) == 1
     stage_1 = ancestral.calls[0]
-    assert stage_1["sigmas"] == LTX_2_5_DISTILLED_SIGMAS
+    assert stage_1["sigmas"] is LTX_2_5_DISTILLED_SIGMAS, (
+        "2.3/2.5 tables are value-identical; identity proves the 2.5 selection ran"
+    )
     assert stage_1["noise_seed"] == 7 + ANCESTRAL_NOISE_SEED_OFFSET
     assert stage_1["stepper"].eta == ANCESTRAL_ETA
     assert stage_1["stepper"].s_noise == ANCESTRAL_S_NOISE
@@ -190,11 +192,13 @@ def test_25_pack_stage2_stays_deterministic(tmp_path, monkeypatch):
 
     assert len(euler.calls) == 1
     stage_2 = euler.calls[0]
-    assert stage_2["sigmas"] == LTX_2_5_STAGE_2_DISTILLED_SIGMAS
+    assert stage_2["sigmas"] is LTX_2_5_STAGE_2_DISTILLED_SIGMAS, (
+        "identity, not equality: the 2.3 table is value-identical"
+    )
     # The load-bearing assertion: no ancestral machinery reaches stage 2.
     assert "stepper" not in stage_2
     assert "noise_seed" not in stage_2
-    assert all(call["sigmas"] != LTX_2_5_STAGE_2_DISTILLED_SIGMAS for call in ancestral.calls)
+    assert all(call["sigmas"] is not LTX_2_5_STAGE_2_DISTILLED_SIGMAS for call in ancestral.calls)
 
 
 def test_25_pack_stage2_renoises_at_first_stage2_sigma(tmp_path, monkeypatch):

--- a/tests/test_ltx25_distilled.py
+++ b/tests/test_ltx25_distilled.py
@@ -1,0 +1,62 @@
+"""is_ltx25_pack detection + ancestral sampler constants.
+
+The real-pack tests are gated behind LTX25_Q8_DIR / MODEL_DIR (see
+tests/conftest.py) since they require locally converted weight packs.
+The synthetic tests exercise the same code path (LTXModelConfig.from_checkpoint_dir)
+against tmp_path directories shaped like a 2.5 config, a 2.3 config, and no
+config at all, so the contract is pinned even on machines without the real
+packs.
+"""
+
+import json
+
+import pytest
+
+from ltx_pipelines_mlx.distilled import (
+    ANCESTRAL_ETA,
+    ANCESTRAL_NOISE_SEED_OFFSET,
+    ANCESTRAL_S_NOISE,
+)
+from ltx_pipelines_mlx.utils.generation import is_ltx25_pack
+from tests.conftest import LTX25_Q8_DIR, MODEL_DIR
+
+skip_no_25_weights = pytest.mark.skipif(LTX25_Q8_DIR is None, reason="ltx-2.5-mlx-q8 pack not found")
+skip_no_23_weights = pytest.mark.skipif(MODEL_DIR is None, reason="q8 weights not found")
+
+
+def test_ancestral_constants_exact_values():
+    assert ANCESTRAL_ETA == 1.0
+    assert ANCESTRAL_S_NOISE == 1.0
+    assert ANCESTRAL_NOISE_SEED_OFFSET == 10000
+
+
+@pytest.mark.slow
+@skip_no_25_weights
+def test_is_ltx25_pack_true_on_real_25_pack():
+    assert is_ltx25_pack(LTX25_Q8_DIR) is True
+
+
+@pytest.mark.slow
+@skip_no_23_weights
+def test_is_ltx25_pack_false_on_real_23_pack():
+    assert is_ltx25_pack(MODEL_DIR) is False
+
+
+def test_is_ltx25_pack_true_on_synthetic_25_config(tmp_path):
+    (tmp_path / "embedded_config.json").write_text(json.dumps({"transformer": {"num_layers": 48, "ff_bias": False}}))
+    assert is_ltx25_pack(tmp_path) is True
+
+
+def test_is_ltx25_pack_false_on_synthetic_23_config(tmp_path):
+    (tmp_path / "embedded_config.json").write_text(
+        json.dumps({"transformer": {"num_layers": 48, "av_ca_timestep_scale_multiplier": 1000.0}})
+    )
+    assert is_ltx25_pack(tmp_path) is False
+
+
+def test_is_ltx25_pack_false_when_no_config_present(tmp_path):
+    # LTXModelConfig.from_checkpoint_dir finds neither embedded_config.json
+    # nor config.json: it warns on stderr and returns the hardcoded
+    # defaults, where ff_bias=True (2.3-shaped) -> is_ltx25_pack is False.
+    # Must not raise.
+    assert is_ltx25_pack(tmp_path) is False

--- a/tests/test_ltx25_distilled.py
+++ b/tests/test_ltx25_distilled.py
@@ -164,20 +164,37 @@ def _run(pipe, **overrides):
     return pipe.generate_two_stage(**kwargs)
 
 
-def test_25_pack_routes_stage1_and_stage2_through_ancestral_loop(tmp_path, monkeypatch):
+def test_25_pack_routes_stage1_through_ancestral_loop(tmp_path, monkeypatch):
     pipe, euler, ancestral, _ = _make_stubbed_pipeline(tmp_path, monkeypatch, ltx25=True)
 
     _run(pipe)
 
-    assert euler.calls == []
-    assert len(ancestral.calls) == 2
-    assert ancestral.calls[0]["sigmas"] == LTX_2_5_DISTILLED_SIGMAS
-    assert ancestral.calls[1]["sigmas"] == LTX_2_5_STAGE_2_DISTILLED_SIGMAS
-    for call in ancestral.calls:
-        assert call["noise_seed"] == 7 + ANCESTRAL_NOISE_SEED_OFFSET
-        stepper = call["stepper"]
-        assert stepper.eta == ANCESTRAL_ETA
-        assert stepper.s_noise == ANCESTRAL_S_NOISE
+    assert len(ancestral.calls) == 1
+    stage_1 = ancestral.calls[0]
+    assert stage_1["sigmas"] == LTX_2_5_DISTILLED_SIGMAS
+    assert stage_1["noise_seed"] == 7 + ANCESTRAL_NOISE_SEED_OFFSET
+    assert stage_1["stepper"].eta == ANCESTRAL_ETA
+    assert stage_1["stepper"].s_noise == ANCESTRAL_S_NOISE
+    assert len(euler.calls) == 1
+
+
+def test_25_pack_stage2_stays_deterministic(tmp_path, monkeypatch):
+    """Upstream: "Stage 2 is always deterministic -- its 3-step refinement
+    schedule is too short to remove freshly injected noise." The ancestral
+    override is scoped to stage 1 (``_stage_1_sampler_kwargs``), so a 2.5 pack
+    must run its stage 2 on the plain Euler loop with the 2.5 stage-2 table.
+    """
+    pipe, euler, ancestral, _ = _make_stubbed_pipeline(tmp_path, monkeypatch, ltx25=True)
+
+    _run(pipe)
+
+    assert len(euler.calls) == 1
+    stage_2 = euler.calls[0]
+    assert stage_2["sigmas"] == LTX_2_5_STAGE_2_DISTILLED_SIGMAS
+    # The load-bearing assertion: no ancestral machinery reaches stage 2.
+    assert "stepper" not in stage_2
+    assert "noise_seed" not in stage_2
+    assert all(call["sigmas"] != LTX_2_5_STAGE_2_DISTILLED_SIGMAS for call in ancestral.calls)
 
 
 def test_25_pack_stage2_renoises_at_first_stage2_sigma(tmp_path, monkeypatch):
@@ -209,12 +226,12 @@ def test_23_pack_keeps_the_deterministic_euler_loop(tmp_path, monkeypatch):
 
 
 def test_stage_step_truncation_applies_to_the_25_tables(tmp_path, monkeypatch):
-    pipe, _, ancestral, _ = _make_stubbed_pipeline(tmp_path, monkeypatch, ltx25=True)
+    pipe, euler, ancestral, _ = _make_stubbed_pipeline(tmp_path, monkeypatch, ltx25=True)
 
     _run(pipe, stage1_steps=3, stage2_steps=2)
 
     assert ancestral.calls[0]["sigmas"] == LTX_2_5_DISTILLED_SIGMAS[:4]
-    assert ancestral.calls[1]["sigmas"] == LTX_2_5_STAGE_2_DISTILLED_SIGMAS[:3]
+    assert euler.calls[0]["sigmas"] == LTX_2_5_STAGE_2_DISTILLED_SIGMAS[:3]
 
 
 def test_teacache_rejected_on_25_pack(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

\`generate --distilled --model <pack-2.5>\` now runs end-to-end. Generation is auto-detected from the pack (\`is_ltx25_pack\`: \`LTXModelConfig.from_checkpoint_dir(...).ff_bias is False\`) — no new CLI flag; 2.3 packs are byte-identical to before.

- **Stage 1**: euler-ancestral sampler (\`EulerAncestralDiffusionStep(eta=1.0, s_noise=1.0)\`) on \`LTX_2_5_DISTILLED_SIGMAS\`, noise seeded at \`seed + 10000\` (upstream's seed-offset rationale reproduced in-source).
- **Stage 2**: stays deterministic (upstream verbatim: *"Stage 2 is always deterministic"*) on \`LTX_2_5_STAGE_2_DISTILLED_SIGMAS\`, renoised at \`stage_2_sigmas[0]\`.
- **Upscaler**: resolves \`spatial_upscaler_x2_v1_0.safetensors\` on 2.5 packs (falls back to the 2.3 stems; hard error only when none exists). Accepts the flat \`LatentUpsampler\` config JSON that mlx-forge emits for 2.5.
- **TeaCache**: explicit \`ValueError\` on 2.5 packs (the 2.3 polynomial is not calibrated for 2.5).
- Docs: CLI usage + v1 limits table.

## Validation

- **2.3 SHA-gate**: acceptance render reproduces \`1248862480…\` exactly (byte-identical 2.3 path).
- **T2V 2.5 determinism**: two identical renders, SHA \`35b98e71…\` (512×512×25, seed 81647281, q8 \`--low-ram\`, peak RSS 13.2 GB).
- **I2V 2.5**: anchored on the T2V first frame, renders clean.
- **Audio loudness** measured at 97 frames: −38.2 dB vs healthy 2.3 reference −35.6 dB. Note: 1-second clips can decode near-silent at some seeds — this is the checkpoint×ancestral-sampler behaviour, **reproduced on upstream torch** (golden block-streamed forward: audio x0 corr 0.9991 vs our MLX; 8-step upstream trajectory drifts identically). Output is intentionally iso-reference.
- Suites: 794 passed + 31 slow, ruff clean; routing/table/seed/upscaler tests are mutation-verified (incl. identity asserts on the value-identical sigma tables).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Yai9eY2wgyDpQJmmtTw9o