### PR TITLE
feat(pipelines)!: auto-predicted duration via the LTX-2.5 DurationHead

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -352,7 +352,7 @@ Entry point: `uv run ltx-2-mlx <command>`. Available commands:
 
 | Command | Pipeline | Tier | Description |
 |---------|----------|------|-------------|
-| `generate` | T2V / I2V (mode flag required) | Stable | `--one-stage` (dev+CFG @ target), `--two-stage` (dev+CFG+upscale, recommended), `--two-stages-hq` (res_2s+CFG+upscale), `--distilled` (distilled+upscale, fastest). `--image` for I2V on any mode. `--segment` for Prompt Relay temporal prompt gating. |
+| `generate` | T2V / I2V (mode flag required) | Stable | `--one-stage` (dev+CFG @ target), `--two-stage` (dev+CFG+upscale, recommended), `--two-stages-hq` (res_2s+CFG+upscale), `--distilled` (distilled+upscale, fastest). `--image` for I2V on any mode. `--segment` for Prompt Relay temporal prompt gating. `-f/--frames` defaults to auto-predicted duration on 2.5 packs (via `DurationHead`) and is **required** on 2.3 packs (immediate `ValueError` before any Gemma load if omitted). `--auto-duration MIN:MAX` overrides the predictor's clamp range on 2.5 packs. |
 | `keyframe` | Keyframe interpolation | Stable | Two-stage interpolation between start/end frames |
 | `ic-lora` | IC-LoRA | Stable | Two-stage generation with control video conditioning (depth, canny, pose, motion tracks) |
 | `hdr-ic-lora` | HDR IC-LoRA | Stable | Two-stage HDR generation via IC-LoRA + LogC3 inverse (saves SDR mp4 + linear-HDR `.npz`) |
@@ -377,11 +377,11 @@ ltx-2-mlx generate \
   --low-ram \
   -H 480 -W 704 -f 33 -o fox.mp4
 
-# q8 inference fits 16 GB Macs
+# q8 inference fits 16 GB Macs (2.3 packs require -f explicitly — no DurationHead)
 ltx-2-mlx generate \
   --model dgrauet/ltx-2.3-mlx-q8 \
   --prompt "a fox in the forest" \
-  --low-ram -o fox.mp4
+  --low-ram -f 97 -o fox.mp4
 ```
 
 `--low-ram` is supported on `generate` (one-stage / `--two-stage` / `--two-stages-hq`), `a2v`, `keyframe`, and `ic-lora`. Bind-time LoRA fusion handles ic-lora's control LoRAs, custom `--distilled-lora-strength`, and `generate --lora` (community LoRAs). See `## Block Streaming` below for details.
@@ -459,23 +459,30 @@ Outputs both `out.mp4` (SDR preview, tonemapped) and `out.hdr.npz` (float32 `(F,
 ### Two-Stage Example
 
 ```bash
-# Two-stage with Euler sampler (auto-selects q8 model)
+# Two-stage with Euler sampler (auto-selects q8 model; -f required on 2.3 packs)
 ltx-2-mlx generate \
   --prompt "a scene description" \
-  --two-stage -o output.mp4
+  --two-stage -f 97 -o output.mp4
 
 # HQ with res_2s second-order sampler (higher quality, ~2x slower)
 ltx-2-mlx generate \
   --prompt "a scene description" \
-  --two-stages-hq -o output.mp4
+  --two-stages-hq -f 97 -o output.mp4
 
 # With I2V conditioning
 ltx-2-mlx generate \
   --prompt "animate this" \
-  --two-stage --image photo.jpg -o output.mp4
+  --two-stage --image photo.jpg -f 97 -o output.mp4
+
+# On a 2.5 pack, -f can be omitted — duration is auto-predicted from the prompt/image
+# via the DurationHead (see "LTX-2.5" section below), or clamped with --auto-duration MIN:MAX
+ltx-2-mlx generate \
+  --model /path/to/ltx-2.5-mlx-q8 \
+  --prompt "a scene description" \
+  --distilled --auto-duration 2:6 -o output.mp4
 ```
 
-Flags: `--two-stage` (Euler), `--two-stages-hq` (res_2s), `--cfg-scale` (default 3.0), `--stg-scale` (default 0.0), `--stage1-steps` (default 30 standard, 15 HQ), `--stage2-steps` (default 3), `--image`.
+Flags: `--two-stage` (Euler), `--two-stages-hq` (res_2s), `--cfg-scale` (default 3.0), `--stg-scale` (default 0.0), `--stage1-steps` (default 30 standard, 15 HQ), `--stage2-steps` (default 3), `--image`, `-f/--frames` (required on 2.3 packs; optional on 2.5 packs — auto-predicted when omitted), `--auto-duration MIN:MAX` (2.5 packs only — overrides the predictor's clamp range; explicit `-f` wins over `--auto-duration` if both are given, with a warning).
 
 ### Prompt Relay (`--segment`)
 
@@ -663,8 +670,8 @@ pipeline.generate_and_save(
 Equivalent CLI flag (works on both `--two-stage` and `--two-stages-hq`):
 
 ```bash
-ltx-2-mlx generate --prompt "..." --two-stage --enable-teacache -o out.mp4
-ltx-2-mlx generate --prompt "..." --two-stages-hq --enable-teacache --teacache-thresh 1.0 -o out.mp4
+ltx-2-mlx generate --prompt "..." --two-stage -f 97 --enable-teacache -o out.mp4
+ltx-2-mlx generate --prompt "..." --two-stages-hq -f 97 --enable-teacache --teacache-thresh 1.0 -o out.mp4
 ```
 
 The HQ path uses the res_2s sampler, which does two model evaluations per outer step (stage 1 at `sigma`, stage 2 at the substep after SDE noise injection). The TeaCache decision is made **once per outer step** on stage 1's gate signal; on skip both stages reuse cached residuals via `block_stack_override`. Cache payload shape: `{"stage1": {cond: (v,a), uncond: (v,a), ...}, "stage2": {...}}`.
@@ -945,6 +952,56 @@ that path. 2.3 packs are byte-identical to before.
 - Ancestral noise is seeded from `seed + ANCESTRAL_NOISE_SEED_OFFSET` (10000) to decorrelate from the initial-latent draw.
 - Stage 2 upscaler resolves to `spatial_upscaler_x2_v1_0.safetensors` (vs `v1_1` on 2.3), falling back to the 2.3 stems; hard error only when none exists (#42 style).
 
+### Auto-Duration (`DurationHead`, `-f` optional on 2.5)
+
+2.5 packs ship a `duration_head.safetensors` (`packages/ltx-core-mlx/src/ltx_core_mlx/duration_head/`)
+that predicts a clip length in seconds from the encoded prompt (+ image,
+when present). `generate`'s `-f/--frames` default changed from a hardcoded
+`97` to `AutoDuration()` (`DEFAULT_AUTO_DURATION`, clamp `[1.0, 20.0]`
+seconds) across the four `generate` modes (`--one-stage`, `--distilled`,
+`--two-stage`, `--two-stages-hq`) — **only** those; `keyframe`, `a2v`,
+`ic-lora`, `retake`, `extend` keep their existing explicit `-f 97` default
+untouched.
+
+- **On 2.5 packs**: omitting `-f` predicts the duration right after prompt
+  encoding (`DurationPredictor.from_checkpoint(self.model_dir)`, built once
+  in `BasePipeline.__init__`) and snaps it to the model's frame grid
+  (`(num_frames - 1) % 8 == 0`). A `[auto-duration] predicted N frames
+  (S.SSs @ FPS fps)` line prints to stderr when a prediction actually runs.
+  `--auto-duration MIN:MAX` overrides the clamp range (seconds); explicit
+  `-f` always wins over `--auto-duration` if both are given, with a stderr
+  warning.
+- **On 2.3 packs** (no `DurationHead` weights): omitting `-f` raises
+  `ValueError: ... Pass num_frames explicitly.` **immediately** —
+  `require_num_frames_source()` runs before any Gemma load or other work,
+  so there's no wasted encode/download on the failure path. `-f` is
+  effectively mandatory on 2.3.
+
+```bash
+# 2.5: let the DurationHead pick the length from the prompt
+ltx-2-mlx generate --model /path/to/ltx-2.5-mlx-q8 --distilled \
+  -p "a heavy wooden door creaks slowly open" -H 512 -W 512 --frame-rate 24 -o out.mp4
+
+# 2.5: clamp the predicted duration to 2-4 seconds
+ltx-2-mlx generate --model /path/to/ltx-2.5-mlx-q8 --distilled \
+  -p "a heavy wooden door creaks slowly open" -H 512 -W 512 --frame-rate 24 \
+  --auto-duration 2:4 -o out.mp4
+
+# 2.3: -f is required — this fails fast with no Gemma/network activity
+ltx-2-mlx generate --model dgrauet/ltx-2.3-mlx-q8 --distilled \
+  -p "a heavy wooden door creaks slowly open" -H 512 -W 512 --frame-rate 24 -o out.mp4
+# ValueError: num_frames was AutoDuration but this checkpoint has no DurationHead
+# weights to auto-predict duration from (DurationHead ships from LTX 2.5 / gemma4
+# onward). Pass num_frames explicitly.
+```
+
+Key files: `packages/ltx-core-mlx/src/ltx_core_mlx/duration_head/duration_head.py`
+(`DurationHead`, `load_duration_head`); `packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/utils/types.py`
+(`AutoDuration`, `DEFAULT_AUTO_DURATION`); `packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/utils/blocks.py`
+(`DurationPredictor`, `require_num_frames_source`, `resolve_num_frames`,
+`seconds_to_clamped_num_frames`); `_base.py::BasePipeline._require_num_frames_source`
+/ `_resolve_num_frames`; `cli.py::_parse_auto_duration` / `_resolve_num_frames_arg`.
+
 ### Two-Stage on LTX-2.5
 
 `generate --two-stage --model <2.5-pack-dir>` runs the dev model + CFG
@@ -966,6 +1023,7 @@ ltx-2-mlx generate --model /path/to/ltx-2.5-mlx-q8 --two-stage --low-ram \
 |---|---|
 | `--two-stage` (dev model + CFG) | supported (see above) |
 | `--two-stages-hq` (res_2s + CFG) | supported — validated e2e on 2.5 (deterministic, audio at healthy 2.3-level loudness) |
+| `DurationHead` / auto-duration (`-f` optional) | supported — `-f` defaults to `AutoDuration()` on `--one-stage`/`--distilled`/`--two-stage`/`--two-stages-hq`; `--auto-duration MIN:MAX` overrides the clamp. Absent on 2.3 packs, where omitting `-f` now raises immediately (see "Auto-Duration" above) |
 | `keyframe` | supported — validated e2e on 2.5 (deterministic, audio -38.3 dB; requires `--dev-transformer transformer-dev.safetensors`) |
 | `a2v` | supported — validated e2e on 2.5 (deterministic, conditioned audio faithfully reconstructed at -36.2 dB) |
 | `ic-lora`, `hdr-ic-lora`, `retake`, `extend`, `lipdub` | not yet supported (no official 2.5 task IC-LoRAs published yet) |

--- a/README.md
+++ b/README.md
@@ -51,19 +51,22 @@ uv sync --all-extras
 ```bash
 # Text-to-Video — pick a pipeline mode (one of `--two-stage`, `--two-stages-hq`, `--one-stage`, `--distilled`).
 # Two-stage is the upstream-recommended production default.
-ltx-2-mlx generate --prompt "A sunset over the ocean" --two-stage -o sunset.mp4
+# NOTE: -f/--frames is required on 2.3 packs (the default model below) — it
+# only defaults to an auto-predicted duration on LTX-2.5 packs. See "LTX-2.5"
+# and "CLI Reference" below.
+ltx-2-mlx generate --prompt "A sunset over the ocean" --two-stage -f 97 -o sunset.mp4
 
 # Image-to-Video (any mode supports --image)
-ltx-2-mlx generate --prompt "Animate this" --image photo.jpg --two-stage -o animated.mp4
+ltx-2-mlx generate --prompt "Animate this" --image photo.jpg --two-stage -f 97 -o animated.mp4
 
 # HQ (res_2s sampler, highest quality)
-ltx-2-mlx generate --prompt "A scene" --two-stages-hq --stage1-steps 20 -o hq.mp4
+ltx-2-mlx generate --prompt "A scene" --two-stages-hq --stage1-steps 20 -f 97 -o hq.mp4
 
 # Distilled two-stage (fastest, mirrors upstream DistilledPipeline)
-ltx-2-mlx generate --prompt "A scene" --distilled -H 720 -W 1280 -o distilled.mp4
+ltx-2-mlx generate --prompt "A scene" --distilled -H 720 -W 1280 -f 97 -o distilled.mp4
 
 # One-stage dev + CFG (full target res, mirrors upstream TI2VidOneStagePipeline)
-ltx-2-mlx generate --prompt "A scene" --one-stage -o one_stage.mp4
+ltx-2-mlx generate --prompt "A scene" --one-stage -f 97 -o one_stage.mp4
 
 # Audio-to-Video
 ltx-2-mlx a2v --prompt "Music video" --audio music.wav -o a2v.mp4
@@ -81,17 +84,17 @@ ltx-2-mlx keyframe --prompt "Smooth transition" --start frame1.png --end frame2.
 ltx-2-mlx enhance --prompt "a cat" --mode t2v
 
 # Use int4 model (fits 16GB)
-ltx-2-mlx generate -p "A cat" --distilled -o cat.mp4 --model dgrauet/ltx-2.3-mlx-q4
+ltx-2-mlx generate -p "A cat" --distilled -f 97 -o cat.mp4 --model dgrauet/ltx-2.3-mlx-q4
 
 # Block streaming: bf16 model on 32 GB Mac
-ltx-2-mlx generate -p "A cat" --two-stage -o cat.mp4 --model dgrauet/ltx-2.3-mlx --low-ram
+ltx-2-mlx generate -p "A cat" --two-stage -f 97 -o cat.mp4 --model dgrauet/ltx-2.3-mlx --low-ram
 
 # Block streaming: q8 model on 16 GB Mac
-ltx-2-mlx generate -p "A cat" --distilled -o cat.mp4 --model dgrauet/ltx-2.3-mlx-q8 --low-ram
+ltx-2-mlx generate -p "A cat" --distilled -f 97 -o cat.mp4 --model dgrauet/ltx-2.3-mlx-q8 --low-ram
 
 # Block streaming works on every generate mode + a2v / keyframe / ic-lora
-ltx-2-mlx generate -p "A cat" -o cat.mp4 --two-stage --low-ram
-ltx-2-mlx generate -p "A cat" -o cat.mp4 --two-stages-hq --low-ram
+ltx-2-mlx generate -p "A cat" -f 97 -o cat.mp4 --two-stage --low-ram
+ltx-2-mlx generate -p "A cat" -f 97 -o cat.mp4 --two-stages-hq --low-ram
 ltx-2-mlx a2v -p "music video" --audio music.wav -o a2v.mp4 --low-ram
 ltx-2-mlx keyframe -p "transition" --start a.png --end b.png -o kf.mp4 --low-ram
 ltx-2-mlx ic-lora -p "scene" --lora lora.safetensors 1.0 --video-conditioning depth.mp4 1.0 --low-ram -o out.mp4
@@ -107,9 +110,9 @@ ltx-2-mlx hdr-ic-lora -p "a sunset over the ocean, vivid HDR" \
 
 # Modality tiling: split video tokens for long/HD scenarios that exceed attention memory.
 # Stack with --low-ram for max memory savings on big targets.
-ltx-2-mlx generate -p "long scene" --two-stage --low-ram \
+ltx-2-mlx generate -p "long scene" --two-stage --low-ram -f 97 \
     --tile-frames 2 --tile-overlap 4 -o long.mp4
-ltx-2-mlx generate -p "1080p scene" --two-stages-hq --low-ram \
+ltx-2-mlx generate -p "1080p scene" --two-stages-hq --low-ram -f 97 \
     --tile-spatial 2 --tile-overlap 4 -H 1080 -W 1920 -o hd.mp4
 
 # Model info
@@ -121,6 +124,10 @@ ltx-2-mlx info --model dgrauet/ltx-2.3-mlx-q8
 ```bash
 ltx-2-mlx generate --distilled --model /path/to/ltx-2.5-mlx-q8 \
     --prompt "a heavy wooden door creaks slowly open" -o out.mp4
+
+# Clamp the auto-predicted duration to 2-4 seconds instead of the default [1, 20]s
+ltx-2-mlx generate --distilled --model /path/to/ltx-2.5-mlx-q8 \
+    --prompt "a heavy wooden door creaks slowly open" --auto-duration 2:4 -o out.mp4
 ```
 
 The 2.5 generation is **auto-detected from the model pack** (no new CLI
@@ -128,6 +135,15 @@ flag) — a local directory is required, since the pack bundles its own
 Gemma-4 text encoder (`text_encoder.safetensors`); no `mlx-community`
 Gemma download happens on this path. `--image` (I2V) works the same as on
 2.3.
+
+**`-f/--frames` is optional on 2.5 packs**: omit it and the pack's
+`DurationHead` predicts a clip length (seconds) from the encoded prompt
+right after text encoding, snapped to the model's frame grid. Pass
+`--auto-duration MIN:MAX` (seconds) to override the predictor's clamp
+range, or pass `-f` explicitly to bypass prediction entirely (explicit
+`-f` always wins). **On 2.3 packs, `-f` stays required** — there is no
+`DurationHead` to predict from, and omitting it now raises immediately
+(`ValueError: ... Pass num_frames explicitly.`) before any Gemma load.
 
 Sampling: stage 1 runs euler-ancestral (8 steps, SDE noise injection);
 stage 2 stays deterministic euler (3 steps) — upstream's rationale is that
@@ -147,6 +163,7 @@ ltx-2-mlx generate --model /path/to/ltx-2.5-mlx-q8 --two-stage \
 |---|---|
 | `--two-stage` (dev + CFG) | supported (see above) |
 | `--two-stages-hq` (res_2s + CFG) | supported — validated e2e on 2.5 (deterministic, audio at healthy 2.3-level loudness) |
+| `DurationHead` / auto-duration (`-f` optional) | supported — `-f` defaults to an auto-predicted duration on `--one-stage`/`--distilled`/`--two-stage`/`--two-stages-hq`; `--auto-duration MIN:MAX` overrides the clamp. Not available on 2.3 packs (no `DurationHead` weights); `-f` stays required there |
 | `keyframe` | supported — validated e2e on 2.5 (deterministic, audio -38.3 dB; requires `--dev-transformer transformer-dev.safetensors`) |
 | `a2v` | supported — validated e2e on 2.5 (deterministic, conditioned audio faithfully reconstructed at -36.2 dB) |
 | `ic-lora`, `hdr-ic-lora`, `retake`, `extend`, `lipdub` | not yet supported (no official 2.5 task IC-LoRAs published yet) |
@@ -234,7 +251,13 @@ ltx-2-mlx generate   T2V / I2V / two-stage / HQ generation
   --model, -m         Model weights (default: dgrauet/ltx-2.3-mlx-q8)
   --height, -H        Video height (default: 480)
   --width, -W         Video width (default: 704)
-  --frames, -f        Number of frames (default: 97)
+  --frames, -f        Number of frames. Required on 2.3 packs (no default —
+                      omitting it raises immediately). Optional on LTX-2.5
+                      packs: defaults to an auto-predicted duration via the
+                      pack's DurationHead when omitted.
+  --auto-duration MIN:MAX  Override the DurationHead's clamp range in seconds
+                      (LTX-2.5 packs only; default clamp [1.0, 20.0]s).
+                      Ignored if -f is also given (explicit -f wins, warns).
   --seed, -s          Random seed (-1 = random)
   --image, -i         Reference image for I2V
   --steps             Denoising steps for one-stage (default: 8)
@@ -324,7 +347,7 @@ step 4 instead of minute 15. Available on every generating subcommand (`generate
 ```
 
 ```bash
-ltx-2-mlx generate -p "a cat walking" -o out.mp4 --frame-rate 24 \
+ltx-2-mlx generate -p "a cat walking" -o out.mp4 -f 97 --frame-rate 24 \
   --stepwise-image-output-dir ./previews
 ```
 

--- a/packages/ltx-core-mlx/src/ltx_core_mlx/duration_head/__init__.py
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/duration_head/__init__.py
@@ -1,0 +1,15 @@
+"""Duration head: predicts shot duration in seconds from Connector outputs."""
+
+from ltx_core_mlx.duration_head.duration_head import (
+    AttentionCrossAttn,
+    AttentionPooler,
+    DurationHead,
+    load_duration_head,
+)
+
+__all__ = [
+    "AttentionCrossAttn",
+    "AttentionPooler",
+    "DurationHead",
+    "load_duration_head",
+]

--- a/packages/ltx-core-mlx/src/ltx_core_mlx/duration_head/duration_head.py
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/duration_head/duration_head.py
@@ -1,0 +1,261 @@
+"""DurationHead — predicts shot duration from frozen Connector outputs.
+
+Ported from ltx-core/src/ltx_core/duration_head/duration_head.py.
+
+The audio and video Connectors (``text_encoders/gemma/embeddings_connector.py``)
+consume a Gemma caption embedding and emit per-token hidden states. Their output
+dimension and sequence length are fixed by the production model, so a thin
+regression head on top has all the signal it needs to predict the natural
+duration of the implied shot -- without running the full diffusion pipeline.
+
+The head is modality-agnostic: pass either or both of {audio, video} connector
+outputs. Modality-specific input projections map each stream to a shared pooler
+hidden dim, learnable modality embeddings tag the streams so an attention
+pooler can tell them apart, and a small MLP turns the pooled vector into a
+log-duration prediction. Targets (when training) are in log-seconds so the
+loss spreads its budget evenly across orders of magnitude; at inference time
+callers get seconds directly -- ``exp`` is applied inside ``__call__``.
+
+Unlike the training-time head, this module never sees packed/multi-sample
+sequences, so it has no segment-id bookkeeping. It also needs no attention
+mask: the connector always substitutes learnable registers for padded
+positions and marks the result as fully attendable, so every token handed to
+this module is already valid.
+
+Weight keys (under the ``duration_head.`` prefix in ``duration_head.safetensors``):
+    ``video_input_proj.{weight,bias}``
+    ``video_modality_emb``
+    ``audio_input_proj.{weight,bias}``
+    ``audio_modality_emb``
+    ``attention_pooler.query_tokens``
+    ``attention_pooler.cross_attn.in_proj_weight``   # torch nn.MultiheadAttention, fused (3*hidden, hidden)
+    ``attention_pooler.cross_attn.in_proj_bias``     # fused (3*hidden,)
+    ``attention_pooler.cross_attn.out_proj.{weight,bias}``
+    ``mlp_hidden.{weight,bias}``
+    ``mlp_out.{weight,bias}``
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ltx_core_mlx.utils.weights import load_split_safetensors
+
+_PACK_PREFIX = "duration_head."
+
+
+class AttentionCrossAttn(nn.Module):
+    """Manual multi-head cross-attention, replacing torch ``nn.MultiheadAttention``.
+
+    Torch's ``nn.MultiheadAttention`` fuses q/k/v projections into a single
+    ``in_proj_weight``/``in_proj_bias`` pair. The loader splits that fused
+    weight into three separate projections so the module tree maps cleanly
+    onto named submodules (``q_proj``, ``k_proj``, ``v_proj``, ``out_proj``).
+
+    Args:
+        hidden_dim: Model / embedding dimension.
+        num_heads: Number of attention heads.
+    """
+
+    def __init__(self, hidden_dim: int = 256, num_heads: int = 4) -> None:
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = hidden_dim // num_heads
+        self.scale = self.head_dim**-0.5
+
+        self.q_proj = nn.Linear(hidden_dim, hidden_dim, bias=True)
+        self.k_proj = nn.Linear(hidden_dim, hidden_dim, bias=True)
+        self.v_proj = nn.Linear(hidden_dim, hidden_dim, bias=True)
+        self.out_proj = nn.Linear(hidden_dim, hidden_dim, bias=True)
+
+    def __call__(self, queries: mx.array, tokens: mx.array) -> mx.array:
+        """Cross-attend ``queries`` against ``tokens``.
+
+        Args:
+            queries: ``(B, Nq, hidden_dim)``.
+            tokens: ``(B, Nk, hidden_dim)``.
+
+        Returns:
+            ``(B, Nq, hidden_dim)``.
+        """
+        batch, num_queries, _ = queries.shape
+        num_tokens = tokens.shape[1]
+
+        q = self.q_proj(queries).reshape(batch, num_queries, self.num_heads, self.head_dim).transpose(0, 2, 1, 3)
+        k = self.k_proj(tokens).reshape(batch, num_tokens, self.num_heads, self.head_dim).transpose(0, 2, 1, 3)
+        v = self.v_proj(tokens).reshape(batch, num_tokens, self.num_heads, self.head_dim).transpose(0, 2, 1, 3)
+
+        scores = (q * self.scale) @ k.transpose(0, 1, 3, 2)
+        weights = mx.softmax(scores, axis=-1)
+        out = weights @ v
+
+        out = out.transpose(0, 2, 1, 3).reshape(batch, num_queries, self.num_heads * self.head_dim)
+        return self.out_proj(out)
+
+
+class AttentionPooler(nn.Module):
+    """Cross-attend ``num_queries`` learnable tokens against ``tokens``.
+
+    Produces a fixed-shape ``(B, num_queries, hidden_dim)`` output regardless
+    of the input sequence length. Every position in ``tokens`` is attendable
+    -- see the module docstring for why no mask is needed.
+
+    Args:
+        hidden_dim: Model / embedding dimension.
+        num_queries: Number of learnable pooling queries.
+        num_heads: Number of attention heads.
+    """
+
+    def __init__(self, hidden_dim: int = 256, num_queries: int = 1, num_heads: int = 4) -> None:
+        super().__init__()
+        self.hidden_dim = hidden_dim
+        self.num_queries = num_queries
+        self.query_tokens = mx.zeros((num_queries, hidden_dim))
+        self.cross_attn = AttentionCrossAttn(hidden_dim=hidden_dim, num_heads=num_heads)
+
+    def __call__(self, tokens: mx.array) -> mx.array:
+        """Pool ``tokens`` down to ``num_queries`` fixed slots.
+
+        Args:
+            tokens: ``(B, N, hidden_dim)``.
+
+        Returns:
+            ``(B, num_queries, hidden_dim)``.
+        """
+        batch = tokens.shape[0]
+        queries = mx.broadcast_to(self.query_tokens[None, :, :], (batch, self.num_queries, self.hidden_dim))
+        return self.cross_attn(queries, tokens)
+
+
+class DurationHead(nn.Module):
+    """Predict duration in seconds from one or both Connector outputs.
+
+    Args:
+        video_cross_attention_dim: Video connector output dim.
+        audio_cross_attention_dim: Audio connector output dim.
+        pooler_hidden_dim: Shared hidden dim both modalities are projected into.
+        num_queries: Number of learnable pooling queries.
+        num_pooler_heads: Attention heads used by the pooler.
+        mlp_hidden_dim: Hidden width of the output MLP.
+    """
+
+    def __init__(
+        self,
+        video_cross_attention_dim: int = 4096,
+        audio_cross_attention_dim: int = 2048,
+        pooler_hidden_dim: int = 256,
+        num_queries: int = 1,
+        num_pooler_heads: int = 4,
+        mlp_hidden_dim: int = 256,
+    ) -> None:
+        super().__init__()
+        self.pooler_hidden_dim = pooler_hidden_dim
+
+        self.video_input_proj = nn.Linear(video_cross_attention_dim, pooler_hidden_dim)
+        self.video_modality_emb = mx.zeros((pooler_hidden_dim,))
+
+        self.audio_input_proj = nn.Linear(audio_cross_attention_dim, pooler_hidden_dim)
+        self.audio_modality_emb = mx.zeros((pooler_hidden_dim,))
+
+        self.attention_pooler = AttentionPooler(
+            hidden_dim=pooler_hidden_dim,
+            num_queries=num_queries,
+            num_heads=num_pooler_heads,
+        )
+        self.mlp_hidden = nn.Linear(pooler_hidden_dim * num_queries, mlp_hidden_dim)
+        self.mlp_out = nn.Linear(mlp_hidden_dim, 1)
+
+    def __call__(
+        self,
+        video_tokens: mx.array | None = None,
+        audio_tokens: mx.array | None = None,
+    ) -> mx.array:
+        """Predict duration in seconds.
+
+        The regression target is trained in log-seconds (spreads the loss
+        budget evenly across orders of magnitude -- see the module
+        docstring), so the MLP output is a log-duration internally; ``exp``
+        is applied here so callers always get seconds.
+
+        Args:
+            video_tokens: ``(B, T_v, video_cross_attention_dim)``, or ``None``.
+            audio_tokens: ``(B, T_a, audio_cross_attention_dim)``, or ``None``.
+
+        Returns:
+            Duration prediction in seconds, shape ``(B,)``.
+
+        Raises:
+            ValueError: If neither ``video_tokens`` nor ``audio_tokens`` is given.
+        """
+        if video_tokens is None and audio_tokens is None:
+            raise ValueError("DurationHead.__call__ requires at least one of video_tokens / audio_tokens")
+
+        token_groups: list[mx.array] = []
+        if video_tokens is not None:
+            token_groups.append(self.video_input_proj(video_tokens) + self.video_modality_emb)
+        if audio_tokens is not None:
+            token_groups.append(self.audio_input_proj(audio_tokens) + self.audio_modality_emb)
+
+        tokens = mx.concatenate(token_groups, axis=1)
+        pooled = self.attention_pooler(tokens)
+        pooled_flat = pooled.reshape(pooled.shape[0], -1)
+        hidden = nn.gelu_approx(self.mlp_hidden(pooled_flat))
+        log_duration = self.mlp_out(hidden).squeeze(-1)
+        return mx.exp(log_duration)
+
+
+def load_duration_head(path: str | Path) -> DurationHead:
+    """Build and load a :class:`DurationHead` from a pack's ``duration_head.safetensors``.
+
+    Strips the ``duration_head.`` prefix and splits torch
+    ``nn.MultiheadAttention``'s fused ``in_proj_weight``/``in_proj_bias``
+    into separate q/k/v projections so the flat weight dict maps onto the
+    named submodules (``attention_pooler.cross_attn.{q_proj,k_proj,v_proj}``).
+
+    Args:
+        path: Path to ``duration_head.safetensors`` (the file itself, not
+            a directory).
+
+    Returns:
+        The loaded :class:`DurationHead`.
+
+    Raises:
+        FileNotFoundError: If ``path`` does not exist.
+    """
+    path = Path(path)
+    if not path.exists():
+        raise FileNotFoundError(f"duration head weights not found at {path}")
+
+    raw = load_split_safetensors(path, prefix=_PACK_PREFIX)
+
+    hidden_dim = raw["video_modality_emb"].shape[0]
+    video_dim = raw["video_input_proj.weight"].shape[1]
+    audio_dim = raw["audio_input_proj.weight"].shape[1]
+    mlp_hidden_dim = raw["mlp_hidden.weight"].shape[0]
+    num_queries = raw["attention_pooler.query_tokens"].shape[0]
+    num_heads = 4  # fixed by upstream architecture; not encoded in the pack
+
+    in_proj_weight = raw.pop("attention_pooler.cross_attn.in_proj_weight")  # (3*hidden, hidden)
+    in_proj_bias = raw.pop("attention_pooler.cross_attn.in_proj_bias")  # (3*hidden,)
+    q_w, k_w, v_w = mx.split(in_proj_weight, 3, axis=0)
+    q_b, k_b, v_b = mx.split(in_proj_bias, 3, axis=0)
+    raw["attention_pooler.cross_attn.q_proj.weight"] = q_w
+    raw["attention_pooler.cross_attn.q_proj.bias"] = q_b
+    raw["attention_pooler.cross_attn.k_proj.weight"] = k_w
+    raw["attention_pooler.cross_attn.k_proj.bias"] = k_b
+    raw["attention_pooler.cross_attn.v_proj.weight"] = v_w
+    raw["attention_pooler.cross_attn.v_proj.bias"] = v_b
+
+    model = DurationHead(
+        video_cross_attention_dim=video_dim,
+        audio_cross_attention_dim=audio_dim,
+        pooler_hidden_dim=hidden_dim,
+        num_queries=num_queries,
+        num_pooler_heads=num_heads,
+        mlp_hidden_dim=mlp_hidden_dim,
+    )
+    model.load_weights(list(raw.items()))
+    return model

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/__init__.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/__init__.py
@@ -36,6 +36,7 @@ from ltx_pipelines_mlx.ti2vid_two_stages_hq import TI2VidTwoStagesHQPipeline
 from ltx_pipelines_mlx.utils.blocks import (
     AudioConditioner,
     AudioDecoder,
+    DurationPredictor,
     ImageConditioner,
     PromptEncoder,
     VideoDecoder,
@@ -49,6 +50,7 @@ __all__ = [
     "AudioDecoder",
     "BasePipeline",
     "DistilledPipeline",
+    "DurationPredictor",
     "HDRICLoraPipeline",
     "ICLoraPipeline",
     "ImageConditioner",

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/_base.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/_base.py
@@ -11,6 +11,7 @@ Lightricks/LTX-2 design where each pipeline file owns its API.
 from __future__ import annotations
 
 import os
+import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -30,8 +31,14 @@ from ltx_core_mlx.utils.weights import (
     load_split_safetensors,
     validate_config_matches_weights,
 )
+from ltx_pipelines_mlx.utils.blocks import (
+    DurationPredictor,
+    require_num_frames_source,
+    resolve_num_frames,
+)
 from ltx_pipelines_mlx.utils.constants import DEFAULT_NEGATIVE_PROMPT
 from ltx_pipelines_mlx.utils.progress import phase
+from ltx_pipelines_mlx.utils.types import AutoDuration
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -127,6 +134,11 @@ class BasePipeline:
         # Stepwise previews. Set by the CLI after construction (like ``verbose``);
         # None means no previews and zero cost in the denoising loops.
         self.stepwise: StepwisePreview | None = None
+
+        # Auto-duration: built once, lazily degrading to None on packs without
+        # DurationHead weights (anything predating 2.5 / gemma4). A few MB when
+        # present, so no memory-pressure motivation to defer construction.
+        self._duration_predictor: DurationPredictor | None = DurationPredictor.from_checkpoint(self.model_dir)
 
     # -------------------- proxy properties to blocks --------------------
     # Subclasses still read/write these as direct attributes; the property
@@ -237,6 +249,52 @@ class BasePipeline:
                 "TeaCache is calibrated for LTX-2.3 only; its polynomial does not "
                 "transfer to 2.5 packs. Drop --enable-teacache for this model."
             )
+
+    def _require_num_frames_source(self, num_frames: int | AutoDuration) -> None:
+        """Guard against ``AutoDuration`` on a checkpoint with no DurationHead weights.
+
+        Call at the very top of a ``generate_*`` method -- before prompt encoding
+        or any other work -- so a pack without DurationHead weights (anything
+        predating 2.5) fails fast instead of after paying for discarded work.
+
+        Raises:
+            ValueError: If ``num_frames`` is ``AutoDuration`` but this pipeline
+                has no duration predictor.
+        """
+        require_num_frames_source(num_frames, self._duration_predictor)
+
+    def _resolve_num_frames(
+        self,
+        num_frames: int | AutoDuration,
+        *,
+        video_encoding: mx.array | None,
+        audio_encoding: mx.array | None,
+        frame_rate: float,
+    ) -> int:
+        """Resolve ``num_frames`` to a concrete frame count, predicting it if ``AutoDuration``.
+
+        Call right after prompt encoding (once ``video_encoding``/``audio_encoding``
+        exist) and before any shape/position computation that consumes ``num_frames``.
+        Prints a ``[auto-duration]`` phase-style line to stderr when a prediction
+        actually ran, for observability.
+
+        Returns:
+            Concrete frame count, either passed through or predicted.
+        """
+        resolved = resolve_num_frames(
+            num_frames,
+            self._duration_predictor,
+            video_encoding=video_encoding,
+            audio_encoding=audio_encoding,
+            frame_rate=frame_rate,
+        )
+        if isinstance(num_frames, AutoDuration) and self.verbose:
+            print(
+                f"[auto-duration] predicted {resolved} frames ({resolved / frame_rate:.2f}s @ {frame_rate:.2f} fps)",
+                file=sys.stderr,
+                flush=True,
+            )
+        return resolved
 
     def _load_text_encoder(self) -> None:
         """Load Gemma + connector via the :class:`PromptEncoder` block."""

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/cli.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/cli.py
@@ -21,8 +21,12 @@ from __future__ import annotations
 import argparse
 import sys
 import time
+from typing import TYPE_CHECKING
 
 from ltx_pipelines_mlx.utils.stepwise import DEFAULT_PREVIEW_FRAMES
+
+if TYPE_CHECKING:
+    from ltx_pipelines_mlx.utils.types import AutoDuration
 
 DEFAULT_MODEL = "dgrauet/ltx-2.3-mlx-q8"
 DEFAULT_GEMMA = "mlx-community/gemma-3-12b-it-4bit"
@@ -157,12 +161,33 @@ def _build_tile_count_config(args: argparse.Namespace):
     )
 
 
-def _add_generation_args(parser: argparse.ArgumentParser) -> None:
-    """Add generation-specific arguments (dimensions, steps) on top of base args."""
+def _add_generation_args(parser: argparse.ArgumentParser, *, frames_default: int | None = 97) -> None:
+    """Add generation-specific arguments (dimensions, steps) on top of base args.
+
+    ``frames_default=None`` (used by the ``generate`` subparser only) leaves
+    ``--frames`` unset so the auto-duration collapse logic in
+    ``_resolve_num_frames_arg`` can distinguish "not given" from an explicit
+    value. Other subcommands (``a2v``, ``keyframe``, ``ic-lora``, ...) keep
+    their historical ``97`` default.
+    """
     _add_base_args(parser)
     parser.add_argument("--height", "-H", type=int, default=480, help="Video height (default: 480)")
     parser.add_argument("--width", "-W", type=int, default=704, help="Video width (default: 704)")
-    parser.add_argument("--frames", "-f", type=int, default=97, help="Number of frames (default: 97)")
+    if frames_default is None:
+        parser.add_argument(
+            "--frames",
+            "-f",
+            type=int,
+            default=None,
+            help=(
+                "Number of frames. Default: auto-predicted from the prompt on packs with "
+                "a DurationHead (LTX-2.5+); required explicitly otherwise. See --auto-duration."
+            ),
+        )
+    else:
+        parser.add_argument(
+            "--frames", "-f", type=int, default=frames_default, help=f"Number of frames (default: {frames_default})"
+        )
     parser.add_argument(
         "--frame-rate",
         type=float,
@@ -220,8 +245,52 @@ def _add_generation_args(parser: argparse.ArgumentParser) -> None:
     )
 
 
-def main() -> None:
-    """Entry point for the ltx-2-mlx CLI."""
+def _parse_auto_duration(value: str) -> AutoDuration:
+    """Parse a ``MIN:MAX`` string (seconds) into an :class:`AutoDuration`."""
+    from ltx_pipelines_mlx.utils.types import AutoDuration
+
+    parts = value.split(":")
+    if len(parts) != 2:
+        raise argparse.ArgumentTypeError(f"--auto-duration expects MIN:MAX (e.g. 2:10), got {value!r}")
+    try:
+        min_seconds, max_seconds = float(parts[0]), float(parts[1])
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"--auto-duration expects MIN:MAX as numbers, got {value!r}") from exc
+    return AutoDuration(min_seconds=min_seconds, max_seconds=max_seconds)
+
+
+def _resolve_num_frames_arg(args: argparse.Namespace) -> int | AutoDuration:
+    """Collapse ``--frames``/``--auto-duration`` into the value a pipeline's ``num_frames`` expects.
+
+    Mirrors upstream ``ltx_pipelines.utils.args._resolve_num_frames``: an explicit
+    ``--frames`` wins (with a warning if ``--auto-duration`` was also given);
+    otherwise ``--auto-duration`` if given, else the ``AutoDuration()`` default.
+    Only the ``generate`` subparser sets ``--frames`` default to ``None`` and
+    exposes ``--auto-duration``, so this is only meaningfully called there.
+    """
+    from ltx_pipelines_mlx.utils.types import DEFAULT_AUTO_DURATION
+
+    frames = getattr(args, "frames", None)
+    auto_duration = getattr(args, "auto_duration", None)
+    if frames is not None and auto_duration is not None:
+        print(
+            f"warning: both --frames and --auto-duration were given; using --frames={frames} "
+            "and ignoring --auto-duration.",
+            file=sys.stderr,
+        )
+    if frames is not None:
+        return frames
+    if auto_duration is not None:
+        return auto_duration
+    return DEFAULT_AUTO_DURATION
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Build the top-level argument parser (all subcommands).
+
+    Factored out of :func:`main` so tests can parse args without invoking
+    the CLI's dispatch/side-effect machinery.
+    """
     parser = argparse.ArgumentParser(
         prog="ltx-2-mlx",
         description="LTX-2.3 video generation on Apple Silicon (MLX)",
@@ -244,7 +313,19 @@ examples:
 
     # --- generate (T2V / I2V / two-stage / HQ) ---
     gen = sub.add_parser("generate", help="Generate video from text (T2V) or image (I2V)")
-    _add_generation_args(gen)
+    _add_generation_args(gen, frames_default=None)
+    gen.add_argument(
+        "--auto-duration",
+        type=_parse_auto_duration,
+        default=None,
+        metavar="MIN:MAX",
+        help=(
+            "Bounds (seconds) for auto-predicted duration, e.g. '2:10'. Only takes effect "
+            "when --frames is not given and the checkpoint has DurationHead weights "
+            "(LTX-2.5+); default bounds are 1:20. Ignored (with a warning) if --frames "
+            "is also given."
+        ),
+    )
     from ltx_pipelines_mlx.utils.args import ImageAction as _ImageAction
 
     gen.add_argument(
@@ -715,6 +796,12 @@ examples:
     )
     slc.add_argument("--crf", type=int, default=18, help="x264 quality, lower = better (default: 18)")
 
+    return parser
+
+
+def main() -> None:
+    """Entry point for the ltx-2-mlx CLI."""
+    parser = _build_parser()
     args = parser.parse_args()
 
     if args.command is None:
@@ -818,7 +905,7 @@ def _cmd_generate(args: argparse.Namespace) -> None:
             output_path=args.output,
             height=args.height,
             width=args.width,
-            num_frames=args.frames,
+            num_frames=_resolve_num_frames_arg(args),
             frame_rate=args.frame_rate,
             seed=args.seed,
             images=args.images,
@@ -859,7 +946,7 @@ def _cmd_generate(args: argparse.Namespace) -> None:
             output_path=args.output,
             height=args.height,
             width=args.width,
-            num_frames=args.frames,
+            num_frames=_resolve_num_frames_arg(args),
             frame_rate=args.frame_rate,
             seed=args.seed,
             images=args.images,
@@ -908,7 +995,7 @@ def _cmd_generate(args: argparse.Namespace) -> None:
             output_path=args.output,
             height=args.height,
             width=args.width,
-            num_frames=args.frames,
+            num_frames=_resolve_num_frames_arg(args),
             frame_rate=args.frame_rate,
             seed=args.seed,
             images=args.images,

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/cli.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/cli.py
@@ -246,7 +246,13 @@ def _add_generation_args(parser: argparse.ArgumentParser, *, frames_default: int
 
 
 def _parse_auto_duration(value: str) -> AutoDuration:
-    """Parse a ``MIN:MAX`` string (seconds) into an :class:`AutoDuration`."""
+    """Parse a ``MIN:MAX`` string (seconds) into an :class:`AutoDuration`.
+
+    Mirrors upstream ``ltx_pipelines.utils.args.AutoDurationAction``'s
+    ``min_seconds <= max_seconds`` guard (and its exact message wording) so an
+    inverted range (e.g. ``10:2``) is rejected at parse time instead of
+    silently flowing through into a wrong-duration render.
+    """
     from ltx_pipelines_mlx.utils.types import AutoDuration
 
     parts = value.split(":")
@@ -256,6 +262,10 @@ def _parse_auto_duration(value: str) -> AutoDuration:
         min_seconds, max_seconds = float(parts[0]), float(parts[1])
     except ValueError as exc:
         raise argparse.ArgumentTypeError(f"--auto-duration expects MIN:MAX as numbers, got {value!r}") from exc
+    if min_seconds > max_seconds:
+        raise argparse.ArgumentTypeError(
+            f"--auto-duration MIN_SECONDS ({min_seconds}) must be <= MAX_SECONDS ({max_seconds})"
+        )
     return AutoDuration(min_seconds=min_seconds, max_seconds=max_seconds)
 
 

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/distilled.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/distilled.py
@@ -46,6 +46,7 @@ from .ti2vid_two_stages import TI2VidTwoStagesPipeline
 from .utils.helpers import create_noised_state
 from .utils.progress import phase
 from .utils.samplers import denoise_loop, euler_ancestral_denoising_loop
+from .utils.types import DEFAULT_AUTO_DURATION, AutoDuration
 
 _materialize = getattr(mx, "eval")  # noqa: B009 -- security hook flags mx.eval pattern
 
@@ -197,7 +198,7 @@ class DistilledPipeline(TI2VidTwoStagesPipeline):
         prompt: str,
         height: int = 480,
         width: int = 704,
-        num_frames: int = 97,
+        num_frames: int | AutoDuration = DEFAULT_AUTO_DURATION,
         *,
         frame_rate: float,
         seed: int = 42,
@@ -215,7 +216,9 @@ class DistilledPipeline(TI2VidTwoStagesPipeline):
             prompt: Text prompt.
             height: Final video height.
             width: Final video width.
-            num_frames: Number of frames.
+            num_frames: Number of frames, or an :class:`AutoDuration` request to
+                predict it from the prompt (requires a DurationHead-equipped
+                checkpoint).
             seed: Random seed.
             stage1_steps: Stage 1 steps (default: full DISTILLED_SIGMAS = 8).
             stage2_steps: Stage 2 steps (default: full STAGE_2_SIGMAS = 3).
@@ -234,6 +237,7 @@ class DistilledPipeline(TI2VidTwoStagesPipeline):
         Raises:
             ValueError: when ``enable_teacache`` is requested on an LTX-2.5 pack.
         """
+        self._require_num_frames_source(num_frames)
         if enable_teacache and self._is_25:
             raise ValueError(
                 "TeaCache is not calibrated for LTX-2.5 packs: the polynomial "
@@ -251,6 +255,9 @@ class DistilledPipeline(TI2VidTwoStagesPipeline):
         with phase("Encoding prompt", verbose=self.verbose):
             video_embeds, audio_embeds = self._encode_text(encode_prompt)
             _materialize(video_embeds, audio_embeds)
+        num_frames = self._resolve_num_frames(
+            num_frames, video_encoding=video_embeds, audio_encoding=audio_embeds, frame_rate=frame_rate
+        )
         if self.low_memory:
             self.prompt_encoder.free()
             aggressive_cleanup()

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ti2vid_one_stage.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ti2vid_one_stage.py
@@ -48,6 +48,7 @@ from .scheduler import ltx2_schedule
 from .ti2vid_two_stages import DEFAULT_CFG_SCALE, TI2VidTwoStagesPipeline
 from .utils.helpers import create_noised_state
 from .utils.samplers import guided_denoise_loop
+from .utils.types import DEFAULT_AUTO_DURATION, AutoDuration
 
 _materialize = getattr(mx, "eval")  # noqa: B009 -- security hook flags mx.eval pattern
 
@@ -108,7 +109,7 @@ class TI2VidOneStagePipeline(TI2VidTwoStagesPipeline):
         prompt: str,
         height: int = 480,
         width: int = 704,
-        num_frames: int = 97,
+        num_frames: int | AutoDuration = DEFAULT_AUTO_DURATION,
         *,
         frame_rate: float,
         seed: int = 42,
@@ -128,7 +129,9 @@ class TI2VidOneStagePipeline(TI2VidTwoStagesPipeline):
             prompt: Text prompt.
             height: Target video height (must be divisible by 32).
             width: Target video width (must be divisible by 32).
-            num_frames: Number of frames (must satisfy ``(F-1) % 8 == 0``).
+            num_frames: Number of frames (must satisfy ``(F-1) % 8 == 0``), or
+                an :class:`AutoDuration` request to predict it from the prompt
+                (requires a DurationHead-equipped checkpoint).
             seed: Random seed.
             num_steps: Denoising steps (default: 30).
             cfg_scale: CFG guidance scale (default: 3.0).
@@ -143,10 +146,15 @@ class TI2VidOneStagePipeline(TI2VidTwoStagesPipeline):
         Returns:
             Tuple of (video_latent, audio_latent) at target resolution.
         """
+        self._require_num_frames_source(num_frames)
+
         # --- Text encoding (positive + negative for CFG; Prompt Relay encodes the
         # combined prompt on the positive side) ---
         encode_prompt, relay_token_ranges = self._prompt_relay_setup(prompt, prompt_relay)
         video_embeds, audio_embeds, neg_video_embeds, neg_audio_embeds = self._encode_text_with_negative(encode_prompt)
+        num_frames = self._resolve_num_frames(
+            num_frames, video_encoding=video_embeds, audio_encoding=audio_embeds, frame_rate=frame_rate
+        )
         num_text_tokens = video_embeds.shape[1]
         relay_mask = self._prompt_relay_mask_builder(prompt_relay, relay_token_ranges, num_text_tokens)
 
@@ -276,7 +284,7 @@ class TI2VidOneStagePipeline(TI2VidTwoStagesPipeline):
         output_path: str,
         height: int = 480,
         width: int = 704,
-        num_frames: int = 97,
+        num_frames: int | AutoDuration = DEFAULT_AUTO_DURATION,
         *,
         frame_rate: float,
         seed: int = 42,

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ti2vid_two_stages.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ti2vid_two_stages.py
@@ -37,6 +37,7 @@ from ltx_pipelines_mlx.scheduler import STAGE_2_SIGMAS, ltx2_schedule
 from ltx_pipelines_mlx.utils.generation import is_ltx25_pack
 from ltx_pipelines_mlx.utils.helpers import create_noised_state
 from ltx_pipelines_mlx.utils.samplers import denoise_loop, guided_denoise_loop
+from ltx_pipelines_mlx.utils.types import DEFAULT_AUTO_DURATION, AutoDuration
 
 # Reference defaults
 DEFAULT_CFG_SCALE = 3.0
@@ -360,7 +361,7 @@ class TI2VidTwoStagesPipeline(BasePipeline):
         prompt: str,
         height: int = 480,
         width: int = 704,
-        num_frames: int = 97,
+        num_frames: int | AutoDuration = DEFAULT_AUTO_DURATION,
         *,
         frame_rate: float,
         seed: int = 42,
@@ -383,7 +384,9 @@ class TI2VidTwoStagesPipeline(BasePipeline):
             prompt: Text prompt.
             height: Final video height.
             width: Final video width.
-            num_frames: Number of frames.
+            num_frames: Number of frames, or an :class:`AutoDuration` request to
+                predict it from the prompt (requires a DurationHead-equipped
+                checkpoint; see :meth:`_base.BasePipeline._require_num_frames_source`).
             seed: Random seed.
             stage1_steps: Denoising steps for stage 1 (default: 20).
             stage2_steps: Denoising steps for stage 2.
@@ -405,12 +408,16 @@ class TI2VidTwoStagesPipeline(BasePipeline):
         Returns:
             Tuple of (video_latent, audio_latent) at full resolution.
         """
+        self._require_num_frames_source(num_frames)
         self._check_teacache_supported(enable_teacache)
 
         # --- Text encoding (Prompt Relay: encode the combined prompt; the negative
         # prompt is a fixed default, so it is unaffected by the local prompts) ---
         encode_prompt, relay_token_ranges = self._prompt_relay_setup(prompt, prompt_relay)
         video_embeds, audio_embeds, neg_video_embeds, neg_audio_embeds = self._encode_text_with_negative(encode_prompt)
+        num_frames = self._resolve_num_frames(
+            num_frames, video_encoding=video_embeds, audio_encoding=audio_embeds, frame_rate=frame_rate
+        )
         num_text_tokens = video_embeds.shape[1]
         relay_mask = self._prompt_relay_mask_builder(prompt_relay, relay_token_ranges, num_text_tokens)
 
@@ -663,7 +670,7 @@ class TI2VidTwoStagesPipeline(BasePipeline):
         output_path: str,
         height: int = 480,
         width: int = 704,
-        num_frames: int = 97,
+        num_frames: int | AutoDuration = DEFAULT_AUTO_DURATION,
         *,
         frame_rate: float,
         seed: int = 42,

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ti2vid_two_stages_hq.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ti2vid_two_stages_hq.py
@@ -27,6 +27,7 @@ from ltx_pipelines_mlx.scheduler import STAGE_2_SIGMAS, ltx2_schedule
 from ltx_pipelines_mlx.ti2vid_two_stages import DEFAULT_CFG_SCALE, TI2VidTwoStagesPipeline
 from ltx_pipelines_mlx.utils.helpers import create_noised_state
 from ltx_pipelines_mlx.utils.samplers import denoise_loop, res2s_denoise_loop
+from ltx_pipelines_mlx.utils.types import DEFAULT_AUTO_DURATION, AutoDuration
 
 # TeaCache calibration constants for the HQ res_2s path (LTX-2 stage 1, 30
 # steps, 384x576x65 reference shape, MLX bf16 q8). Calibrated 2026-04-27 from
@@ -89,7 +90,7 @@ class TI2VidTwoStagesHQPipeline(TI2VidTwoStagesPipeline):
         prompt: str,
         height: int = 480,
         width: int = 704,
-        num_frames: int = 97,
+        num_frames: int | AutoDuration = DEFAULT_AUTO_DURATION,
         *,
         frame_rate: float,
         seed: int = 42,
@@ -111,13 +112,18 @@ class TI2VidTwoStagesHQPipeline(TI2VidTwoStagesPipeline):
         Same as TI2VidTwoStagesPipeline.generate_two_stage but uses res_2s sampler
         for Stage 1 instead of Euler. ``enable_teacache`` / ``teacache_thresh``
         / ``tap`` are forwarded to ``res2s_denoise_loop`` exactly as in the
-        Euler path.
+        Euler path. ``num_frames`` may be an :class:`AutoDuration` request,
+        resolved after prompt encoding (see :meth:`TI2VidTwoStagesPipeline.generate_two_stage`).
         """
+        self._require_num_frames_source(num_frames)
         self._check_teacache_supported(enable_teacache)
 
         # --- Text encoding (Prompt Relay: encode the combined prompt) ---
         encode_prompt, relay_token_ranges = self._prompt_relay_setup(prompt, prompt_relay)
         video_embeds, audio_embeds, neg_video_embeds, neg_audio_embeds = self._encode_text_with_negative(encode_prompt)
+        num_frames = self._resolve_num_frames(
+            num_frames, video_encoding=video_embeds, audio_encoding=audio_embeds, frame_rate=frame_rate
+        )
         num_text_tokens = video_embeds.shape[1]
         relay_mask = self._prompt_relay_mask_builder(prompt_relay, relay_token_ranges, num_text_tokens)
 

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/utils/blocks.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/utils/blocks.py
@@ -39,6 +39,7 @@ Differences vs upstream:
 
 from __future__ import annotations
 
+import logging
 import sys
 from collections.abc import Callable
 from pathlib import Path
@@ -46,6 +47,7 @@ from typing import TYPE_CHECKING
 
 import mlx.core as mx
 
+from ltx_core_mlx.duration_head import DurationHead, load_duration_head
 from ltx_core_mlx.model.audio_vae.audio_vae import AudioVAEDecoder
 from ltx_core_mlx.model.audio_vae.bwe import VocoderWithBWE
 from ltx_core_mlx.model.transformer.model import LTXModelConfig
@@ -58,9 +60,12 @@ from ltx_core_mlx.text_encoders.gemma.encoders.encoder_configurator import selec
 from ltx_core_mlx.text_encoders.gemma.feature_extractor import GemmaFeaturesExtractorV2
 from ltx_core_mlx.utils.memory import aggressive_cleanup
 from ltx_core_mlx.utils.weights import load_split_safetensors, remap_audio_vae_keys
+from ltx_pipelines_mlx.utils.constants import AutoDuration
 
 if TYPE_CHECKING:
     from ltx_core_mlx.text_encoders.gemma.encoders.gemma4_encoder import Gemma4TextEncoder
+
+logger = logging.getLogger(__name__)
 
 _materialize = getattr(mx, "eval")  # noqa: B009 -- security hook flags the literal mx.eval pattern
 
@@ -444,11 +449,248 @@ class VideoUpsampler:
         return upsampler(latent)
 
 
+# ============================================================================
+# Duration Head Helpers
+# ============================================================================
+
+
+def snap_frames_to_grid(frames: int, time_scale: int = 8) -> int:
+    """Round ``frames`` down to the nearest ``k * time_scale + 1``.
+
+    The model's frame count must satisfy ``(frames - 1) % time_scale == 0``
+    (causal VAE temporal grid). The default ``time_scale=8`` corresponds to
+    the VAE's 8x temporal compression.
+
+    Args:
+        frames: Number of frames to snap.
+        time_scale: Temporal grid scale factor (default 8 for LTX-2).
+
+    Returns:
+        Snapped frame count on the 8k+1 grid.
+    """
+    if frames < 1:
+        raise ValueError(f"frames must be >= 1, got {frames}")
+    return ((frames - 1) // time_scale) * time_scale + 1
+
+
+def seconds_to_clamped_num_frames(
+    seconds: float,
+    *,
+    frame_rate: float,
+    min_frames: int = 1,
+    max_frames: int = 1024,
+    time_scale: int = 8,
+) -> int:
+    """Convert a duration in seconds to a frame count snapped to the VAE's temporal grid.
+
+    Outlier durations are clamped to ``[min_frames, max_frames]`` (before snapping) so a
+    misbehaving prediction can't request an OOM-sized generation. Snapping floors to the
+    grid, which can undershoot ``min_frames``; when that happens the result is snapped up
+    to the next grid point instead, so the ``[min_frames, max_frames]`` contract always holds.
+
+    Args:
+        seconds: Duration in seconds.
+        frame_rate: Video frame rate in frames per second.
+        min_frames: Minimum frame count (default 1). Result >= min_frames.
+        max_frames: Maximum frame count (default 1024). Result <= max_frames.
+        time_scale: Temporal grid scale factor (default 8 for LTX-2).
+
+    Returns:
+        Frame count clamped to [min_frames, max_frames] and snapped to 8k+1 grid.
+    """
+    raw_frames = round(seconds * frame_rate)
+    raw_frames = max(min_frames, min(raw_frames, max_frames))
+    frames = snap_frames_to_grid(raw_frames, time_scale)
+    if frames < min_frames:
+        # Round up to next grid point: ceiling division on the grid
+        # Formula: -(-((min_frames - 1) // time_scale)) * time_scale + 1
+        frames = min(-(-(min_frames - 1) // time_scale) * time_scale + 1, max_frames)
+    return frames
+
+
+def require_num_frames_source(
+    num_frames: int | AutoDuration,
+    duration_predictor: DurationPredictor | None,
+) -> None:
+    """Guard against an unsatisfiable auto-duration request.
+
+    Call at the very top of a pipeline's ``__call__`` -- before prompt encoding or any other
+    work -- so a checkpoint without DurationHead weights (anything predating 2.5) fails fast
+    with a clear message instead of after paying for work whose result would be discarded.
+
+    Args:
+        num_frames: Either an explicit frame count or AutoDuration request.
+        duration_predictor: Optional DurationPredictor (required if num_frames is AutoDuration).
+
+    Raises:
+        ValueError: If num_frames is AutoDuration but duration_predictor is None.
+    """
+    if isinstance(num_frames, AutoDuration) and duration_predictor is None:
+        raise ValueError(
+            "num_frames was AutoDuration but this checkpoint has no DurationHead weights to "
+            "auto-predict duration from (DurationHead ships from LTX 2.5 / gemma4 onward). "
+            "Pass num_frames explicitly."
+        )
+
+
+def resolve_num_frames(
+    num_frames: int | AutoDuration,
+    duration_predictor: DurationPredictor | None,
+    *,
+    video_encoding: mx.array | None,
+    audio_encoding: mx.array | None,
+    frame_rate: float,
+) -> int:
+    """Resolve ``num_frames`` to a concrete frame count, predicting it if ``AutoDuration``.
+
+    Call after prompt encoding (once ``video_encoding``/``audio_encoding`` exist) and after
+    ``require_num_frames_source`` has already validated a predictor is available when needed.
+
+    Args:
+        num_frames: Either an explicit frame count or AutoDuration request.
+        duration_predictor: Optional DurationPredictor (must be provided if AutoDuration).
+        video_encoding: Video embedding tokens from prompt encoder (shape B, N, 4096).
+        audio_encoding: Audio embedding tokens from prompt encoder (shape B, N, 2048).
+        frame_rate: Video frame rate in frames per second.
+
+    Returns:
+        Concrete frame count, either passed through or predicted.
+    """
+    if not isinstance(num_frames, AutoDuration):
+        return num_frames
+    return duration_predictor(
+        video_encoding,
+        audio_encoding,
+        frame_rate=frame_rate,
+        min_seconds=num_frames.min_seconds,
+        max_seconds=num_frames.max_seconds,
+    )
+
+
+class DurationPredictor:
+    """Predicts shot duration (in frames) from prompt encoder output.
+
+    Unlike most blocks, the model is held directly rather than rebuilt on every call:
+    DurationHead is a few MB, so there's no memory pressure motivating the
+    build-on-call / free-on-exit pattern used for the large transformer/VAE blocks.
+
+    Attributes:
+        _head: The loaded DurationHead model.
+    """
+
+    def __init__(self, head: DurationHead) -> None:
+        """Construct from an already-built, already-loaded head.
+
+        Args:
+            head: A DurationHead instance.
+        """
+        self._head = head
+
+    @classmethod
+    def from_checkpoint(cls, model_dir: str | Path) -> DurationPredictor | None:
+        """Build a predictor from a checkpoint path, or ``None`` if unavailable.
+
+        Returns ``None`` when the duration-head file is absent, so a checkpoint without
+        DurationHead weights (anything predating 2.5 / gemma3 monoliths) gracefully
+        skips prediction rather than crashing later.
+
+        Args:
+            model_dir: Path to the model directory (local or HuggingFace repo ID).
+
+        Returns:
+            DurationPredictor if duration_head.safetensors exists and loads; None otherwise.
+        """
+        model_path = Path(model_dir) if isinstance(model_dir, str) else model_dir
+        head_path = model_path / "duration_head.safetensors"
+
+        if not head_path.exists():
+            logger.info(
+                "No DurationHead weights found in %s; auto-duration prediction unavailable.",
+                model_path,
+            )
+            return None
+
+        try:
+            head = load_duration_head(head_path)
+            return cls(head)
+        except FileNotFoundError:
+            logger.info(
+                "No DurationHead weights found in %s; auto-duration prediction unavailable.",
+                head_path,
+            )
+            return None
+
+    def __call__(
+        self,
+        video_encoding: mx.array | None,
+        audio_encoding: mx.array | None,
+        *,
+        frame_rate: float,
+        min_seconds: float = 1.0,
+        max_seconds: float = 20.0,
+    ) -> int:
+        """Predict a frame count from prompt encoder tokens, snapped to the VAE's grid.
+
+        ``min_seconds``/``max_seconds`` clamp the prediction so a misbehaving prediction can't
+        request a degenerate or OOM-sized generation; the defaults are 1s and 20s. The result is
+        a frame count snapped to the VAE's ``8k + 1`` causal temporal grid.
+
+        Args:
+            video_encoding: Video embedding tokens (shape 1, N, 4096) or None.
+            audio_encoding: Audio embedding tokens (shape 1, N, 2048) or None.
+            frame_rate: Video frame rate in frames per second.
+            min_seconds: Minimum predicted duration in seconds (default 1.0).
+            max_seconds: Maximum predicted duration in seconds (default 20.0).
+
+        Returns:
+            Predicted frame count, clamped to [min_seconds, max_seconds] and snapped to grid.
+
+        Raises:
+            ValueError: If both video_encoding and audio_encoding are None.
+            ValueError: If prediction has batch size != 1.
+        """
+        if video_encoding is None and audio_encoding is None:
+            raise ValueError("DurationPredictor requires at least one of video_encoding / audio_encoding")
+
+        seconds_pred = self._head(video_tokens=video_encoding, audio_tokens=audio_encoding)
+        if seconds_pred.shape != (1,):
+            raise ValueError(
+                f"DurationPredictor only supports a single-item batch, got prediction shape {tuple(seconds_pred.shape)}"
+            )
+
+        seconds = float(seconds_pred.item())
+        min_frames = round(min_seconds * frame_rate)
+        max_frames = round(max_seconds * frame_rate)
+        num_frames = seconds_to_clamped_num_frames(
+            seconds, frame_rate=frame_rate, min_frames=min_frames, max_frames=max_frames
+        )
+
+        if seconds > max_seconds or seconds < min_seconds:
+            logger.warning(
+                "DurationHead prediction clamped: raw %.2fs outside [%.2fs, %.2fs], using %.2fs (%d frames) @ %.2f fps",
+                seconds,
+                min_seconds,
+                max_seconds,
+                num_frames / frame_rate,
+                num_frames,
+                frame_rate,
+            )
+        else:
+            logger.info("DurationHead predicted %.2fs (%d frames @ %.2f fps)", seconds, num_frames, frame_rate)
+
+        return num_frames
+
+
 __all__ = [
     "AudioConditioner",
     "AudioDecoder",
+    "DurationPredictor",
     "ImageConditioner",
     "PromptEncoder",
     "VideoDecoder",
     "VideoUpsampler",
+    "require_num_frames_source",
+    "resolve_num_frames",
+    "seconds_to_clamped_num_frames",
+    "snap_frames_to_grid",
 ]

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/utils/blocks.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/utils/blocks.py
@@ -60,7 +60,7 @@ from ltx_core_mlx.text_encoders.gemma.encoders.encoder_configurator import selec
 from ltx_core_mlx.text_encoders.gemma.feature_extractor import GemmaFeaturesExtractorV2
 from ltx_core_mlx.utils.memory import aggressive_cleanup
 from ltx_core_mlx.utils.weights import load_split_safetensors, remap_audio_vae_keys
-from ltx_pipelines_mlx.utils.constants import AutoDuration
+from ltx_pipelines_mlx.utils.types import AutoDuration
 
 if TYPE_CHECKING:
     from ltx_core_mlx.text_encoders.gemma.encoders.gemma4_encoder import Gemma4TextEncoder
@@ -602,13 +602,6 @@ class DurationPredictor:
         """
         model_path = Path(model_dir) if isinstance(model_dir, str) else model_dir
         head_path = model_path / "duration_head.safetensors"
-
-        if not head_path.exists():
-            logger.info(
-                "No DurationHead weights found in %s; auto-duration prediction unavailable.",
-                model_path,
-            )
-            return None
 
         try:
             head = load_duration_head(head_path)

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/utils/constants.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/utils/constants.py
@@ -6,21 +6,6 @@ from dataclasses import dataclass, field
 
 from ltx_core_mlx.components.guiders import MultiModalGuiderParams
 
-
-@dataclass(frozen=True)
-class AutoDuration:
-    """Request auto-predicted duration, clamped to ``[min_seconds, max_seconds]``.
-
-    The predicted duration is converted to a frame count snapped to the VAE's causal
-    temporal grid (``8k + 1``). Defaults: 1s and 20s.
-    """
-
-    min_seconds: float = 1.0
-    max_seconds: float = 20.0
-
-
-DEFAULT_AUTO_DURATION = AutoDuration()
-
 DEFAULT_IMAGE_CRF = 33
 VIDEO_LATENT_CHANNELS = 128
 

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/utils/constants.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/utils/constants.py
@@ -6,6 +6,21 @@ from dataclasses import dataclass, field
 
 from ltx_core_mlx.components.guiders import MultiModalGuiderParams
 
+
+@dataclass(frozen=True)
+class AutoDuration:
+    """Request auto-predicted duration, clamped to ``[min_seconds, max_seconds]``.
+
+    The predicted duration is converted to a frame count snapped to the VAE's causal
+    temporal grid (``8k + 1``). Defaults: 1s and 20s.
+    """
+
+    min_seconds: float = 1.0
+    max_seconds: float = 20.0
+
+
+DEFAULT_AUTO_DURATION = AutoDuration()
+
 DEFAULT_IMAGE_CRF = 33
 VIDEO_LATENT_CHANNELS = 128
 

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/utils/types.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/utils/types.py
@@ -19,6 +19,21 @@ if TYPE_CHECKING:
 
 
 @dataclass(frozen=True)
+class AutoDuration:
+    """Request auto-predicted duration, clamped to ``[min_seconds, max_seconds]``.
+
+    The predicted duration is converted to a frame count snapped to the VAE's causal
+    temporal grid (``8k + 1``). Defaults: 1s and 20s.
+    """
+
+    min_seconds: float = 1.0
+    max_seconds: float = 20.0
+
+
+DEFAULT_AUTO_DURATION = AutoDuration()
+
+
+@dataclass(frozen=True)
 class ModalitySpec:
     """Specification for one modality passed to a diffusion stage.
 

--- a/tests/test_duration_head.py
+++ b/tests/test_duration_head.py
@@ -23,7 +23,7 @@ from ltx_pipelines_mlx.utils.blocks import (
     resolve_num_frames,
     seconds_to_clamped_num_frames,
 )
-from ltx_pipelines_mlx.utils.constants import AutoDuration
+from ltx_pipelines_mlx.utils.types import AutoDuration
 from tests.conftest import LTX25_Q8_DIR
 
 
@@ -182,7 +182,47 @@ def test_resolve_passthrough_and_predict():
     """Explicit int is passed through; AutoDuration delegates to predictor."""
     # Passthrough for explicit int
     assert resolve_num_frames(97, None, video_encoding=None, audio_encoding=None, frame_rate=24.0) == 97
-    # AutoDuration with None predictor would raise, but we test with mock
+
+    # Fake predictor that records its arguments
+    class FakePredictor:
+        def __init__(self):
+            self.call_args = None
+
+        def __call__(self, video_encoding, audio_encoding, *, frame_rate, min_seconds=1.0, max_seconds=20.0):
+            self.call_args = {
+                "video_encoding": video_encoding,
+                "audio_encoding": audio_encoding,
+                "frame_rate": frame_rate,
+                "min_seconds": min_seconds,
+                "max_seconds": max_seconds,
+            }
+            return 41  # Dummy return value on the 8k+1 grid
+
+    # Test AutoDuration delegation with fake predictor
+    fake_predictor = FakePredictor()
+    video_enc = mx.random.normal((1, 16, 4096))
+    audio_enc = mx.random.normal((1, 16, 2048))
+    auto_dur = AutoDuration(min_seconds=0.5, max_seconds=10.0)
+
+    result = resolve_num_frames(
+        auto_dur,
+        fake_predictor,
+        video_encoding=video_enc,
+        audio_encoding=audio_enc,
+        frame_rate=24.0,
+    )
+
+    # Verify result is passed through
+    assert result == 41
+
+    # Verify predictor was called with correct arguments
+    assert fake_predictor.call_args is not None
+    assert fake_predictor.call_args["video_encoding"] is video_enc
+    assert fake_predictor.call_args["audio_encoding"] is audio_enc
+    assert fake_predictor.call_args["frame_rate"] == 24.0
+    # Verify min/max_seconds come from AutoDuration instance
+    assert fake_predictor.call_args["min_seconds"] == 0.5
+    assert fake_predictor.call_args["max_seconds"] == 10.0
 
 
 def test_duration_predictor_from_checkpoint_missing_file(tmp_path):

--- a/tests/test_duration_head.py
+++ b/tests/test_duration_head.py
@@ -17,6 +17,13 @@ import mlx.core as mx
 import pytest
 
 from ltx_core_mlx.duration_head import AttentionPooler, DurationHead, load_duration_head
+from ltx_pipelines_mlx.utils.blocks import (
+    DurationPredictor,
+    require_num_frames_source,
+    resolve_num_frames,
+    seconds_to_clamped_num_frames,
+)
+from ltx_pipelines_mlx.utils.constants import AutoDuration
 from tests.conftest import LTX25_Q8_DIR
 
 
@@ -146,3 +153,77 @@ def test_duration_head_pinned_regression():
     assert out_both.item() == pytest.approx(4.09065055847168, rel=1e-5)
     assert out_video.item() == pytest.approx(3.8629565238952637, rel=1e-5)
     assert out_audio.item() == pytest.approx(4.285473346710205, rel=1e-5)
+
+
+# ============================================================================
+# Task 2: AutoDuration + DurationPredictor + helpers
+# ============================================================================
+
+
+def test_seconds_snap_to_grid():
+    """Test snapping to VAE's 8k+1 causal temporal grid."""
+    # 2.0s @ 24fps = 48 -> floor grille 8k+1 = 41
+    assert seconds_to_clamped_num_frames(2.0, frame_rate=24.0) == 41
+    # clamp haut : 100s @ 24 -> max_frames 1024 -> snap 1017
+    assert seconds_to_clamped_num_frames(100.0, frame_rate=24.0) == 1017
+    # remontée quand le floor passe sous min_frames
+    assert seconds_to_clamped_num_frames(0.01, frame_rate=24.0, min_frames=24) == 25
+
+
+def test_require_num_frames_source_raises_without_predictor():
+    """AutoDuration without predictor raises; explicit int never raises."""
+    with pytest.raises(ValueError, match="Pass num_frames explicitly"):
+        require_num_frames_source(AutoDuration(), None)
+    # Explicit int should not raise
+    require_num_frames_source(97, None)
+
+
+def test_resolve_passthrough_and_predict():
+    """Explicit int is passed through; AutoDuration delegates to predictor."""
+    # Passthrough for explicit int
+    assert resolve_num_frames(97, None, video_encoding=None, audio_encoding=None, frame_rate=24.0) == 97
+    # AutoDuration with None predictor would raise, but we test with mock
+
+
+def test_duration_predictor_from_checkpoint_missing_file(tmp_path):
+    """from_checkpoint returns None when duration_head.safetensors is absent."""
+    predictor = DurationPredictor.from_checkpoint(tmp_path)
+    assert predictor is None
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(LTX25_Q8_DIR is None, reason="local ltx-2.5-mlx-q8 pack not found")
+def test_duration_predictor_from_checkpoint_loads(tmp_path):
+    """from_checkpoint loads a real predictor from pack with duration_head.safetensors."""
+    predictor = DurationPredictor.from_checkpoint(LTX25_Q8_DIR)
+    assert predictor is not None
+
+    # Test that predictor returns int on grid for random encodings
+    video_encoding = mx.random.normal((1, 16, 4096))
+    audio_encoding = mx.random.normal((1, 16, 2048))
+    num_frames = predictor(video_encoding, audio_encoding, frame_rate=24.0)
+
+    assert isinstance(num_frames, int)
+    # Verify it's on the 8k+1 grid: (num_frames - 1) % 8 == 0
+    assert (num_frames - 1) % 8 == 0
+    # Verify default clamps are respected (1s @ 24fps = 24, 20s @ 24fps = 480)
+    assert num_frames >= 25  # Snapped up from 24
+    assert num_frames <= 1017  # Snapped down from 480
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(LTX25_Q8_DIR is None, reason="local ltx-2.5-mlx-q8 pack not found")
+def test_duration_predictor_with_custom_bounds(tmp_path):
+    """Predictor respects custom min/max_seconds bounds."""
+    predictor = DurationPredictor.from_checkpoint(LTX25_Q8_DIR)
+    video_encoding = mx.random.normal((1, 16, 4096))
+
+    # Request 0.5s-1.0s duration (narrower than default 1s-20s)
+    num_frames = predictor(video_encoding, None, frame_rate=24.0, min_seconds=0.5, max_seconds=1.0)
+
+    assert isinstance(num_frames, int)
+    # min_seconds=0.5 @ 24fps = 12 frames, max_frames=24
+    # result should be between snapped(12) and snapped(24)
+    assert (num_frames - 1) % 8 == 0
+    assert num_frames >= 9  # Snapped up from 12
+    assert num_frames <= 25  # Snapped up from 24

--- a/tests/test_duration_head.py
+++ b/tests/test_duration_head.py
@@ -251,6 +251,91 @@ def test_duration_predictor_from_checkpoint_loads(tmp_path):
     assert num_frames <= 1017  # Snapped down from 480
 
 
+# ============================================================================
+# Task 3: CLI --frames/--auto-duration collapse
+# ============================================================================
+
+
+def _parse_generate_args(*extra: str):
+    from ltx_pipelines_mlx.cli import _build_parser
+
+    parser = _build_parser()
+    return parser.parse_args(["generate", "-p", "a fox", "-o", "out.mp4", "--frame-rate", "24", "--distilled", *extra])
+
+
+def test_cli_frames_default_is_none_and_resolves_to_auto_duration():
+    """No -f => parsed default is None => resolves to AutoDuration()."""
+    from ltx_pipelines_mlx.cli import _resolve_num_frames_arg
+
+    args = _parse_generate_args()
+    assert args.frames is None
+    assert args.auto_duration is None
+
+    resolved = _resolve_num_frames_arg(args)
+    assert resolved == AutoDuration()
+
+
+def test_cli_explicit_frames_wins():
+    from ltx_pipelines_mlx.cli import _resolve_num_frames_arg
+
+    args = _parse_generate_args("-f", "25")
+    assert args.frames == 25
+    assert _resolve_num_frames_arg(args) == 25
+
+
+def test_cli_auto_duration_flag_parses_and_resolves():
+    from ltx_pipelines_mlx.cli import _resolve_num_frames_arg
+
+    args = _parse_generate_args("--auto-duration", "2:10")
+    assert args.auto_duration == AutoDuration(min_seconds=2.0, max_seconds=10.0)
+    assert args.frames is None
+    assert _resolve_num_frames_arg(args) == AutoDuration(min_seconds=2.0, max_seconds=10.0)
+
+
+def test_cli_explicit_frames_and_auto_duration_warns_and_frames_wins(capsys):
+    from ltx_pipelines_mlx.cli import _resolve_num_frames_arg
+
+    args = _parse_generate_args("-f", "25", "--auto-duration", "2:10")
+    resolved = _resolve_num_frames_arg(args)
+
+    assert resolved == 25
+    err = capsys.readouterr().err
+    assert "--frames" in err and "--auto-duration" in err
+
+
+def test_cli_auto_duration_rejects_malformed_value():
+    from ltx_pipelines_mlx.cli import _build_parser
+
+    parser = _build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(
+            [
+                "generate",
+                "-p",
+                "x",
+                "-o",
+                "out.mp4",
+                "--frame-rate",
+                "24",
+                "--distilled",
+                "--auto-duration",
+                "not-a-range",
+            ]
+        )
+
+
+def test_cli_other_subcommands_keep_97_default():
+    """keyframe/a2v/ic-lora keep their historical -f default untouched."""
+    from ltx_pipelines_mlx.cli import _build_parser
+
+    parser = _build_parser()
+    kf_args = parser.parse_args(
+        ["keyframe", "-p", "x", "-o", "out.mp4", "--frame-rate", "24", "--start", "a.png", "--end", "b.png"]
+    )
+    assert kf_args.frames == 97
+    assert not hasattr(kf_args, "auto_duration")
+
+
 @pytest.mark.slow
 @pytest.mark.skipif(LTX25_Q8_DIR is None, reason="local ltx-2.5-mlx-q8 pack not found")
 def test_duration_predictor_with_custom_bounds(tmp_path):

--- a/tests/test_duration_head.py
+++ b/tests/test_duration_head.py
@@ -324,6 +324,20 @@ def test_cli_auto_duration_rejects_malformed_value():
         )
 
 
+def test_cli_auto_duration_rejects_inverted_bounds(capsys):
+    """Mirrors upstream AutoDurationAction: MIN must be <= MAX, checked at parse time.
+
+    Without this guard, --auto-duration 10:2 would silently flow through
+    (AutoDuration doesn't validate its own fields) and produce a
+    wrong-duration render instead of a clear CLI error.
+    """
+    with pytest.raises(SystemExit):
+        _parse_generate_args("--auto-duration", "10:2")
+
+    err = capsys.readouterr().err
+    assert "MIN_SECONDS (10.0) must be <= MAX_SECONDS (2.0)" in err
+
+
 def test_cli_other_subcommands_keep_97_default():
     """keyframe/a2v/ic-lora keep their historical -f default untouched."""
     from ltx_pipelines_mlx.cli import _build_parser

--- a/tests/test_duration_head.py
+++ b/tests/test_duration_head.py
@@ -1,0 +1,148 @@
+"""Tests for the LTX-2.5 duration head.
+
+Non-slow tests exercise the pure-MLX module (shape contracts, the
+video-only/audio-only/both-None branches, and a numerical regression pinned
+against real pack weights). The slow bidirectional load-contract test (all
+15 pack tensors consumed, no model param left unfed) requires the local
+``ltx-2.5-mlx-q8`` pack and is gated the same way as
+``test_ltx25_load_contract.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import struct
+
+import mlx.core as mx
+import pytest
+
+from ltx_core_mlx.duration_head import AttentionPooler, DurationHead, load_duration_head
+from tests.conftest import LTX25_Q8_DIR
+
+
+def test_duration_head_requires_at_least_one_modality():
+    model = DurationHead()
+    with pytest.raises(ValueError, match="at least one of"):
+        model()
+
+
+def test_duration_head_video_only_shape():
+    model = DurationHead()
+    video_tokens = mx.random.normal((2, 8, 4096))
+    out = model(video_tokens=video_tokens)
+    assert out.shape == (2,)
+
+
+def test_duration_head_audio_only_shape():
+    model = DurationHead()
+    audio_tokens = mx.random.normal((2, 8, 2048))
+    out = model(audio_tokens=audio_tokens)
+    assert out.shape == (2,)
+
+
+def test_duration_head_both_modalities_shape():
+    model = DurationHead()
+    video_tokens = mx.random.normal((3, 5, 4096))
+    audio_tokens = mx.random.normal((3, 7, 2048))
+    out = model(video_tokens=video_tokens, audio_tokens=audio_tokens)
+    assert out.shape == (3,)
+
+
+def test_duration_head_output_is_positive():
+    """exp() is applied internally, so output must always be > 0 regardless of sign of logits."""
+    model = DurationHead()
+    video_tokens = mx.random.normal((4, 3, 4096)) * 100.0  # large-magnitude logits
+    out = model(video_tokens=video_tokens)
+    assert bool(mx.all(out > 0))
+
+
+def test_attention_pooler_pools_to_num_queries():
+    pooler = AttentionPooler(hidden_dim=256, num_queries=3, num_heads=4)
+    tokens = mx.random.normal((2, 10, 256))
+    out = pooler(tokens)
+    assert out.shape == (2, 3, 256)
+
+
+def test_load_duration_head_missing_file_raises(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        load_duration_head(tmp_path / "does_not_exist.safetensors")
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(LTX25_Q8_DIR is None, reason="local ltx-2.5-mlx-q8 pack not found")
+def test_load_duration_head_covers_every_pack_tensor():
+    """Bidirectional load contract: every pack tensor is consumed, every model param is fed.
+
+    Mirrors ``test_ltx25_load_contract.py``'s pattern (#52 silent-no-op class):
+    a weight nobody reads, or a param the pack doesn't serve, must fail loudly.
+    """
+    path = LTX25_Q8_DIR / "duration_head.safetensors"
+    with open(path, "rb") as f:
+        n = struct.unpack("<Q", f.read(8))[0]
+        header = json.loads(f.read(n))
+    pack_keys = {k for k in header if k != "__metadata__"}
+    assert len(pack_keys) == 15, f"expected 15 duration_head tensors, pack has {len(pack_keys)}"
+
+    # load_duration_head() itself would raise via load_weights(strict=True) if any
+    # model param went unfed, or silently ignore extra pack keys if not filtered --
+    # so also check the raw key set explicitly maps 1:1 onto the expected schema.
+    stripped = {k.removeprefix("duration_head.") for k in pack_keys}
+    expected = {
+        "video_input_proj.weight",
+        "video_input_proj.bias",
+        "video_modality_emb",
+        "audio_input_proj.weight",
+        "audio_input_proj.bias",
+        "audio_modality_emb",
+        "attention_pooler.query_tokens",
+        "attention_pooler.cross_attn.in_proj_weight",
+        "attention_pooler.cross_attn.in_proj_bias",
+        "attention_pooler.cross_attn.out_proj.weight",
+        "attention_pooler.cross_attn.out_proj.bias",
+        "mlp_hidden.weight",
+        "mlp_hidden.bias",
+        "mlp_out.weight",
+        "mlp_out.bias",
+    }
+    assert stripped == expected
+
+    model = load_duration_head(path)
+    mx.eval(model.parameters())
+
+    video_tokens = mx.random.normal((1, 16, 4096))
+    audio_tokens = mx.random.normal((1, 16, 2048))
+    out = model(video_tokens=video_tokens, audio_tokens=audio_tokens)
+    assert out.shape == (1,)
+    assert bool(out.item() > 0)
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(LTX25_Q8_DIR is None, reason="local ltx-2.5-mlx-q8 pack not found")
+def test_duration_head_pinned_regression():
+    """Pure-MLX regression pinned from a seeded input, derived from the torch parity harness.
+
+    Parity numbers (see task-1-report.md): torch vs. MLX on real weights with
+    identical seeded inputs (video ``(1,1024,4096)``, audio ``(1,1024,2048)``,
+    ``torch.manual_seed(0)``):
+        both:  torch=3.572701  mlx=3.57217   rel_err=1.5e-4
+        video: torch=3.199023  mlx=3.19872   rel_err=9.4e-5
+        audio: torch=3.893557  mlx=3.89286   rel_err=1.8e-4
+
+    This test pins the MLX-only values (mx.random-seeded, independent of the
+    torch harness's exact RNG stream) so future refactors can't silently drift.
+    """
+    path = LTX25_Q8_DIR / "duration_head.safetensors"
+    model = load_duration_head(path)
+
+    mx.random.seed(0)
+    video_tokens = mx.random.normal((1, 1024, 4096))
+    audio_tokens = mx.random.normal((1, 1024, 2048))
+
+    out_both = model(video_tokens=video_tokens, audio_tokens=audio_tokens)
+    out_video = model(video_tokens=video_tokens)
+    out_audio = model(audio_tokens=audio_tokens)
+
+    # Pinned against the reference pack; regenerate if the pack's weights change.
+    assert out_both.item() == pytest.approx(4.09065055847168, rel=1e-5)
+    assert out_video.item() == pytest.approx(3.8629565238952637, rel=1e-5)
+    assert out_audio.item() == pytest.approx(4.285473346710205, rel=1e-5)

--- a/tests/test_ltx25_distilled.py
+++ b/tests/test_ltx25_distilled.py
@@ -286,3 +286,73 @@ def test_upsampler_missing_raises_file_not_found(tmp_path):
     pipe = _upsampler_pipeline(tmp_path, ltx25=True, files=[])
     with pytest.raises(FileNotFoundError, match="Spatial upsampler weights not found"):
         pipe._resolve_upsampler_path()
+
+
+# --------------------------------------------------------------------------
+# Task 3: auto-duration wiring inside DistilledPipeline.generate_two_stage
+# --------------------------------------------------------------------------
+
+from ltx_pipelines_mlx.utils.types import DEFAULT_AUTO_DURATION, AutoDuration  # noqa: E402
+
+
+class _FakeDurationPredictor:
+    """Records its call args and always predicts a fixed frame count."""
+
+    def __init__(self, frames: int):
+        self._frames = frames
+        self.call_args: dict | None = None
+
+    def __call__(self, video_encoding, audio_encoding, *, frame_rate, min_seconds=1.0, max_seconds=20.0):
+        self.call_args = {
+            "video_encoding": video_encoding,
+            "audio_encoding": audio_encoding,
+            "frame_rate": frame_rate,
+            "min_seconds": min_seconds,
+            "max_seconds": max_seconds,
+        }
+        return self._frames
+
+
+def test_auto_duration_resolves_after_encode_on_25(tmp_path, monkeypatch):
+    """A 2.5 pack with a predictor resolves AutoDuration from the (stubbed) encodings.
+
+    18 -> latent F = (18 + 7) // 8 = 3 on the 2.5 pack's stub predictor
+    (prompt encoding stub returns zeros regardless, so any int works here;
+    17 is used to also pin the 8k+1-grid convention documented on DurationPredictor).
+    """
+    pipe, _, ancestral, noised_calls = _make_stubbed_pipeline(tmp_path, monkeypatch, ltx25=True)
+    fake_predictor = _FakeDurationPredictor(17)
+    pipe._duration_predictor = fake_predictor  # type: ignore[assignment]
+
+    _run(pipe, num_frames=DEFAULT_AUTO_DURATION)
+
+    # Predictor was called with the (stubbed) positive encodings, not negatives —
+    # DistilledPipeline has no CFG / negative prompt.
+    assert fake_predictor.call_args is not None
+    assert fake_predictor.call_args["frame_rate"] == 24.0
+    assert fake_predictor.call_args["min_seconds"] == DEFAULT_AUTO_DURATION.min_seconds
+    assert fake_predictor.call_args["max_seconds"] == DEFAULT_AUTO_DURATION.max_seconds
+
+    expected_f = (17 + 7) // 8
+    assert expected_f == 3
+    # Stage 1 video/audio noised-state calls carry the resolved latent F.
+    assert noised_calls[0]["spatial_dims"][0] == expected_f
+    assert noised_calls[1]["spatial_dims"][0] == expected_f
+    assert len(ancestral.calls) == 1
+
+
+def test_auto_duration_raises_early_on_23(tmp_path, monkeypatch):
+    """A pack without a DurationHead (predictor None) must fail before any encode work."""
+    pipe, euler, ancestral, _ = _make_stubbed_pipeline(tmp_path, monkeypatch, ltx25=False)
+    assert pipe._duration_predictor is None
+
+    def _unreachable_encode(prompt):
+        raise AssertionError("_encode_text must not be reached when the guard should fire first")
+
+    pipe._encode_text = _unreachable_encode  # type: ignore[method-assign]
+
+    with pytest.raises(ValueError, match="Pass num_frames explicitly"):
+        _run(pipe, num_frames=AutoDuration())
+
+    assert euler.calls == []
+    assert ancestral.calls == []

--- a/tests/test_ltx25_two_stage.py
+++ b/tests/test_ltx25_two_stage.py
@@ -132,7 +132,7 @@ def test_teacache_raises_on_25_pack(tmp_path, monkeypatch):
     """Verify that enable_teacache=True raises ValueError on an LTX-2.5 pack."""
     pipe = _make_two_stage(tmp_path, monkeypatch, ltx25=True)
     with pytest.raises(ValueError, match="TeaCache"):
-        pipe.generate_two_stage(prompt="a fox", frame_rate=24.0, enable_teacache=True)
+        pipe.generate_two_stage(prompt="a fox", num_frames=9, frame_rate=24.0, enable_teacache=True)
 
 
 class _AbortError(Exception):
@@ -154,14 +154,14 @@ def test_teacache_still_allowed_on_23_pack(tmp_path, monkeypatch):
 
     monkeypatch.setattr(pipe, "_encode_text_with_negative", boom, raising=False)
     with pytest.raises(_AbortError):
-        pipe.generate_two_stage(prompt="a fox", frame_rate=24.0, enable_teacache=True)
+        pipe.generate_two_stage(prompt="a fox", num_frames=9, frame_rate=24.0, enable_teacache=True)
 
 
 def test_teacache_raises_on_25_pack_hq(tmp_path, monkeypatch):
     """Verify that enable_teacache=True raises ValueError on an LTX-2.5 pack (HQ pipeline)."""
     pipe = _make_two_stage_hq(tmp_path, monkeypatch, ltx25=True)
     with pytest.raises(ValueError, match="TeaCache"):
-        pipe.generate_two_stage(prompt="a fox", frame_rate=24.0, enable_teacache=True)
+        pipe.generate_two_stage(prompt="a fox", num_frames=9, frame_rate=24.0, enable_teacache=True)
 
 
 def test_teacache_still_allowed_on_23_pack_hq(tmp_path, monkeypatch):
@@ -177,7 +177,7 @@ def test_teacache_still_allowed_on_23_pack_hq(tmp_path, monkeypatch):
 
     monkeypatch.setattr(pipe, "_encode_text_with_negative", boom, raising=False)
     with pytest.raises(_AbortError):
-        pipe.generate_two_stage(prompt="a fox", frame_rate=24.0, enable_teacache=True)
+        pipe.generate_two_stage(prompt="a fox", num_frames=9, frame_rate=24.0, enable_teacache=True)
 
 
 def test_cli_generate_distilled_lora_defaults_to_none(monkeypatch):


### PR DESCRIPTION
## Summary

Ports the LTX-2.5 **DurationHead** (attention-pooler regression head over the connector text encodings → predicted shot duration in seconds) and adopts the full upstream CLI semantics (user decision: "option B, iso complet"):

- **No \`-f\` on \`generate\` → \`num_frames = AutoDuration()\`**: 2.5 packs predict the duration (clamped to [1 s, 20 s], snapped to the \`8k+1\` grid); 2.3 packs fail fast with upstream's message ("… Pass num_frames explicitly.") **before** any model load.
- New \`--auto-duration MIN:MAX\` (custom clamp; inverted bounds rejected at parse time like upstream). Explicit \`-f N\` always wins (warning when both given).
- Other subcommands (keyframe/a2v/ic-lora/…) keep their current \`-f\` defaults.

**BREAKING CHANGE**: the implicit \`-f 97\` default disappears from the generate modes.

Core: \`ltx_core_mlx/duration_head/\` (loader splits torch's fused MHA \`in_proj\` into q/k/v; tanh-GELU verified). Pipelines: guard first, resolution right after prompt encoding, in all 4 generate modes.

## Validation

- **Torch parity on real weights**: rel err 9.4e-5 – 1.8e-4 (3 modality modes), pinned-value regression test mutation-verified (q/k/v swap caught).
- **Arithmetic byte-exact vs upstream** (clamp→snap→raise-to-grid), mutation-verified (order inversion + branch deletion both caught).
- **Auto-duration e2e** (2.5 q8, no \`-f\`): predicts **89 frames (3.71 s)** for the acceptance prompt, SHA-deterministic ×2; \`--auto-duration 2:4\` respected; 2.3 no-\`-f\` errors with zero load markers.
- **Explicit-frames path byte-identical**: both SHA-gates exact (2.3 distilled \`1248862480…\`, 2.5 distilled \`35b98e71…\`).
- Suites 798 + 35 slow, ruff clean. Render delivered for user review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Yai9eY2wgyDpQJmmtTw9o