### PR TITLE
docs: add the LTX-2.5 pack variants table (bf16 / q8 / q4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,6 +180,14 @@ Weights are pre-converted by [mlx-forge](https://github.com/dgrauet/mlx-forge) a
 | int8 | [dgrauet/ltx-2.3-mlx-q8](https://huggingface.co/dgrauet/ltx-2.3-mlx-q8) | ~26GB | Recommended for 32GB+; fits 16GB with `--low-ram`. Stack with tiling for HD on Mac Studio. |
 | int4 | [dgrauet/ltx-2.3-mlx-q4](https://huggingface.co/dgrauet/ltx-2.3-mlx-q4) | ~12GB | Lower quality, fits 16GB |
 
+LTX-2.5 packs (same variant semantics; carry the Gemma-4 text tower, conv VAE pair and DurationHead):
+
+| Variant | HuggingFace | Size | Notes |
+|---------|-------------|------|-------|
+| bf16 | [dgrauet/ltx-2.5-mlx](https://huggingface.co/dgrauet/ltx-2.5-mlx) | ~131GB | Full precision (dev + distilled + Gemma-4 in bf16); needs `--low-ram` on 32GB |
+| int8 | [dgrauet/ltx-2.5-mlx-q8](https://huggingface.co/dgrauet/ltx-2.5-mlx-q8) | ~70GB | Recommended; validated e2e on all 2.5 pipelines |
+| int4 | [dgrauet/ltx-2.5-mlx-q4](https://huggingface.co/dgrauet/ltx-2.5-mlx-q4) | ~47GB | Lower quality; validated (contracts + deterministic distilled render, ~97s/render) |
+
 ### MLX Layout Conventions
 
 | Layer Type | PyTorch | MLX | Notes |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,8 +184,8 @@ LTX-2.5 packs (same variant semantics; carry the Gemma-4 text tower, conv VAE pa
 
 | Variant | HuggingFace | Size | Notes |
 |---------|-------------|------|-------|
-| bf16 | [dgrauet/ltx-2.5-mlx](https://huggingface.co/dgrauet/ltx-2.5-mlx) | ~131GB | Full precision (dev + distilled + Gemma-4 in bf16); needs `--low-ram` on 32GB |
-| int8 | [dgrauet/ltx-2.5-mlx-q8](https://huggingface.co/dgrauet/ltx-2.5-mlx-q8) | ~70GB | Recommended; validated e2e on all 2.5 pipelines |
+| bf16 | [dgrauet/ltx-2.5-mlx](https://huggingface.co/dgrauet/ltx-2.5-mlx) | ~120GB | Full precision (dev + distilled + Gemma-4 in bf16); needs `--low-ram` on 32GB |
+| int8 | [dgrauet/ltx-2.5-mlx-q8](https://huggingface.co/dgrauet/ltx-2.5-mlx-q8) | ~75GB | Recommended; validated e2e on all 2.5 pipelines |
 | int4 | [dgrauet/ltx-2.5-mlx-q4](https://huggingface.co/dgrauet/ltx-2.5-mlx-q4) | ~47GB | Lower quality; validated (contracts + deterministic distilled render, ~97s/render) |
 
 ### MLX Layout Conventions


### PR DESCRIPTION
Adds the 2.5 row set next to the 2.3 variants table, with the freshly published HF repos. The q4 pack was validated locally: 35 load-contract tests green, distilled render SHA-deterministic ×2 (\`0df224b2…\`, ~97 s/render at 512×512×25). Sizes from the HF API (bf16 120 GB, q8 75 GB) and the local q4 dir (47 GB — upload still in flight at writing time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Yai9eY2wgyDpQJmmtTw9o