### PR TITLE
feat(pipelines): validate keyframe interpolation on LTX-2.5 packs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -966,7 +966,8 @@ ltx-2-mlx generate --model /path/to/ltx-2.5-mlx-q8 --two-stage --low-ram \
 |---|---|
 | `--two-stage` (dev model + CFG) | supported (see above) |
 | `--two-stages-hq` (res_2s + CFG) | supported — validated e2e on 2.5 (deterministic, audio at healthy 2.3-level loudness) |
-| `a2v`, `keyframe`, `ic-lora`, `hdr-ic-lora`, `retake`, `extend`, `lipdub` | not yet supported |
+| `keyframe` | supported — validated e2e on 2.5 (deterministic, audio -38.3 dB; requires `--dev-transformer transformer-dev.safetensors`) |
+| `a2v`, `ic-lora`, `hdr-ic-lora`, `retake`, `extend`, `lipdub` | not yet supported |
 | `enhance` / `--enhance-prompt` | raises `NotImplementedError` (`_guard_enhance_not_gemma4`) — Gemma 3 only |
 | `--enable-teacache` | raises `ValueError` — 2.3 polynomial isn't calibrated for 2.5 |
 | Modality tiling, Prompt Relay | validated on 2.3 only |

--- a/README.md
+++ b/README.md
@@ -147,7 +147,8 @@ ltx-2-mlx generate --model /path/to/ltx-2.5-mlx-q8 --two-stage \
 |---|---|
 | `--two-stage` (dev + CFG) | supported (see above) |
 | `--two-stages-hq` (res_2s + CFG) | supported — validated e2e on 2.5 (deterministic, audio at healthy 2.3-level loudness) |
-| `a2v`, `keyframe`, `ic-lora`, `hdr-ic-lora`, `retake`, `extend`, `lipdub` | not yet supported |
+| `keyframe` | supported — validated e2e on 2.5 (deterministic, audio -38.3 dB; requires `--dev-transformer transformer-dev.safetensors`) |
+| `a2v`, `ic-lora`, `hdr-ic-lora`, `retake`, `extend`, `lipdub` | not yet supported |
 | `enhance` / `--enhance-prompt` | raises a clear error (Gemma 3-only) |
 | `--enable-teacache` | raises a clear error (not calibrated for 2.5) |
 | Modality tiling, Prompt Relay | validated on 2.3 only |

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/keyframe_interpolation.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/keyframe_interpolation.py
@@ -199,9 +199,9 @@ class KeyframeInterpolationPipeline(TI2VidTwoStagesPipeline):
             raise ValueError(
                 "Keyframe interpolation requires the dev (non-distilled) model. "
                 "The distilled model hallucinates unrelated content during interpolation.\n"
-                "Use: --dev-transformer transformer-dev.safetensors "
-                "--distilled-lora ltx-2.3-22b-distilled-lora-384.safetensors --cfg-scale 3.0\n"
-                "Model repo with both variants: dgrauet/ltx-2.3-mlx-q8"
+                "Use: --dev-transformer transformer-dev.safetensors --cfg-scale 3.0 "
+                "(the distilled LoRA for stage 2 is resolved from the pack; "
+                "override with --distilled-lora if needed)"
             )
         if self.dit is None:
             self.dit = self._load_dev_transformer()


### PR DESCRIPTION
No pipeline change — \`KeyframeInterpolationPipeline\` inherits the 2.5 wiring from #107/#108. Validated e2e on the 2.5 q8 pack (512×512×49, seed 81647281, \`--dev-transformer transformer-dev.safetensors --low-ram\`): SHA-deterministic across two runs (\`622375dd…\`), audio −38.3 dB mean (healthy). Render delivered for user review.

Also modernizes the dev-model guard message (it hardcoded the 2.3 LoRA filename + repo; the LoRA now resolves from the pack) and updates the v1-limits tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Yai9eY2wgyDpQJmmtTw9o