### PR TITLE
feat: wire TeaCache into A2VidPipelineTwoStage stage-1

### DIFF
--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/a2vid_two_stage.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/a2vid_two_stage.py
@@ -68,6 +68,7 @@ class A2VidPipelineTwoStage(TI2VidTwoStagesPipeline):
         cfg_scale: float = 3.0,
         stg_scale: float = 1.0,
         on_step: OnStepFn | None = None,
+        teacache_controller=None,
     ) -> object:
         """Run Stage 1 denoising with Euler + CFG. Override for HQ (res2s)."""
         # Video: full guidance (ref LTX_2_3_PARAMS)
@@ -95,6 +96,7 @@ class A2VidPipelineTwoStage(TI2VidTwoStagesPipeline):
             audio_guider_factory=audio_factory,
             sigmas=sigmas,
             on_step=on_step,
+            teacache=teacache_controller,
         )
 
     def generate_and_save(
@@ -116,6 +118,8 @@ class A2VidPipelineTwoStage(TI2VidTwoStagesPipeline):
         images=None,
         audio_start_time: float = 0.0,
         audio_max_duration: float | None = None,
+        enable_teacache: bool = False,
+        teacache_thresh: float | None = None,
     ) -> str:
         """Generate video from audio and save to file.
 
@@ -252,6 +256,12 @@ class A2VidPipelineTwoStage(TI2VidTwoStagesPipeline):
         sigmas_1 = ltx2_schedule(stage1_steps, num_tokens=num_tokens)
         x0_model = X0Model(self.dit)
 
+        teacache_controller = None
+        if enable_teacache:
+            from ltx_pipelines_mlx.ti2vid_two_stages import _build_teacache_controller
+            teacache_controller = _build_teacache_controller(stage1_steps, teacache_thresh)
+            teacache_controller.reset()
+
         output_1 = self._denoise_stage1(
             x0_model=x0_model,
             video_state=video_state_1,
@@ -264,6 +274,7 @@ class A2VidPipelineTwoStage(TI2VidTwoStagesPipeline):
             cfg_scale=cfg_scale,
             stg_scale=stg_scale,
             on_step=self._stepwise_hook(F, H_half, W_half, stage=1),
+            teacache_controller=teacache_controller,
         )
         if self.low_memory:
             aggressive_cleanup()

--- a/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/cli.py
+++ b/packages/ltx-pipelines-mlx/src/ltx_pipelines_mlx/cli.py
@@ -1092,6 +1092,10 @@ def _cmd_a2v(args: argparse.Namespace) -> None:
         kwargs["cfg_scale"] = args.cfg_scale
     if args.stg_scale is not None:
         kwargs["stg_scale"] = args.stg_scale
+    if getattr(args, "enable_teacache", False):
+        kwargs["enable_teacache"] = True
+        if getattr(args, "teacache_thresh", None) is not None:
+            kwargs["teacache_thresh"] = args.teacache_thresh
     pipe.generate_and_save(**kwargs)
 
     _print_result(args.output, t0, args.quiet)

--- a/tests/test_a2vid_teacache.py
+++ b/tests/test_a2vid_teacache.py
@@ -1,0 +1,92 @@
+"""A2VidPipelineTwoStage stage-1 must thread its TeaCache controller through.
+
+``TI2VidTwoStagesPipeline`` has carried calibrated TeaCache Euler coefficients and a
+``_build_teacache_controller`` helper for a while, and ``_add_generation_args`` already
+exposes ``--enable-teacache`` on every generate subcommand — but the a2v pipeline never
+passed a controller down to ``guided_denoise_loop``, so the flag was accepted and silently
+ignored on ``a2v``. These pin the wiring.
+
+The assertions are deliberately at ``_denoise_stage1`` rather than through
+``generate_and_save``: the wiring under test is one keyword argument's journey into
+``guided_denoise_loop``, and standing up the full pipeline (VAE, text encoder, audio
+encoder, upsampler) to observe it would test the stubs more than the code.
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+import pytest
+
+from ltx_pipelines_mlx import a2vid_two_stage as a2v_mod
+from ltx_pipelines_mlx.a2vid_two_stage import A2VidPipelineTwoStage
+
+
+class _LoopSpy:
+    """Stand-in for guided_denoise_loop that records the kwargs it was handed."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    def __call__(self, **kwargs):
+        self.calls.append(kwargs)
+        return object()
+
+
+@pytest.fixture
+def stage1(monkeypatch):
+    """A pipeline whose _denoise_stage1 can be called without loading any weights."""
+    pipe = A2VidPipelineTwoStage.__new__(A2VidPipelineTwoStage)
+    # _pre_denoise_flush only exists to release memory between stages; there is nothing
+    # allocated here to release.
+    pipe._pre_denoise_flush = lambda *a, **k: None  # type: ignore[method-assign]
+
+    spy = _LoopSpy()
+    monkeypatch.setattr(a2v_mod, "guided_denoise_loop", spy)
+
+    def run(**overrides):
+        kwargs = dict(
+            x0_model=object(),
+            video_state=object(),
+            audio_state=object(),
+            video_embeds=mx.zeros((1, 8, 4096), dtype=mx.bfloat16),
+            audio_embeds=mx.zeros((1, 8, 2048), dtype=mx.bfloat16),
+            neg_video_embeds=mx.zeros((1, 8, 4096), dtype=mx.bfloat16),
+            neg_audio_embeds=mx.zeros((1, 8, 2048), dtype=mx.bfloat16),
+            sigmas=[1.0, 0.5, 0.0],
+        )
+        kwargs.update(overrides)
+        pipe._denoise_stage1(**kwargs)
+        return spy
+
+    return run
+
+
+def test_teacache_controller_reaches_the_denoise_loop(stage1):
+    """The regression: a controller passed in must arrive as `teacache=`."""
+    controller = object()
+
+    spy = stage1(teacache_controller=controller)
+
+    assert len(spy.calls) == 1
+    assert spy.calls[0]["teacache"] is controller, (
+        "identity, not truthiness: the controller carries calibrated per-model "
+        "coefficients, so the loop must receive the caller's object rather than "
+        "any controller"
+    )
+
+
+def test_teacache_defaults_to_none(stage1):
+    """Omitting it must disable TeaCache, not enable a default one."""
+    spy = stage1()
+
+    assert spy.calls[0]["teacache"] is None
+
+
+def test_on_step_hook_still_threads_through(stage1):
+    """The stepwise hook shares these call sites; neither may displace the other."""
+    hook = object()
+
+    spy = stage1(on_step=hook, teacache_controller=object())
+
+    assert spy.calls[0]["on_step"] is hook
+    assert spy.calls[0]["teacache"] is not None


### PR DESCRIPTION
## What

`--enable-teacache` is wired onto every `generate` subcommand by `_add_generation_args`, and
`a2v` accepts the flag — but `A2VidPipelineTwoStage` never built a controller or passed one
down, so on `a2v` the flag was **accepted and silently ignored**.

This threads it through:

- `_denoise_stage1` takes a `teacache_controller` param and forwards it as
  `teacache=` to `guided_denoise_loop`
- `generate_and_save` takes `enable_teacache` / `teacache_thresh` and builds the controller
  via the existing `_build_teacache_controller` from `ti2vid_two_stages`
- `cli.py::_cmd_a2v` extracts both from args and passes them on (the flag itself was already
  wired; only the handler was missing)

No new machinery — `TI2VidTwoStagesPipeline` already carries the calibrated Euler
coefficients (`LTX2_TEACACHE_COEFFICIENTS`) and the builder, and `guided_denoise_loop`
already takes `teacache=`. This just connects the a2v pipeline to them.

## Note on calibration

The coefficients are the ones calibrated for `guided_denoise_loop` (Euler), which is the loop
a2v stage 1 actually uses — so they apply directly. Per CLAUDE.md, calibration is
scheduler-specific, and a2v stage 1 is Euler, not res_2s. Off by default (`enable_teacache=False`),
so this is strictly opt-in.

## Measured effect (a2v, 512×320, 113 frames, M3 Ultra, q8)

Same seed, `enable_teacache` the only variable:

| stage-1 steps | off | on | speedup |
|---|---|---|---|
| 18 | 162.5s | 158.9s | 1.02× — **noise** |
| 30 | 234.2s | 180.8s | **1.30×** (23% saved) |

Worth stating plainly: **at low step counts this buys nothing.** The gain only appears once
there are enough steps for cached skips to amortise past warmup, which matches the 30-step
regime the existing coefficients were calibrated in. It is also below the 1.46× documented for
`--two-stage`, which is what I would expect — a2v stage 1 carries the audio branch and its
extra cross-attention through every non-skipped step.

Outputs at the same seed are **not** byte-identical between off and on, which is the check that
distinguishes "the controller is actually reaching the denoise loop" from "the kwarg was
accepted and silently dropped".

## Tests

`A2VidPipelineTwoStage` had **no test coverage at all**, so this adds
`tests/test_a2vid_teacache.py` — three cases pinning the wiring at `_denoise_stage1` with a
spy on `guided_denoise_loop`:

- the controller reaches the loop as `teacache=` (asserted by identity, since the controller
  carries calibrated per-model coefficients)
- omitting it yields `teacache=None` rather than a default controller
- the `on_step` hook still threads through — it shares these call sites, and neither may
  displace the other

Assertions sit at `_denoise_stage1` rather than through `generate_and_save` deliberately:
the behaviour under test is one keyword argument's journey into the denoise loop, and
stubbing the full pipeline (VAE, text encoder, audio encoder, upsampler) to observe it would
mostly test the stubs.

Verified the three fail against `main`'s `a2vid_two_stage.py` and pass with this change.
Full suite: **800 passed, 58 skipped**, `ruff check` clean.
