### PR TITLE
feat(pipelines): wire the two-stage dev+CFG pipeline for LTX-2.5 packs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -932,7 +932,8 @@ End-to-end run on M2 Pro 32 GB, dev model + HDR LoRA fused, q8:
 LTX-2.5 pack. No new CLI flag — generation is auto-detected from the pack's
 `embedded_config.json` (`ff_bias is False` ⇔ 2.5) via
 `is_ltx25_pack()`/`LTXModelConfig.from_checkpoint_dir()`, resolved once in
-`DistilledPipeline.__init__` as `self._is_25`. The pack carries its own
+`TI2VidTwoStagesPipeline.__init__` (declared as `_is_25: bool = False` on
+`BasePipeline`, inherited by `DistilledPipeline`) as `self._is_25`. The pack carries its own
 Gemma-4 text encoder (`text_encoder.safetensors` + `text_encoder_config.json`,
 selected by `select_text_encoder()`) — no `mlx-community` Gemma 3 download on
 that path. 2.3 packs are byte-identical to before.
@@ -979,7 +980,7 @@ subsequent releases behind the same pack-evidence detection.
 - `packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/distilled.py` — `DistilledPipeline` (2.3/2.5 dispatch), `ANCESTRAL_*` constants.
 - `packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/utils/generation.py` — `is_ltx25_pack()`.
 - `packages/ltx-core-mlx/src/ltx_core_mlx/text_encoders/gemma/encoders/encoder_configurator.py` — `select_text_encoder()`, `check_gemma_version()`.
-- `packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ti2vid_two_stages.py` — `_resolve_upsampler_path()` (`_is_25` class attribute, default `False`).
+- `packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ti2vid_two_stages.py` — `_resolve_upsampler_path()` (`_is_25` resolved in `__init__` via `is_ltx25_pack`; the `_is_25: bool = False` class attribute lives on `BasePipeline`).
 - `tests/test_ltx25_distilled.py` — routing, sigma-table, TeaCache-guard, upsampler-resolution tests.
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -944,18 +944,34 @@ that path. 2.3 packs are byte-identical to before.
 - Ancestral noise is seeded from `seed + ANCESTRAL_NOISE_SEED_OFFSET` (10000) to decorrelate from the initial-latent draw.
 - Stage 2 upscaler resolves to `spatial_upscaler_x2_v1_0.safetensors` (vs `v1_1` on 2.3), falling back to the 2.3 stems; hard error only when none exists (#42 style).
 
-### v1 limits (2.5 packs, `generate --distilled` only)
+### Two-Stage on LTX-2.5
+
+`generate --two-stage --model <2.5-pack-dir>` runs the dev model + CFG
+two-stage pipeline (half-res Stage 1 → upsample → distilled Stage 2 refine)
+end-to-end on a local LTX-2.5 pack, same `is_ltx25_pack()` auto-detection as
+the distilled path. T2V and I2V (`--image`) both work. `--two-stages-hq`
+(res_2s sampler) stays unvalidated on 2.5 packs — its TeaCache guard exists,
+but the HQ pipeline itself hasn't been exercised end-to-end yet.
+
+```bash
+ltx-2-mlx generate --model /path/to/ltx-2.5-mlx-q8 --two-stage --low-ram \
+  -p "a heavy wooden door creaks slowly open" -H 512 -W 512 -f 49 \
+  --frame-rate 24 -o out.mp4
+```
+
+### v1 limits (2.5 packs)
 
 | Feature | Status |
 |---|---|
-| `--two-stage` / `--two-stages-hq` (dev model + CFG) | not yet supported |
+| `--two-stage` (dev model + CFG) | supported (see above) |
+| `--two-stages-hq` (res_2s + CFG) | not yet supported |
 | `a2v`, `keyframe`, `ic-lora`, `hdr-ic-lora`, `retake`, `extend`, `lipdub` | not yet supported |
 | `enhance` / `--enhance-prompt` | raises `NotImplementedError` (`_guard_enhance_not_gemma4`) — Gemma 3 only |
 | `--enable-teacache` | raises `ValueError` — 2.3 polynomial isn't calibrated for 2.5 |
 | Modality tiling, Prompt Relay | validated on 2.3 only |
 | Diffusion (`DiffVAEMode`) VAE decoder | not loaded — conv `vae_decoder_conv` used (see Weight Format) |
 
-Further 2.5 pipelines (two-stage, a2v, keyframe, ic-lora, ...) land in
+Further 2.5 pipelines (`--two-stages-hq`, a2v, keyframe, ic-lora, ...) land in
 subsequent releases behind the same pack-evidence detection.
 
 ### Key Files

--- a/README.md
+++ b/README.md
@@ -134,18 +134,27 @@ stage 2 stays deterministic euler (3 steps) — upstream's rationale is that
 stage 2's short 3-step refinement schedule is too short to remove freshly
 injected noise.
 
-**v1 limits on 2.5 packs** (`generate --distilled` only):
+The dev model + CFG two-stage pipeline also works on 2.5 packs:
+
+```bash
+ltx-2-mlx generate --model /path/to/ltx-2.5-mlx-q8 --two-stage \
+    --prompt "a heavy wooden door creaks slowly open" -o out.mp4
+```
+
+**v1 limits on 2.5 packs**:
 
 | Feature | Status |
 |---|---|
-| `--two-stage` / `--two-stages-hq` (dev + CFG) | not yet supported |
+| `--two-stage` (dev + CFG) | supported (see above) |
+| `--two-stages-hq` (res_2s + CFG) | not yet supported |
 | `a2v`, `keyframe`, `ic-lora`, `hdr-ic-lora`, `retake`, `extend`, `lipdub` | not yet supported |
 | `enhance` / `--enhance-prompt` | raises a clear error (Gemma 3-only) |
 | `--enable-teacache` | raises a clear error (not calibrated for 2.5) |
 | Modality tiling, Prompt Relay | validated on 2.3 only |
 | Diffusion (`DiffVAEMode`) VAE decoder | not loaded — conv decoder used |
 
-Further 2.5 pipelines land in subsequent releases.
+Further 2.5 pipelines (`--two-stages-hq`, a2v, keyframe, ic-lora, ...) land in
+subsequent releases.
 
 ### Python API
 

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/_base.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/_base.py
@@ -65,6 +65,11 @@ class BasePipeline:
             decoder load, video decode). CLI maps this from ``--quiet``.
     """
 
+    #: Whether the checkpoint is an LTX-2.5 weight pack. Declared here (not just
+    #: on subclasses) so shared helpers like ``_check_teacache_supported`` can
+    #: read it safely regardless of which pipeline family sets it.
+    _is_25: bool = False
+
     def __init__(
         self,
         model_dir: str,

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/_base.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/_base.py
@@ -214,6 +214,25 @@ class BasePipeline:
     # Shared component loading methods (used by subclass pipelines)
     # ------------------------------------------------------------------
 
+    def _check_teacache_supported(self, enable_teacache: bool) -> None:
+        """Raise ValueError if TeaCache is requested on an LTX-2.5 pack.
+
+        TeaCache coefficients are calibrated for LTX-2.3 only and do not
+        transfer to 2.5 packs, which use different sampler dynamics (ancestral
+        vs deterministic Euler, different per-step input/output correlations).
+
+        Args:
+            enable_teacache: Whether TeaCache was requested.
+
+        Raises:
+            ValueError: When both enable_teacache is True and the pack is LTX-2.5.
+        """
+        if enable_teacache and self._is_25:
+            raise ValueError(
+                "TeaCache is calibrated for LTX-2.3 only; its polynomial does not "
+                "transfer to 2.5 packs. Drop --enable-teacache for this model."
+            )
+
     def _load_text_encoder(self) -> None:
         """Load Gemma + connector via the :class:`PromptEncoder` block."""
         with phase("Loading text encoder (Gemma)", verbose=self.verbose):

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/cli.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/cli.py
@@ -334,8 +334,11 @@ examples:
     )
     gen.add_argument(
         "--distilled-lora",
-        default="ltx-2.3-22b-distilled-lora-384.safetensors",
-        help="Distilled LoRA filename for stage 2 (default: ltx-2.3-22b-distilled-lora-384.safetensors)",
+        default=None,
+        help=(
+            "Distilled LoRA filename for stage 2 (default: resolved from the pack "
+            "— 2.3 -> ltx-2.3-22b-distilled-lora-384, 2.5 -> ltx-2.5-22b-distilled-lora-450-bf16)"
+        ),
     )
     gen.add_argument(
         "--distilled-lora-strength", type=float, default=1.0, help="Distilled LoRA strength for stage 2 (default: 1.0)"

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/distilled.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/distilled.py
@@ -43,7 +43,6 @@ from .scheduler import (
     STAGE_2_SIGMAS,
 )
 from .ti2vid_two_stages import TI2VidTwoStagesPipeline
-from .utils.generation import is_ltx25_pack
 from .utils.helpers import create_noised_state
 from .utils.progress import phase
 from .utils.samplers import denoise_loop, euler_ancestral_denoising_loop
@@ -105,12 +104,6 @@ class DistilledPipeline(TI2VidTwoStagesPipeline):
             low_ram_streaming=low_ram_streaming,
             tile_count=tile_count,
         )
-        # Resolved once, here, because ``super().__init__`` has just turned
-        # ``model_dir`` into a concrete local path (downloading the HF repo if
-        # needed) — the same point where every other model-dir-derived fact
-        # (prompt encoder, conditioners, decoder blocks) is bound. Reading the
-        # checkpoint config later, per stage, would re-open it on every call.
-        self._is_25 = is_ltx25_pack(self.model_dir)
 
     def load(self) -> None:
         """Load distilled DiT + VAE encoder + upsampler (skip decoders).

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ti2vid_two_stages.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ti2vid_two_stages.py
@@ -99,8 +99,9 @@ class TI2VidTwoStagesPipeline(BasePipeline):
     Stage 1: Dev model + CFG guidance at half resolution (Euler sampler).
     Stage 2: Dev + distilled LoRA fused, simple denoising at full resolution.
 
-    Requires ``dev_transformer`` and ``distilled_lora`` — the two-stage pipeline
-    needs the dev model for quality generation at half resolution with CFG.
+    Needs the dev model for quality generation at half resolution with CFG;
+    the distilled LoRA is auto-resolved from the pack when not given
+    explicitly (see ``distilled_lora`` below).
 
     Args:
         model_dir: Path to model weights or HuggingFace repo ID.
@@ -113,13 +114,6 @@ class TI2VidTwoStagesPipeline(BasePipeline):
             ``ltx-2.3-22b-distilled-lora-384.safetensors`` for LTX-2.3 packs.
         distilled_lora_strength: LoRA fusion strength (default 1.0).
     """
-
-    #: Whether the checkpoint is an LTX-2.5 weight pack. Resolved once per
-    #: pipeline instance. The class default keeps instances without explicit
-    #: detection on the 2.3 behaviour; subclasses like
-    #: :class:`~ltx_pipelines_mlx.distilled.DistilledPipeline` set this
-    #: dynamically via :func:`is_ltx25_pack`.
-    _is_25: bool = False
 
     def __init__(
         self,
@@ -140,8 +134,11 @@ class TI2VidTwoStagesPipeline(BasePipeline):
             low_memory: Aggressive memory management.
             low_ram_streaming: Stream transformer blocks from disk.
             dev_transformer: Dev transformer filename.
-            distilled_lora: Distilled LoRA filename. When ``None``, resolved based
-                on pack version via :func:`is_ltx25_pack`.
+            distilled_lora: Distilled LoRA filename for Stage 2. When ``None``
+                (default), auto-resolved based on pack version:
+                ``ltx-2.5-22b-distilled-lora-450-bf16.safetensors`` for LTX-2.5
+                packs, ``ltx-2.3-22b-distilled-lora-384.safetensors`` for
+                LTX-2.3 packs.
             distilled_lora_strength: LoRA fusion strength (default 1.0).
             tile_count: Optional tiling configuration.
         """

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ti2vid_two_stages.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ti2vid_two_stages.py
@@ -408,6 +408,12 @@ class TI2VidTwoStagesPipeline(BasePipeline):
         Returns:
             Tuple of (video_latent, audio_latent) at full resolution.
         """
+        if enable_teacache and self._is_25:
+            raise ValueError(
+                "TeaCache is calibrated for LTX-2.3 only; its polynomial does not "
+                "transfer to 2.5 packs. Drop --enable-teacache for this model."
+            )
+
         # --- Text encoding (Prompt Relay: encode the combined prompt; the negative
         # prompt is a fixed default, so it is unaffected by the local prompts) ---
         encode_prompt, relay_token_ranges = self._prompt_relay_setup(prompt, prompt_relay)

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ti2vid_two_stages.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ti2vid_two_stages.py
@@ -408,11 +408,7 @@ class TI2VidTwoStagesPipeline(BasePipeline):
         Returns:
             Tuple of (video_latent, audio_latent) at full resolution.
         """
-        if enable_teacache and self._is_25:
-            raise ValueError(
-                "TeaCache is calibrated for LTX-2.3 only; its polynomial does not "
-                "transfer to 2.5 packs. Drop --enable-teacache for this model."
-            )
+        self._check_teacache_supported(enable_teacache)
 
         # --- Text encoding (Prompt Relay: encode the combined prompt; the negative
         # prompt is a fixed default, so it is unaffected by the local prompts) ---

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ti2vid_two_stages.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ti2vid_two_stages.py
@@ -34,6 +34,7 @@ from ltx_core_mlx.utils.positions import compute_audio_positions, compute_audio_
 from ltx_core_mlx.utils.weights import load_split_safetensors
 from ltx_pipelines_mlx._base import BasePipeline
 from ltx_pipelines_mlx.scheduler import STAGE_2_SIGMAS, ltx2_schedule
+from ltx_pipelines_mlx.utils.generation import is_ltx25_pack
 from ltx_pipelines_mlx.utils.helpers import create_noised_state
 from ltx_pipelines_mlx.utils.samplers import denoise_loop, guided_denoise_loop
 
@@ -106,14 +107,18 @@ class TI2VidTwoStagesPipeline(BasePipeline):
         gemma_model_id: Gemma model for text encoding.
         low_memory: Aggressive memory management.
         dev_transformer: Dev transformer filename (e.g. ``transformer-dev.safetensors``).
-        distilled_lora: Distilled LoRA filename for Stage 2.
+        distilled_lora: Distilled LoRA filename for Stage 2. When ``None`` (default),
+            auto-resolved based on pack version:
+            ``ltx-2.5-22b-distilled-lora-450-bf16.safetensors`` for LTX-2.5 packs,
+            ``ltx-2.3-22b-distilled-lora-384.safetensors`` for LTX-2.3 packs.
         distilled_lora_strength: LoRA fusion strength (default 1.0).
     """
 
     #: Whether the checkpoint is an LTX-2.5 weight pack. Resolved once per
-    #: pipeline instance by the subclasses that support 2.5 packs (currently
-    #: :class:`~ltx_pipelines_mlx.distilled.DistilledPipeline`); the class
-    #: default keeps every other two-stage pipeline on the 2.3 behaviour.
+    #: pipeline instance. The class default keeps instances without explicit
+    #: detection on the 2.3 behaviour; subclasses like
+    #: :class:`~ltx_pipelines_mlx.distilled.DistilledPipeline` set this
+    #: dynamically via :func:`is_ltx25_pack`.
     _is_25: bool = False
 
     def __init__(
@@ -123,10 +128,23 @@ class TI2VidTwoStagesPipeline(BasePipeline):
         low_memory: bool = True,
         low_ram_streaming: bool = False,
         dev_transformer: str = "transformer-dev.safetensors",
-        distilled_lora: str = "ltx-2.3-22b-distilled-lora-384.safetensors",
+        distilled_lora: str | None = None,
         distilled_lora_strength: float = 1.0,
         tile_count=None,
-    ):
+    ) -> None:
+        """Initialize the two-stage pipeline.
+
+        Args:
+            model_dir: Path to model weights or HuggingFace repo ID.
+            gemma_model_id: Gemma model for text encoding.
+            low_memory: Aggressive memory management.
+            low_ram_streaming: Stream transformer blocks from disk.
+            dev_transformer: Dev transformer filename.
+            distilled_lora: Distilled LoRA filename. When ``None``, resolved based
+                on pack version via :func:`is_ltx25_pack`.
+            distilled_lora_strength: LoRA fusion strength (default 1.0).
+            tile_count: Optional tiling configuration.
+        """
         super().__init__(
             model_dir,
             gemma_model_id=gemma_model_id,
@@ -134,6 +152,13 @@ class TI2VidTwoStagesPipeline(BasePipeline):
             low_ram_streaming=low_ram_streaming,
         )
         self._dev_transformer = dev_transformer
+        self._is_25 = is_ltx25_pack(self.model_dir)
+        if distilled_lora is None:
+            distilled_lora = (
+                "ltx-2.5-22b-distilled-lora-450-bf16.safetensors"
+                if self._is_25
+                else "ltx-2.3-22b-distilled-lora-384.safetensors"
+            )
         self._distilled_lora = distilled_lora
         self._distilled_lora_strength = distilled_lora_strength
         self._tile_count = tile_count

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ti2vid_two_stages_hq.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ti2vid_two_stages_hq.py
@@ -113,6 +113,8 @@ class TI2VidTwoStagesHQPipeline(TI2VidTwoStagesPipeline):
         / ``tap`` are forwarded to ``res2s_denoise_loop`` exactly as in the
         Euler path.
         """
+        self._check_teacache_supported(enable_teacache)
+
         # --- Text encoding (Prompt Relay: encode the combined prompt) ---
         encode_prompt, relay_token_ranges = self._prompt_relay_setup(prompt, prompt_relay)
         video_embeds, audio_embeds, neg_video_embeds, neg_audio_embeds = self._encode_text_with_negative(encode_prompt)

--- a/tests/test_ltx25_two_stage.py
+++ b/tests/test_ltx25_two_stage.py
@@ -51,27 +51,6 @@ def _make_two_stage(
     if with_upscaler:
         (tmp_path / with_upscaler).touch()
 
-    # Stub out network-dependent methods
-    def stub_load_text_encoder():
-        pass
-
-    def stub_encode_text(prompt):
-        import mlx.core as mx
-
-        return (
-            mx.zeros((1, 8, 4096), dtype=mx.bfloat16),
-            mx.zeros((1, 8, 2048), dtype=mx.bfloat16),
-        )
-
-    monkeypatch.setattr(
-        "ltx_pipelines_mlx._base.BasePipeline._load_text_encoder",
-        stub_load_text_encoder,
-    )
-    monkeypatch.setattr(
-        "ltx_pipelines_mlx._base.BasePipeline._encode_text",
-        stub_encode_text,
-    )
-
     return TI2VidTwoStagesPipeline(
         model_dir=str(tmp_path),
         distilled_lora=distilled_lora,
@@ -94,27 +73,6 @@ def _make_two_stage_hq(
 
     if with_upscaler:
         (tmp_path / with_upscaler).touch()
-
-    # Stub out network-dependent methods
-    def stub_load_text_encoder():
-        pass
-
-    def stub_encode_text(prompt):
-        import mlx.core as mx
-
-        return (
-            mx.zeros((1, 8, 4096), dtype=mx.bfloat16),
-            mx.zeros((1, 8, 2048), dtype=mx.bfloat16),
-        )
-
-    monkeypatch.setattr(
-        "ltx_pipelines_mlx._base.BasePipeline._load_text_encoder",
-        stub_load_text_encoder,
-    )
-    monkeypatch.setattr(
-        "ltx_pipelines_mlx._base.BasePipeline._encode_text",
-        stub_encode_text,
-    )
 
     return TI2VidTwoStagesHQPipeline(
         model_dir=str(tmp_path),
@@ -220,3 +178,39 @@ def test_teacache_still_allowed_on_23_pack_hq(tmp_path, monkeypatch):
     monkeypatch.setattr(pipe, "_encode_text_with_negative", boom, raising=False)
     with pytest.raises(_AbortError):
         pipe.generate_two_stage(prompt="a fox", frame_rate=24.0, enable_teacache=True)
+
+
+def test_cli_generate_distilled_lora_defaults_to_none(monkeypatch):
+    """Regression for the C1 review finding: the CLI must not reintroduce a
+    literal ``--distilled-lora`` default, or the pack-evidence resolution in
+    ``TI2VidTwoStagesPipeline.__init__`` (2.5 -> ...-450-bf16, 2.3 -> ...-384)
+    is unreachable from ``generate --two-stage``. This test parses real argv
+    through the real CLI parser (not a hand-built parser) so it fails the
+    same way #C1 did if the default is ever reintroduced.
+    """
+    import ltx_pipelines_mlx.cli as cli
+
+    captured: dict = {}
+
+    def _capture(args):
+        captured["distilled_lora"] = args.distilled_lora
+
+    monkeypatch.setattr(cli, "_cmd_generate", _capture)
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "ltx-2-mlx",
+            "generate",
+            "--two-stage",
+            "--prompt",
+            "a fox",
+            "--frame-rate",
+            "24",
+            "-o",
+            "out.mp4",
+        ],
+    )
+
+    cli.main()
+
+    assert captured["distilled_lora"] is None

--- a/tests/test_ltx25_two_stage.py
+++ b/tests/test_ltx25_two_stage.py
@@ -1,0 +1,123 @@
+"""LTX-2.5 pack detection + distilled LoRA resolution in TI2VidTwoStagesPipeline.
+
+The tests exercise pack-evidence-based LoRA resolution (2.5 vs 2.3 defaults),
+explicit-argument override, and upsampler path resolution via synthetic packs
+shaped like 2.5 configs, 2.3 configs, and missing configs.
+"""
+
+import json
+
+from ltx_pipelines_mlx.ti2vid_two_stages import TI2VidTwoStagesPipeline
+
+
+def _write_pack_config(tmp_path, *, ltx25: bool) -> None:
+    """Write a minimal transformer config marking the dir as a 2.5 / 2.3 pack."""
+    transformer: dict = {"num_layers": 48}
+    if ltx25:
+        transformer["ff_bias"] = False
+    (tmp_path / "embedded_config.json").write_text(json.dumps({"transformer": transformer}))
+
+
+def _make_two_stage(
+    tmp_path,
+    monkeypatch,
+    *,
+    ltx25: bool,
+    distilled_lora: str | None = None,
+    with_upscaler: str | None = None,
+) -> TI2VidTwoStagesPipeline:
+    """Build a TI2VidTwoStagesPipeline over a synthetic pack.
+
+    Writes tmp_path/embedded_config.json shaped like a 2.5 or 2.3 config,
+    creates an empty tmp_path/<with_upscaler>.safetensors if requested,
+    stubs out network-dependent methods via monkeypatch, then constructs
+    TI2VidTwoStagesPipeline(model_dir=str(tmp_path), distilled_lora=distilled_lora).
+
+    Args:
+        tmp_path: pytest temporary directory.
+        monkeypatch: pytest monkeypatch fixture.
+        ltx25: When True, write ff_bias=False (LTX-2.5 signal).
+        distilled_lora: Optional override for the distilled LoRA filename.
+        with_upscaler: Optional upsampler filename to create as an empty file.
+
+    Returns:
+        Constructed TI2VidTwoStagesPipeline instance.
+    """
+    _write_pack_config(tmp_path, ltx25=ltx25)
+
+    if with_upscaler:
+        (tmp_path / with_upscaler).touch()
+
+    # Stub out network-dependent methods
+    def stub_load_text_encoder():
+        pass
+
+    def stub_encode_text(prompt):
+        import mlx.core as mx
+
+        return (
+            mx.zeros((1, 8, 4096), dtype=mx.bfloat16),
+            mx.zeros((1, 8, 2048), dtype=mx.bfloat16),
+        )
+
+    monkeypatch.setattr(
+        "ltx_pipelines_mlx._base.BasePipeline._load_text_encoder",
+        stub_load_text_encoder,
+    )
+    monkeypatch.setattr(
+        "ltx_pipelines_mlx._base.BasePipeline._encode_text",
+        stub_encode_text,
+    )
+
+    return TI2VidTwoStagesPipeline(
+        model_dir=str(tmp_path),
+        distilled_lora=distilled_lora,
+    )
+
+
+def test_25_pack_sets_is_25_true(tmp_path, monkeypatch):
+    """Verify that an LTX-2.5 pack sets _is_25 to True."""
+    pipe = _make_two_stage(tmp_path, monkeypatch, ltx25=True)
+    assert pipe._is_25 is True
+
+
+def test_23_pack_sets_is_25_false(tmp_path, monkeypatch):
+    """Verify that an LTX-2.3 pack sets _is_25 to False."""
+    pipe = _make_two_stage(tmp_path, monkeypatch, ltx25=False)
+    assert pipe._is_25 is False
+
+
+def test_25_pack_resolves_450_lora_by_default(tmp_path, monkeypatch):
+    """Verify that an LTX-2.5 pack resolves to the 2.5 distilled LoRA when unspecified."""
+    pipe = _make_two_stage(tmp_path, monkeypatch, ltx25=True)
+    assert pipe._distilled_lora == "ltx-2.5-22b-distilled-lora-450-bf16.safetensors"
+
+
+def test_23_pack_resolves_384_lora_by_default(tmp_path, monkeypatch):
+    """Verify that an LTX-2.3 pack resolves to the 2.3 distilled LoRA when unspecified."""
+    pipe = _make_two_stage(tmp_path, monkeypatch, ltx25=False)
+    assert pipe._distilled_lora == "ltx-2.3-22b-distilled-lora-384.safetensors"
+
+
+def test_explicit_lora_wins_on_25_pack(tmp_path, monkeypatch):
+    """Verify that an explicit distilled_lora overrides the 2.5 default."""
+    pipe = _make_two_stage(tmp_path, monkeypatch, ltx25=True, distilled_lora="custom.safetensors")
+    assert pipe._distilled_lora == "custom.safetensors"
+
+
+def test_explicit_lora_wins_on_23_pack(tmp_path, monkeypatch):
+    """Verify that an explicit distilled_lora overrides the 2.3 default."""
+    pipe = _make_two_stage(tmp_path, monkeypatch, ltx25=False, distilled_lora="custom.safetensors")
+    assert pipe._distilled_lora == "custom.safetensors"
+
+
+def test_25_pack_upsampler_resolves_v1_0(tmp_path, monkeypatch):
+    """Verify that an LTX-2.5 pack picks the v1_0 upsampler when present."""
+    pipe = _make_two_stage(tmp_path, monkeypatch, ltx25=True, with_upscaler="spatial_upscaler_x2_v1_0.safetensors")
+    assert pipe._resolve_upsampler_path().name == "spatial_upscaler_x2_v1_0.safetensors"
+
+
+def test_23_pack_keeps_v1_1_upsampler(tmp_path, monkeypatch):
+    """Verify that an LTX-2.3 pack keeps the v1_1 upsampler."""
+    pipe = _make_two_stage(tmp_path, monkeypatch, ltx25=False, with_upscaler="spatial_upscaler_x2_v1_1.safetensors")
+    assert pipe._resolve_upsampler_path().name == "spatial_upscaler_x2_v1_1.safetensors"

--- a/tests/test_ltx25_two_stage.py
+++ b/tests/test_ltx25_two_stage.py
@@ -10,6 +10,7 @@ import json
 import pytest
 
 from ltx_pipelines_mlx.ti2vid_two_stages import TI2VidTwoStagesPipeline
+from ltx_pipelines_mlx.ti2vid_two_stages_hq import TI2VidTwoStagesHQPipeline
 
 
 def _write_pack_config(tmp_path, *, ltx25: bool) -> None:
@@ -72,6 +73,50 @@ def _make_two_stage(
     )
 
     return TI2VidTwoStagesPipeline(
+        model_dir=str(tmp_path),
+        distilled_lora=distilled_lora,
+    )
+
+
+def _make_two_stage_hq(
+    tmp_path,
+    monkeypatch,
+    *,
+    ltx25: bool,
+    distilled_lora: str | None = None,
+    with_upscaler: str | None = None,
+) -> TI2VidTwoStagesHQPipeline:
+    """Build a TI2VidTwoStagesHQPipeline over a synthetic pack.
+
+    Same as _make_two_stage but constructs TI2VidTwoStagesHQPipeline instead.
+    """
+    _write_pack_config(tmp_path, ltx25=ltx25)
+
+    if with_upscaler:
+        (tmp_path / with_upscaler).touch()
+
+    # Stub out network-dependent methods
+    def stub_load_text_encoder():
+        pass
+
+    def stub_encode_text(prompt):
+        import mlx.core as mx
+
+        return (
+            mx.zeros((1, 8, 4096), dtype=mx.bfloat16),
+            mx.zeros((1, 8, 2048), dtype=mx.bfloat16),
+        )
+
+    monkeypatch.setattr(
+        "ltx_pipelines_mlx._base.BasePipeline._load_text_encoder",
+        stub_load_text_encoder,
+    )
+    monkeypatch.setattr(
+        "ltx_pipelines_mlx._base.BasePipeline._encode_text",
+        stub_encode_text,
+    )
+
+    return TI2VidTwoStagesHQPipeline(
         model_dir=str(tmp_path),
         distilled_lora=distilled_lora,
     )
@@ -145,6 +190,29 @@ def test_teacache_still_allowed_on_23_pack(tmp_path, monkeypatch):
     verify that it gets raised, not a ValueError from the guard.
     """
     pipe = _make_two_stage(tmp_path, monkeypatch, ltx25=False)
+
+    def boom(*a, **k):
+        raise _AbortError
+
+    monkeypatch.setattr(pipe, "_encode_text_with_negative", boom, raising=False)
+    with pytest.raises(_AbortError):
+        pipe.generate_two_stage(prompt="a fox", frame_rate=24.0, enable_teacache=True)
+
+
+def test_teacache_raises_on_25_pack_hq(tmp_path, monkeypatch):
+    """Verify that enable_teacache=True raises ValueError on an LTX-2.5 pack (HQ pipeline)."""
+    pipe = _make_two_stage_hq(tmp_path, monkeypatch, ltx25=True)
+    with pytest.raises(ValueError, match="TeaCache"):
+        pipe.generate_two_stage(prompt="a fox", frame_rate=24.0, enable_teacache=True)
+
+
+def test_teacache_still_allowed_on_23_pack_hq(tmp_path, monkeypatch):
+    """Verify that the TeaCache guard does not raise on an LTX-2.3 pack (HQ pipeline).
+
+    We plant a probe (_AbortError) right after the guard (in text encoding) and
+    verify that it gets raised, not a ValueError from the guard.
+    """
+    pipe = _make_two_stage_hq(tmp_path, monkeypatch, ltx25=False)
 
     def boom(*a, **k):
         raise _AbortError

--- a/tests/test_ltx25_two_stage.py
+++ b/tests/test_ltx25_two_stage.py
@@ -7,6 +7,8 @@ shaped like 2.5 configs, 2.3 configs, and missing configs.
 
 import json
 
+import pytest
+
 from ltx_pipelines_mlx.ti2vid_two_stages import TI2VidTwoStagesPipeline
 
 
@@ -121,3 +123,32 @@ def test_23_pack_keeps_v1_1_upsampler(tmp_path, monkeypatch):
     """Verify that an LTX-2.3 pack keeps the v1_1 upsampler."""
     pipe = _make_two_stage(tmp_path, monkeypatch, ltx25=False, with_upscaler="spatial_upscaler_x2_v1_1.safetensors")
     assert pipe._resolve_upsampler_path().name == "spatial_upscaler_x2_v1_1.safetensors"
+
+
+def test_teacache_raises_on_25_pack(tmp_path, monkeypatch):
+    """Verify that enable_teacache=True raises ValueError on an LTX-2.5 pack."""
+    pipe = _make_two_stage(tmp_path, monkeypatch, ltx25=True)
+    with pytest.raises(ValueError, match="TeaCache"):
+        pipe.generate_two_stage(prompt="a fox", frame_rate=24.0, enable_teacache=True)
+
+
+class _AbortError(Exception):
+    """Sentinel exception for testing that guard allows 2.3 path to proceed."""
+
+    pass
+
+
+def test_teacache_still_allowed_on_23_pack(tmp_path, monkeypatch):
+    """Verify that the TeaCache guard does not raise on an LTX-2.3 pack.
+
+    We plant a probe (_AbortError) right after the guard (in text encoding) and
+    verify that it gets raised, not a ValueError from the guard.
+    """
+    pipe = _make_two_stage(tmp_path, monkeypatch, ltx25=False)
+
+    def boom(*a, **k):
+        raise _AbortError
+
+    monkeypatch.setattr(pipe, "_encode_text_with_negative", boom, raising=False)
+    with pytest.raises(_AbortError):
+        pipe.generate_two_stage(prompt="a fox", frame_rate=24.0, enable_teacache=True)


### PR DESCRIPTION
## Summary

\`generate --two-stage --model <pack-2.5>\` now runs end-to-end (dev model + CFG stage 1, distilled-LoRA refine stage 2). Auto-detected via \`is_ltx25_pack\`; no new flag; 2.3 byte-identical.

- \`TI2VidTwoStagesPipeline\` sets \`_is_25\` from pack evidence and resolves \`distilled_lora=None\` accordingly (2.5 → \`ltx-2.5-22b-distilled-lora-450-bf16.safetensors\`, 2.3 → unchanged default). \`_is_25\` is declared once on \`BasePipeline\`; the redundant recompute in \`DistilledPipeline\` was removed.
- CLI \`--distilled-lora\` default is now \`None\` (resolved from the pack) — the literal 2.3 default would have broken non-\`--low-ram\` two-stage on 2.5 (caught in final review; argparse→constructor regression test added).
- TeaCache on 2.5 → explicit \`ValueError\` via a shared \`_check_teacache_supported\`, called first-statement in BOTH the standard and HQ \`generate_two_stage\` (the HQ override does not inherit the base body — mutation-tested both directions).
- Upscaler v1_0 resolution comes alive on this path via \`_is_25\` (wired in #106's groundwork).
- Docs: two-stage marked supported on 2.5; \`--two-stages-hq\` remains not supported (guard present, pipeline unvalidated).

## Validation

- **2.3 byte-identity**: two-stage baseline SHA identical main-vs-branch (\`53e1f852…\`); distilled SHA-gate \`1248862480…\` exact.
- **T2V 2.5 determinism**: two identical renders (\`5b372402…\`); **I2V 2.5** end-to-end OK; suites 776+31, ruff clean.
- **Audio (known model behaviour, torch-verified)**: the 2.5 dev-path audio runs quiet at short durations (−58.6 dB at 512×512×49 vs 2.3's −35.2 dB, same config). Golden block-streamed torch forwards on \`transformer-dev\` reproduce our MLX outputs (corr 0.9986) — the port is faithful; the drift is the checkpoint's, same family as the ancestral finding in #106. Audio CFG is not the cause (probed). Follow-up candidate (separate PR, affects 2.3 + re-baseline): current upstream keeps **stage-1** audio and discards stage-2's — our port predates that change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Yai9eY2wgyDpQJmmtTw9o