### PR TITLE
fix(cli): forward the source frame rate in the retake/extend decode helper

### DIFF
--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/cli.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/cli.py
@@ -1406,9 +1406,13 @@ def _decode_and_save(
         pipe._loaded = False
         aggressive_cleanup()
 
-    # Load decoders on-demand and decode+save
+    # Load decoders on-demand and decode+save. The source frame rate was
+    # recorded by _encode_source_video; _decode_and_save_video requires it
+    # (keyword-only since the v0.14.0 frame_rate audit).
+    if pipe.source_frame_rate is None:
+        raise RuntimeError("source_frame_rate was never recorded; encode the source video first")
     pipe._load_decoders()
-    pipe._decode_and_save_video(video_latent, audio_latent, args.output)
+    pipe._decode_and_save_video(video_latent, audio_latent, args.output, frame_rate=pipe.source_frame_rate)
 
 
 def _guard_enhance_not_gemma4(gemma_path: str) -> None:

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/retake.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/retake.py
@@ -85,6 +85,10 @@ class RetakePipeline(BasePipeline):
     ):
         super().__init__(model_dir, gemma_model_id=gemma_model_id, low_memory=low_memory)
         self._dev_transformer = dev_transformer
+        # Source frame rate, recorded by _encode_source_video so CLI-level
+        # decode helpers can forward it to _decode_and_save_video without
+        # re-probing the file.
+        self.source_frame_rate: float | None = None
 
     def _encode_source_video(
         self,
@@ -146,6 +150,7 @@ class RetakePipeline(BasePipeline):
             frame_rate=info.fps,
             num_frames=vae_compatible_frames,
         )
+        self.source_frame_rate = meta.frame_rate
         return video_latent, audio_latent, meta
 
     def retake_from_video(

--- a/tests/test_retake_cli_decode.py
+++ b/tests/test_retake_cli_decode.py
@@ -1,0 +1,50 @@
+"""Regression: the retake/extend CLI decode helper forwards the source frame rate.
+
+The v0.14.0 audit made ``_decode_and_save_video``'s ``frame_rate`` keyword-only;
+the shared CLI helper ``_decode_and_save`` was missed (wrapper-audit-gap class,
+see the v0.14.1 memo) and every ``ltx-2-mlx retake``/``extend`` invocation died
+with a TypeError at decode time. These tests pin the forwarding.
+"""
+
+import argparse
+
+import pytest
+
+from ltx_pipelines_mlx.cli import _decode_and_save
+
+
+class _SpyPipe:
+    """Minimal pipeline double for the CLI decode helper."""
+
+    low_memory = False
+    source_frame_rate: float | None = 24.0
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    def _load_decoders(self) -> None:
+        self.calls.append({"load_decoders": True})
+
+    def _decode_and_save_video(self, video_latent, audio_latent, output_path, *, frame_rate: float):
+        self.calls.append({"output": output_path, "frame_rate": frame_rate})
+
+
+def test_decode_and_save_forwards_source_frame_rate(tmp_path):
+    pipe = _SpyPipe()
+    pipe.source_frame_rate = 30.0
+    args = argparse.Namespace(output=str(tmp_path / "out.mp4"))
+
+    _decode_and_save(pipe, object(), object(), args)
+
+    decode_call = pipe.calls[-1]
+    assert decode_call["frame_rate"] == 30.0
+    assert decode_call["output"] == args.output
+
+
+def test_decode_and_save_requires_recorded_frame_rate(tmp_path):
+    pipe = _SpyPipe()
+    pipe.source_frame_rate = None
+    args = argparse.Namespace(output=str(tmp_path / "out.mp4"))
+
+    with pytest.raises(RuntimeError, match="source_frame_rate"):
+        _decode_and_save(pipe, object(), object(), args)


### PR DESCRIPTION
Every \`ltx-2-mlx retake\`/\`extend\` CLI invocation has been dying with \`TypeError: _decode_and_save_video() missing 1 required keyword-only argument: 'frame_rate'\` since the v0.14.0 frame_rate audit — the shared CLI helper \`_decode_and_save\` was the one call site the audit (and the v0.14.1 wrapper hotfix) missed; retake/extend are Beta-tier with no e2e smoke, so it went unnoticed. Surfaced while validating retake on LTX-2.5.

Fix: \`RetakePipeline._encode_source_video\` records the probed source frame rate (\`self.source_frame_rate\`), and the helper forwards it (with a loud RuntimeError if somehow unset). Two regression tests pin the forwarding at the CLI-helper level. 800 tests green, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Yai9eY2wgyDpQJmmtTw9o