### PR TITLE
docs: mark --two-stages-hq as supported on LTX-2.5 packs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -965,14 +965,14 @@ ltx-2-mlx generate --model /path/to/ltx-2.5-mlx-q8 --two-stage --low-ram \
 | Feature | Status |
 |---|---|
 | `--two-stage` (dev model + CFG) | supported (see above) |
-| `--two-stages-hq` (res_2s + CFG) | not yet supported |
+| `--two-stages-hq` (res_2s + CFG) | supported — validated e2e on 2.5 (deterministic, audio at healthy 2.3-level loudness) |
 | `a2v`, `keyframe`, `ic-lora`, `hdr-ic-lora`, `retake`, `extend`, `lipdub` | not yet supported |
 | `enhance` / `--enhance-prompt` | raises `NotImplementedError` (`_guard_enhance_not_gemma4`) — Gemma 3 only |
 | `--enable-teacache` | raises `ValueError` — 2.3 polynomial isn't calibrated for 2.5 |
 | Modality tiling, Prompt Relay | validated on 2.3 only |
 | Diffusion (`DiffVAEMode`) VAE decoder | not loaded — conv `vae_decoder_conv` used (see Weight Format) |
 
-Further 2.5 pipelines (`--two-stages-hq`, a2v, keyframe, ic-lora, ...) land in
+Further 2.5 pipelines (a2v, keyframe, ic-lora, ...) land in
 subsequent releases behind the same pack-evidence detection.
 
 ### Key Files

--- a/README.md
+++ b/README.md
@@ -146,14 +146,14 @@ ltx-2-mlx generate --model /path/to/ltx-2.5-mlx-q8 --two-stage \
 | Feature | Status |
 |---|---|
 | `--two-stage` (dev + CFG) | supported (see above) |
-| `--two-stages-hq` (res_2s + CFG) | not yet supported |
+| `--two-stages-hq` (res_2s + CFG) | supported — validated e2e on 2.5 (deterministic, audio at healthy 2.3-level loudness) |
 | `a2v`, `keyframe`, `ic-lora`, `hdr-ic-lora`, `retake`, `extend`, `lipdub` | not yet supported |
 | `enhance` / `--enhance-prompt` | raises a clear error (Gemma 3-only) |
 | `--enable-teacache` | raises a clear error (not calibrated for 2.5) |
 | Modality tiling, Prompt Relay | validated on 2.3 only |
 | Diffusion (`DiffVAEMode`) VAE decoder | not loaded — conv decoder used |
 
-Further 2.5 pipelines (`--two-stages-hq`, a2v, keyframe, ic-lora, ...) land in
+Further 2.5 pipelines (a2v, keyframe, ic-lora, ...) land in
 subsequent releases.
 
 ### Python API


### PR DESCRIPTION
No code change — the HQ pipeline inherits everything from #107/#108. Validated e2e on the 2.5 q8 pack (512×512×49, seed 81647281): SHA-deterministic across two runs (\`5f66ac60…\`), audio −36.2 dB mean / −15.1 max — healthy 2.3-level loudness, notably better than \`--two-stage\` on the same checkpoint (−50.8 dB). Render delivered for user review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Yai9eY2wgyDpQJmmtTw9o