### PR TITLE
fix: stage-2 sigma schedule must always terminate at 0.0

### DIFF
--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/a2vid_two_stage.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/a2vid_two_stage.py
@@ -31,7 +31,7 @@ from ltx_core_mlx.model.transformer.model import X0Model
 from ltx_core_mlx.utils.audio import load_audio
 from ltx_core_mlx.utils.memory import aggressive_cleanup
 from ltx_core_mlx.utils.positions import compute_audio_positions, compute_audio_token_count, compute_video_positions
-from ltx_pipelines_mlx.scheduler import STAGE_2_SIGMAS, ltx2_schedule
+from ltx_pipelines_mlx.scheduler import ltx2_schedule, stage2_sigmas
 from ltx_pipelines_mlx.ti2vid_two_stages import DEFAULT_CFG_SCALE, TI2VidTwoStagesPipeline
 from ltx_pipelines_mlx.utils.helpers import create_noised_state
 from ltx_pipelines_mlx.utils.samplers import OnStepFn, denoise_loop, guided_denoise_loop
@@ -312,7 +312,7 @@ class A2VidPipelineTwoStage(TI2VidTwoStagesPipeline):
         # --- Stage 2: Refine at full resolution (no CFG) ---
         video_tokens, _ = self.video_patchifier.patchify(video_upscaled)
 
-        sigmas_2 = STAGE_2_SIGMAS[: stage2_steps + 1] if stage2_steps else STAGE_2_SIGMAS
+        sigmas_2 = stage2_sigmas(stage2_steps)
         start_sigma = sigmas_2[0]
 
         video_positions_2 = compute_video_positions(F, H_full, W_full)

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/distilled.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/distilled.py
@@ -40,7 +40,7 @@ from .scheduler import (
     DISTILLED_SIGMAS,
     LTX_2_5_DISTILLED_SIGMAS,
     LTX_2_5_STAGE_2_DISTILLED_SIGMAS,
-    STAGE_2_SIGMAS,
+    stage2_sigmas,
 )
 from .ti2vid_two_stages import TI2VidTwoStagesPipeline
 from .utils.helpers import create_noised_state
@@ -392,8 +392,14 @@ class DistilledPipeline(TI2VidTwoStagesPipeline):
 
         # --- Stage 2: full resolution refine (no LoRA swap — already distilled) ---
         video_tokens, _ = self.video_patchifier.patchify(video_upscaled)
-        stage2_table = LTX_2_5_STAGE_2_DISTILLED_SIGMAS if self._is_25 else STAGE_2_SIGMAS
-        sigmas_2 = stage2_table[: stage2_steps + 1] if stage2_steps else stage2_table
+        if self._is_25:
+            # Upstream's 2.5 path keeps its own slice: its tests assert both the
+            # truncation and the table's object identity, and #33's speckle was
+            # never reproduced on a 2.5 pack. See scheduler.stage2_sigmas.
+            stage2_table = LTX_2_5_STAGE_2_DISTILLED_SIGMAS
+            sigmas_2 = stage2_table[: stage2_steps + 1] if stage2_steps else stage2_table
+        else:
+            sigmas_2 = stage2_sigmas(stage2_steps)
         # Upstream renoises the upscaled stage-1 latent at ``stage_2_sigmas[0]``
         # (``ModalitySpec(noise_scale=stage_2_sigmas[0].item())``); our
         # ``create_noised_state(sigma=...)`` below is that same mechanism.

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ic_lora.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ic_lora.py
@@ -41,7 +41,7 @@ from ltx_pipelines_mlx.iclora_utils import (
     append_ic_lora_reference_video_conditionings,
     read_lora_reference_downscale_factor,
 )
-from ltx_pipelines_mlx.scheduler import DISTILLED_SIGMAS, STAGE_2_SIGMAS
+from ltx_pipelines_mlx.scheduler import DISTILLED_SIGMAS, stage2_sigmas
 from ltx_pipelines_mlx.utils.helpers import create_noised_state
 from ltx_pipelines_mlx.utils.samplers import denoise_loop
 
@@ -632,7 +632,7 @@ class ICLoraPipeline(BasePipeline):
             n = max(1, min(int(refine_steps), len(DISTILLED_SIGMAS) - 1))
             sigmas_2 = DISTILLED_SIGMAS[len(DISTILLED_SIGMAS) - 1 - n :]
         else:
-            sigmas_2 = STAGE_2_SIGMAS[: stage2_steps + 1] if stage2_steps else STAGE_2_SIGMAS
+            sigmas_2 = stage2_sigmas(stage2_steps)
         start_sigma = sigmas_2[0]
 
         video_positions_2 = compute_video_positions(F, H_full, W_full, frame_rate=frame_rate)

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/keyframe_interpolation.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/keyframe_interpolation.py
@@ -29,7 +29,7 @@ from ltx_core_mlx.model.video_vae.video_vae import VideoEncoder
 from ltx_core_mlx.utils.image import prepare_image_for_encoding
 from ltx_core_mlx.utils.memory import aggressive_cleanup
 from ltx_core_mlx.utils.positions import compute_audio_positions, compute_audio_token_count, compute_video_positions
-from ltx_pipelines_mlx.scheduler import DISTILLED_SIGMAS, STAGE_2_SIGMAS, ltx2_schedule
+from ltx_pipelines_mlx.scheduler import DISTILLED_SIGMAS, ltx2_schedule, stage2_sigmas
 from ltx_pipelines_mlx.ti2vid_two_stages import TI2VidTwoStagesPipeline
 from ltx_pipelines_mlx.utils.helpers import create_noised_state
 from ltx_pipelines_mlx.utils.samplers import denoise_loop, guided_denoise_loop
@@ -345,7 +345,7 @@ class KeyframeInterpolationPipeline(TI2VidTwoStagesPipeline):
 
         # Stage 2 orchestration matches upstream `create_noised_state`:
         #     init (initial_latent=upscaled) -> apply conditionings -> noise.
-        sigmas_2 = STAGE_2_SIGMAS[: stage2_steps + 1] if stage2_steps else STAGE_2_SIGMAS
+        sigmas_2 = stage2_sigmas(stage2_steps)
         start_sigma = sigmas_2[0]
 
         video_positions_2 = compute_video_positions(F, H_full, W_full, frame_rate=frame_rate)

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/lipdub.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/lipdub.py
@@ -30,7 +30,7 @@ from ltx_core_mlx.utils.positions import compute_audio_positions, compute_audio_
 
 from .ic_lora import ICLoraPipeline
 from .iclora_utils import append_ic_lora_reference_video_conditionings
-from .scheduler import DISTILLED_SIGMAS, STAGE_2_SIGMAS
+from .scheduler import DISTILLED_SIGMAS, stage2_sigmas
 from .utils.helpers import create_noised_state
 from .utils.samplers import denoise_loop
 
@@ -308,7 +308,7 @@ class LipDubPipeline(ICLoraPipeline):
         # Intentional divergence from ic_lora.py which reloads a clean transformer.
 
         video_tokens_up, _ = self.video_patchifier.patchify(video_upscaled)
-        sigmas_2 = STAGE_2_SIGMAS[: stage2_steps + 1] if stage2_steps else STAGE_2_SIGMAS
+        sigmas_2 = stage2_sigmas(stage2_steps)
         start_sigma = sigmas_2[0]
 
         video_positions_2 = compute_video_positions(F, H_full, W_full, frame_rate=frame_rate)

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/scheduler.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/scheduler.py
@@ -41,6 +41,7 @@ __all__ = [
     "get_sigma_schedule",
     "ltx2_schedule",
     "sigma_to_timestep",
+    "stage2_sigmas",
 ]
 
 # Predefined sigma schedule for 8-step distilled model.
@@ -90,6 +91,44 @@ LTX_2_5_STAGE_2_DISTILLED_SIGMAS: list[float] = [
     0.421875,
     0.0,
 ]
+
+
+def stage2_sigmas(stage2_steps: int | None = None) -> list[float]:
+    """Stage-2 refinement sigma schedule that always terminates at 0.0.
+
+    ``STAGE_2_SIGMAS`` is a fixed 4-value table (3 steps) whose terminal value
+    is 0.0. Naively prefix-slicing it for ``stage2_steps < 3`` (e.g.
+    ``STAGE_2_SIGMAS[:stage2_steps + 1]``) drops that terminal 0.0, so
+    ``denoise_loop`` stops at a non-zero sigma and hands the VAE a latent that
+    is still partially noised — which the decoder renders as heavy colour
+    speckle. Always append the terminal 0.0 so the final Euler step fully
+    denoises, for any step count.
+
+    Args:
+        stage2_steps: Number of stage-2 steps. ``None``/0 → the full default
+            3-step schedule. Values ``>= 3`` are clamped to the 3 steps the
+            table provides (no phantom zero-length final step).
+
+    Note:
+        Deliberately scoped to ``STAGE_2_SIGMAS``. The LTX-2.5 distilled path has
+        its own value-identical ``LTX_2_5_STAGE_2_DISTILLED_SIGMAS`` and appears
+        to carry the same truncation, but upstream's tests assert that slice AND
+        the table's object identity on purpose, and the speckle this fixes was
+        only ever reproduced on the dev two-stage path. Left alone rather than
+        "fixed" on inference.
+
+    Returns:
+        Sigma list of length ``num_steps + 1``, always ending at 0.0.
+    """
+    if not stage2_steps:
+        return list(STAGE_2_SIGMAS)
+    head = list(STAGE_2_SIGMAS[:stage2_steps])
+    if head and head[-1] == 0.0:
+        # Only stage2_steps >= 4 lands here: STAGE_2_SIGMAS[:3] stops at 0.421875, so
+        # stage2_steps == 3 takes the append path below and reconstructs the full table.
+        # Same result either way; this branch just avoids appending a duplicate 0.0.
+        return head
+    return head + [0.0]
 
 
 def get_sigma_schedule(

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ti2vid_two_stages.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ti2vid_two_stages.py
@@ -33,7 +33,7 @@ from ltx_core_mlx.utils.memory import aggressive_cleanup
 from ltx_core_mlx.utils.positions import compute_audio_positions, compute_audio_token_count, compute_video_positions
 from ltx_core_mlx.utils.weights import load_split_safetensors
 from ltx_pipelines_mlx._base import BasePipeline
-from ltx_pipelines_mlx.scheduler import STAGE_2_SIGMAS, ltx2_schedule
+from ltx_pipelines_mlx.scheduler import ltx2_schedule, stage2_sigmas
 from ltx_pipelines_mlx.utils.generation import is_ltx25_pack
 from ltx_pipelines_mlx.utils.helpers import create_noised_state
 from ltx_pipelines_mlx.utils.samplers import denoise_loop, guided_denoise_loop
@@ -597,7 +597,7 @@ class TI2VidTwoStagesPipeline(BasePipeline):
         # --- Stage 2: Refine at full resolution (no CFG) ---
         video_tokens, _ = self.video_patchifier.patchify(video_upscaled)
 
-        sigmas_2 = STAGE_2_SIGMAS[: stage2_steps + 1] if stage2_steps else STAGE_2_SIGMAS
+        sigmas_2 = stage2_sigmas(stage2_steps)
         start_sigma = sigmas_2[0]
 
         video_positions_2 = compute_video_positions(F, H_full, W_full, frame_rate=frame_rate)

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ti2vid_two_stages_hq.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/ti2vid_two_stages_hq.py
@@ -23,7 +23,7 @@ from ltx_core_mlx.components.patchifiers import (
 from ltx_core_mlx.model.transformer.model import X0Model
 from ltx_core_mlx.utils.memory import aggressive_cleanup
 from ltx_core_mlx.utils.positions import compute_audio_positions, compute_audio_token_count, compute_video_positions
-from ltx_pipelines_mlx.scheduler import STAGE_2_SIGMAS, ltx2_schedule
+from ltx_pipelines_mlx.scheduler import ltx2_schedule, stage2_sigmas
 from ltx_pipelines_mlx.ti2vid_two_stages import DEFAULT_CFG_SCALE, TI2VidTwoStagesPipeline
 from ltx_pipelines_mlx.utils.helpers import create_noised_state
 from ltx_pipelines_mlx.utils.samplers import denoise_loop, res2s_denoise_loop
@@ -290,7 +290,7 @@ class TI2VidTwoStagesHQPipeline(TI2VidTwoStagesPipeline):
         # --- Stage 2: Refine at full resolution (no CFG) ---
         video_tokens, _ = self.video_patchifier.patchify(video_upscaled)
 
-        sigmas_2 = STAGE_2_SIGMAS[: stage2_steps + 1] if stage2_steps else STAGE_2_SIGMAS
+        sigmas_2 = stage2_sigmas(stage2_steps)
         start_sigma = sigmas_2[0]
 
         video_positions_2 = compute_video_positions(F, H_full, W_full, frame_rate=frame_rate)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -8,6 +8,7 @@ from ltx_pipelines_mlx.scheduler import (
     get_sigma_schedule,
     ltx2_schedule,
     sigma_to_timestep,
+    stage2_sigmas,
 )
 
 
@@ -62,6 +63,50 @@ class TestStage2Sigmas:
         """Stage 2 sigmas should be a subset of distilled sigmas."""
         for s in STAGE_2_SIGMAS:
             assert s in DISTILLED_SIGMAS
+
+
+# ---------------------------------------------------------------------------
+# stage2_sigmas — must ALWAYS terminate at 0.0 (regression: a2v fast corruption)
+# ---------------------------------------------------------------------------
+class TestStage2SigmasHelper:
+    """Regression guard for the stage-2 schedule-truncation bug.
+
+    Prefix-slicing STAGE_2_SIGMAS for stage2_steps < 3 used to drop the terminal
+    0.0, leaving the VAE a partially noised latent (rendered as colour speckle).
+    stage2_sigmas() must always end at 0.0 regardless of step count.
+    """
+
+    def test_none_returns_full_schedule(self):
+        assert stage2_sigmas(None) == STAGE_2_SIGMAS
+        assert stage2_sigmas(0) == STAGE_2_SIGMAS
+
+    @pytest.mark.parametrize("steps", [1, 2, 3, 4, 5])
+    def test_always_terminates_at_zero(self, steps):
+        assert stage2_sigmas(steps)[-1] == 0.0
+
+    @pytest.mark.parametrize("steps", [1, 2, 3])
+    def test_length_is_steps_plus_one(self, steps):
+        # N steps => N+1 sigmas (denoise_loop iterates consecutive pairs)
+        assert len(stage2_sigmas(steps)) == steps + 1
+
+    def test_three_steps_matches_full_table(self):
+        # The supported case must be byte-identical to the old STAGE_2_SIGMAS[:4].
+        assert stage2_sigmas(3) == STAGE_2_SIGMAS
+
+    def test_two_steps_keeps_calibrated_head(self):
+        assert stage2_sigmas(2) == [STAGE_2_SIGMAS[0], STAGE_2_SIGMAS[1], 0.0]
+
+    def test_beyond_table_length_clamps_without_phantom_zero(self):
+        # asking for more steps than the table provides must not append a
+        # second trailing 0.0 (a zero-length final Euler step).
+        assert stage2_sigmas(4) == STAGE_2_SIGMAS
+        assert stage2_sigmas(9) == STAGE_2_SIGMAS
+
+    @pytest.mark.parametrize("steps", [1, 2, 3, 4])
+    def test_strictly_decreasing(self, steps):
+        s = stage2_sigmas(steps)
+        for i in range(len(s) - 1):
+            assert s[i] > s[i + 1]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

`STAGE_2_SIGMAS` is a fixed 4-value table (3 steps) whose terminal value is `0.0`. Every
two-stage pipeline prefix-slices it as `STAGE_2_SIGMAS[: stage2_steps + 1]`, which **drops
that terminal `0.0`** whenever `stage2_steps < 3`:

```python
>>> STAGE_2_SIGMAS[: 2 + 1]
[0.909375, 0.725, 0.421875]   # never reaches 0.0
```

`denoise_loop` therefore stops at sigma 0.42 and hands the VAE a latent that is still
~42% noised. The decoder renders that as heavy colour speckle across the whole frame.

This adds `scheduler.stage2_sigmas()`, which always terminates at `0.0` for any step count,
and routes the seven affected two-stage call sites through it.

## Why it matters

`--stage2-steps` is a documented flag, so any value below 3 silently produces corrupted
output rather than a faster-but-rougher render. Found downstream while chasing exactly that:
an a2v "fast" preset at `stage2_steps=2` produced speckle, which looked like a TeaCache
regression until the sigma schedule turned out to be the cause.

## Behaviour

| `stage2_steps` | before | after |
|---|---|---|
| `None` / `0` | full 3-step table | **unchanged** |
| `1` | `[0.909, 0.725]` — no terminal 0 | `[0.909, 0.0]` |
| `2` | `[0.909, 0.725, 0.422]` — no terminal 0 | `[0.909, 0.725, 0.0]` |
| `3` | full table | **unchanged (byte-identical)** |
| `>= 4` | full table | clamped to the table's 3 steps (no phantom zero-length final step) |

The default path is byte-identical, so nothing changes for anyone not passing
`--stage2-steps 1` or `2`.

## Deliberately NOT changed: the LTX-2.5 path

`DistilledPipeline` selects `LTX_2_5_STAGE_2_DISTILLED_SIGMAS` on 2.5 packs, and that table
carries the same prefix-slice. It **looks** like the same bug, and my first attempt fixed it
too — but that breaks two of your tests on purpose:

- `test_stage_step_truncation_applies_to_the_25_tables` asserts the truncated slice directly
- `test_25_pack_stage2_stays_deterministic` asserts *object identity* of the table, with the
  comment "identity, not equality: the 2.3 table is value-identical"

Both read as intentional, and I have only ever reproduced the speckle on the dev two-stage
path — never on a 2.5 pack. So the 2.5 branch keeps its existing behaviour here and the
scoping is documented in `stage2_sigmas`'s docstring. Happy to extend it if you confirm the
2.5 path should terminate at 0.0 as well; that felt like your call rather than mine.

## Tests

New `tests/test_scheduler.py` cases cover every step count including the degenerate ones.
Full suite: **813 passed, 58 skipped**, `ruff check` clean.
