### PR TITLE
fix(core): run the plain AdaLN path under streaming, not dedupe-without-lazy

### DIFF
--- a/packages/ltx-core-mlx/src/ltx_core_mlx/loader/block_streaming.py
+++ b/packages/ltx-core-mlx/src/ltx_core_mlx/loader/block_streaming.py
@@ -374,18 +374,22 @@ class StreamingLTXModel(nn.Module):
         # The lazy AdaLN carrier (``PerTokenAdaLNParams``) is a non-tree
         # argument, so it cannot cross the compiled block -- and the compiled
         # block is load-bearing here: it is what keeps 48 per-block syncs
-        # under the Metal watchdog (see the module docstring). Rather than
-        # falling back to the eager block (forfeiting that protection), keep
-        # the GEMM dedupe but materialise its result eagerly for the duration
-        # of this forward: the lazy activation cut is forfeited under
-        # streaming, the watchdog/compile properties are not.
+        # under the Metal watchdog (see the module docstring). Disable the
+        # whole dedupe pair for streamed forwards rather than just the lazy
+        # gather: benchmarked at 480x704x97 (M2 Pro, q8), dedupe-without-lazy
+        # is the slowest arm of all (the materialised full-width gather costs
+        # more than the GEMM it saves -- 420s vs 313s plain / 339s lazy), so
+        # the plain path is what streaming should run.
         from ltx_core_mlx.model.transformer import model as _model_mod
 
+        dedupe_prev = _model_mod._ADALN_DEDUPE
         lazy_prev = _model_mod._ADALN_LAZY
+        _model_mod._ADALN_DEDUPE = False
         _model_mod._ADALN_LAZY = False
         try:
             return self.inner(*args, **kwargs)
         finally:
+            _model_mod._ADALN_DEDUPE = dedupe_prev
             _model_mod._ADALN_LAZY = lazy_prev
 
     def __getattr__(self, name: str):


### PR DESCRIPTION
Follow-up to #86, driven by the production-res benchmark (480×704×97 I2V, M2 Pro, q8, all arms bit-identical \`e0c3567c…\`):

| Arm | Time | Peak RSS |
|---|---|---|
| plain (off) | **312.8 s** | 12.76 GB |
| dedupe+lazy | 339.5 s | **12.27 GB** |
| dedupe w/o lazy | 420.0 s | 13.11 GB |

The streamer's #86 fallback (lazy off, dedupe kept — the carrier can't cross \`mx.compile\`) forced exactly the slowest arm on conditioned \`--low-ram\` runs. Streamed forwards now disable the whole pair and run the plain path.

Open question flagged to the maintainer separately: whether dedupe+lazy should stay default-on at all on this hardware class (+8.5 % time for −0.5 GB here; the original multi-GB claim came from an M4 Max bench).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Yai9eY2wgyDpQJmmtTw9o