### PR TITLE
feat(pipelines): wire --low-ram block streaming into retake and extend

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -797,6 +797,7 @@ LTX-2.3 bf16 distilled, 480x704x33: confirmed runs end-to-end on M2 Pro 32 GB. W
 - `a2v` (audio-to-video)
 - `keyframe` (interpolation)
 - `ic-lora` (control video conditioning, via bind-time LoRA fusion)
+- `retake` / `extend` (dev model + CFG; mirrors upstream RetakePipeline's `offload_mode`)
 
 Validated runs on M2 Pro 32 GB:
 - bf16 HQ at 480x704x97 (4 sec): 49:38 — would OOM without streaming.
@@ -1026,7 +1027,7 @@ ltx-2-mlx generate --model /path/to/ltx-2.5-mlx-q8 --two-stage --low-ram \
 | `DurationHead` / auto-duration (`-f` optional) | supported — `-f` defaults to `AutoDuration()` on `--one-stage`/`--distilled`/`--two-stage`/`--two-stages-hq`; `--auto-duration MIN:MAX` overrides the clamp. Absent on 2.3 packs, where omitting `-f` now raises immediately (see "Auto-Duration" above) |
 | `keyframe` | supported — validated e2e on 2.5 (deterministic, audio -38.3 dB; requires `--dev-transformer transformer-dev.safetensors`) |
 | `a2v` | supported — validated e2e on 2.5 (deterministic, conditioned audio faithfully reconstructed at -36.2 dB) |
-| `retake`, `extend` | supported — validated e2e on 2.5 (retake deterministic ×2; extend +N latent frames; no `--low-ram` on these commands, so long/HD sources may exceed 32 GB) |
+| `retake`, `extend` | supported — validated e2e on 2.5 (retake deterministic ×2; extend +N latent frames). `--low-ram` wired (mirrors upstream `offload_mode`): 49-frame retake that OOM'd now peaks at 13.8 GB |
 | `ic-lora`, `hdr-ic-lora`, `lipdub` | not yet supported (no official 2.5 task IC-LoRAs published yet) |
 | `enhance` / `--enhance-prompt` | raises `NotImplementedError` (`_guard_enhance_not_gemma4`) — Gemma 3 only |
 | `--enable-teacache` | raises `ValueError` — 2.3 polynomial isn't calibrated for 2.5 |

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ ltx-2-mlx generate --model /path/to/ltx-2.5-mlx-q8 --two-stage \
 | `DurationHead` / auto-duration (`-f` optional) | supported — `-f` defaults to an auto-predicted duration on `--one-stage`/`--distilled`/`--two-stage`/`--two-stages-hq`; `--auto-duration MIN:MAX` overrides the clamp. Not available on 2.3 packs (no `DurationHead` weights); `-f` stays required there |
 | `keyframe` | supported — validated e2e on 2.5 (deterministic, audio -38.3 dB; requires `--dev-transformer transformer-dev.safetensors`) |
 | `a2v` | supported — validated e2e on 2.5 (deterministic, conditioned audio faithfully reconstructed at -36.2 dB) |
-| `retake`, `extend` | supported — validated e2e on 2.5 (retake deterministic ×2; extend +N latent frames; no `--low-ram` on these commands, so long/HD sources may exceed 32 GB) |
+| `retake`, `extend` | supported — validated e2e on 2.5 (retake deterministic ×2; extend +N latent frames). `--low-ram` wired (mirrors upstream `offload_mode`): 49-frame retake that OOM'd now peaks at 13.8 GB |
 | `ic-lora`, `hdr-ic-lora`, `lipdub` | not yet supported (no official 2.5 task IC-LoRAs published yet) |
 | `enhance` / `--enhance-prompt` | raises a clear error (Gemma 3-only) |
 | `--enable-teacache` | raises a clear error (not calibrated for 2.5) |

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/cli.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/cli.py
@@ -235,7 +235,7 @@ def _add_generation_args(parser: argparse.ArgumentParser, *, frames_default: int
             "transformer peak Metal ~75%% (e.g. q8 ~10-12 GB -> ~2.8 GB). "
             "Targets 16 GB Macs (q8) and 32 GB Macs (bf16). Supported "
             "on generate (one-stage / --two-stage / --two-stages-hq), a2v, "
-            "keyframe, and ic-lora. Compatible with generate's --lora flag "
+            "keyframe, ic-lora, retake, and extend. Compatible with generate's --lora flag "
             "via per-block BlockLoraSource bind-time fusion. Two-stage at "
             "LoRA strength 1.0 swaps to the pre-fused "
             "transformer-distilled.safetensors at the stage 1->2 transition; "
@@ -502,6 +502,11 @@ examples:
         "--stg-scale", type=float, default=None, help="STG guidance scale (default: 1.0 — upstream LTX_2_3_PARAMS)"
     )
     ret.add_argument("--no-regen-audio", action="store_true", help="Preserve original audio (don't regenerate)")
+    ret.add_argument(
+        "--low-ram",
+        action="store_true",
+        help="Stream transformer blocks from mmap'd safetensors (see generate --low-ram)",
+    )
 
     # --- extend ---
     ext = sub.add_parser("extend", help="[beta] Add frames before or after an existing video")
@@ -509,6 +514,11 @@ examples:
     ext.add_argument("--video", "-v", required=True, help="Source video file")
     ext.add_argument("--extend-frames", type=int, required=True, help="Number of latent frames to add")
     ext.add_argument("--direction", choices=["before", "after"], default="after", help="Direction (default: after)")
+    ext.add_argument(
+        "--low-ram",
+        action="store_true",
+        help="Stream transformer blocks from mmap'd safetensors (see generate --low-ram)",
+    )
     ext.add_argument("--steps", type=int, default=None, help="Denoising steps (default: 30)")
     ext.add_argument("--cfg-scale", type=float, default=None, help="CFG guidance scale (default: 3.0)")
     ext.add_argument(
@@ -1102,7 +1112,11 @@ def _cmd_retake(args: argparse.Namespace) -> None:
         print("Mode: Retake")
         print(f"Video: {args.video}, frames {args.start}-{args.end}")
 
-    pipe = RetakePipeline(model_dir=args.model, gemma_model_id=args.gemma)
+    pipe = RetakePipeline(
+        model_dir=args.model,
+        gemma_model_id=args.gemma,
+        low_ram_streaming=getattr(args, "low_ram", False),
+    )
     pipe.verbose = not args.quiet
     pipe.stepwise = _build_stepwise(args)
     kwargs: dict = dict(
@@ -1140,7 +1154,11 @@ def _cmd_extend(args: argparse.Namespace) -> None:
         print(f"Mode: Extend ({args.direction})")
         print(f"Video: {args.video}, +{args.extend_frames} latent frames")
 
-    pipe = RetakePipeline(model_dir=args.model, gemma_model_id=args.gemma)
+    pipe = RetakePipeline(
+        model_dir=args.model,
+        gemma_model_id=args.gemma,
+        low_ram_streaming=getattr(args, "low_ram", False),
+    )
     pipe.verbose = not args.quiet
     pipe.stepwise = _build_stepwise(args)
     kwargs: dict = dict(

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/retake.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/retake.py
@@ -73,6 +73,8 @@ class RetakePipeline(BasePipeline):
         model_dir: Path to model weights.
         gemma_model_id: Gemma model for text encoding.
         low_memory: Aggressive memory management.
+        low_ram_streaming: Stream transformer blocks from mmap'd safetensors
+            (``--low-ram``); mirrors upstream RetakePipeline's ``offload_mode``.
         dev_transformer: Dev transformer filename.
     """
 
@@ -81,9 +83,15 @@ class RetakePipeline(BasePipeline):
         model_dir: str,
         gemma_model_id: str = "mlx-community/gemma-3-12b-it-4bit",
         low_memory: bool = True,
+        low_ram_streaming: bool = False,
         dev_transformer: str = "transformer-dev.safetensors",
     ):
-        super().__init__(model_dir, gemma_model_id=gemma_model_id, low_memory=low_memory)
+        super().__init__(
+            model_dir,
+            gemma_model_id=gemma_model_id,
+            low_memory=low_memory,
+            low_ram_streaming=low_ram_streaming,
+        )
         self._dev_transformer = dev_transformer
         # Source frame rate, recorded by _encode_source_video so CLI-level
         # decode helpers can forward it to _decode_and_save_video without

--- a/tests/test_retake_cli_decode.py
+++ b/tests/test_retake_cli_decode.py
@@ -48,3 +48,32 @@ def test_decode_and_save_requires_recorded_frame_rate(tmp_path):
 
     with pytest.raises(RuntimeError, match="source_frame_rate"):
         _decode_and_save(pipe, object(), object(), args)
+
+
+def test_retake_cli_forwards_low_ram(monkeypatch):
+    """The retake/extend subcommands construct RetakePipeline with low_ram_streaming.
+
+    Upstream's RetakePipeline threads ``offload_mode`` into its stages; our
+    ``--low-ram`` is the MLX equivalent, so dropping the pass-through would
+    silently regress to full-weight loading (the 32 GB OOM class).
+    """
+    from ltx_pipelines_mlx.cli import _build_parser
+
+    parser = _build_parser()
+    for argv in (
+        ["retake", "-p", "x", "-o", "o.mp4", "--video", "v.mp4", "--start", "1", "--end", "2", "--low-ram"],
+        ["extend", "-p", "x", "-o", "o.mp4", "--video", "v.mp4", "--extend-frames", "4", "--low-ram"],
+    ):
+        args = parser.parse_args(argv)
+        assert args.low_ram is True
+
+    args = parser.parse_args(["retake", "-p", "x", "-o", "o.mp4", "--video", "v.mp4", "--start", "1", "--end", "2"])
+    assert args.low_ram is False
+
+
+def test_retake_pipeline_accepts_low_ram_streaming(tmp_path, monkeypatch):
+    from ltx_pipelines_mlx.retake import RetakePipeline
+
+    (tmp_path / "embedded_config.json").write_text('{"transformer": {}}')
+    pipe = RetakePipeline(model_dir=str(tmp_path), low_ram_streaming=True)
+    assert pipe.low_ram_streaming is True


### PR DESCRIPTION
Mirrors upstream \`RetakePipeline\`'s \`offload_mode\` (their CUDA weight-streaming equivalent, exposed as \`--offload\` in the official CLI). Our \`RetakePipeline\` already loads through the streaming funnel (\`_load_transformer_with_optional_streaming\`), so the wiring is the constructor pass-through + the \`--low-ram\` flag on the \`retake\`/\`extend\` subcommands + forwarding tests.

**Validation**: the 49-frame retake source that was OOM-killed on the 32 GB machine now completes with \`--low-ram\` at a **13.8 GB peak RSS** (45 min, q8). The extend command shares the identical loading funnel; its non-streamed e2e was validated in #114 (an extend-with-low-ram render was attempted three times but the background tasks were externally stopped — flagging for transparency; the code path exercised is byte-for-byte the one the retake run proved).

Suites 802 green, ruff clean. Docs/help text updated (coverage lists + limits table).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Yai9eY2wgyDpQJmmtTw9o